### PR TITLE
feat(examples): add 4-phase runtime loop reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `make example` now runs `examples/full_agent_loop.py`
 - `_pick_tool()` in `examples/full_agent_loop.py` now guards against empty router results (raises `ValueError`) and prefers `analytics.metrics.query` for internal consistency with the hardcoded tool-call text (#169 review)
 - `docs/guide_agent_loop.md` table separator uses explicit spaces (`| --- |`) for robust rendering across Markdown parsers (#169 review)
+- `_pick_tool()` simplified: removed false `analytics.metrics.query` guarantee; tool-call text now generated dynamically from the selected tool's hydrated schema (#169 review)
+- `catalog.hydrate()` used instead of `catalog.get()` for post-routing schema access in `examples/full_agent_loop.py` (#169 review)
+- `_simulate_large_result()` made generic (no analytics-specific field names) (#169 review)
 
 ## [0.1.7] - 2026-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - README now includes a "Runtime Loop (4 Phases)" section and references the new example/guide
 - `make example` now runs `examples/full_agent_loop.py`
+- `_pick_tool()` in `examples/full_agent_loop.py` now guards against empty router results (raises `ValueError`) and prefers `analytics.metrics.query` for internal consistency with the hardcoded tool-call text (#169 review)
+- `docs/guide_agent_loop.md` table separator uses explicit spaces (`| --- |`) for robust rendering across Markdown parsers (#169 review)
 
 ## [0.1.7] - 2026-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- End-to-end four-phase runtime loop example in `examples/full_agent_loop.py` (#24)
+- Runtime loop guide with flow diagram and phase guidance in `docs/guide_agent_loop.md` (#24)
+
+### Changed
+- README now includes a "Runtime Loop (4 Phases)" section and references the new example/guide
+- `make example` now runs `examples/full_agent_loop.py`
+
 ## [0.1.7] - 2026-03-21
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ test:
 
 example:
 	python examples/minimal_loop.py
+	python examples/full_agent_loop.py
 	python examples/tool_wrapping.py
 	python examples/routing_demo.py
 	python examples/before_after.py

--- a/README.md
+++ b/README.md
@@ -138,6 +138,20 @@ result = router.route("send a reminder email about unpaid invoices")
 print(result.candidate_ids)
 ```
 
+## Runtime Loop (4 Phases)
+
+For a complete route -> call -> interpret -> answer reference flow, see:
+
+- `examples/full_agent_loop.py` for a runnable end-to-end script.
+- `docs/guide_agent_loop.md` for the flow diagram, pseudo-code, and module map.
+
+The runtime loop example demonstrates:
+
+1. Route-phase prompt assembly with ChoiceCards.
+2. Call-phase prompt assembly with selected tool schema hydration.
+3. Interpret-phase firewall behavior (large tool output summarized into context).
+4. Answer-phase context composition with accumulated history and result envelopes.
+
 ---
 
 ## Framework Integrations
@@ -201,6 +215,7 @@ contextweaver replay --session session.json --phase answer
 | Script | Description |
 |---|---|
 | `minimal_loop.py` | Basic event ingestion → context build |
+| `full_agent_loop.py` | End-to-end route → call → interpret → answer runtime loop |
 | `tool_wrapping.py` | Context firewall in action |
 | `routing_demo.py` | Build catalog → route queries → choice cards |
 | `before_after.py` | Side-by-side token comparison: WITHOUT vs WITH contextweaver |

--- a/docs/guide_agent_loop.md
+++ b/docs/guide_agent_loop.md
@@ -1,0 +1,86 @@
+# Agent Runtime Loop Guide
+
+This guide explains the reference runtime loop in
+`examples/full_agent_loop.py`.
+
+The loop demonstrates all four context phases in one deterministic flow:
+
+1. `route` - shortlist candidate tools.
+2. `call` - inject only the selected tool schema.
+3. `interpret` - summarize tool output via the firewall.
+4. `answer` - compose the final response context.
+
+## Flow Diagram
+
+```mermaid
+flowchart TD
+    U[User Query] --> R[Phase.route\nContextManager.build_route_prompt_sync]
+    R --> C[ChoiceCards + routed candidate IDs]
+    C --> M[Model selects tool_id]
+    M --> H[Catalog.hydrate(tool_id)]
+    H --> P[Phase.call\nContextManager.build_call_prompt_sync]
+    P --> X[Simulated tool execution]
+    X --> F[ingest_tool_result_sync\nFirewall stores raw artifact + summary]
+    F --> I[Phase.interpret\nContextManager.build_sync]
+    I --> A[Phase.answer\nContextManager.build_sync]
+```
+
+## Pseudo-code
+
+```python
+catalog = build_catalog_with_schemas()
+router = Router(TreeBuilder().build(catalog.all()), items=catalog.all())
+manager = ContextManager(budget=ContextBudget(route=500, call=800, interpret=600, answer=1000))
+
+manager.ingest(user_turn)
+
+route_pack, cards, route_result = manager.build_route_prompt_sync(goal, query, router)
+tool_id = model_select(route_result.candidate_ids)
+
+manager.ingest(tool_call)
+call_pack = manager.build_call_prompt_sync(tool_id, query, catalog)
+
+raw_result = simulate_large_json()
+manager.ingest_tool_result_sync(tool_call_id, raw_result)
+interpret_pack = manager.build_sync(phase=Phase.interpret, query=query)
+
+answer_pack = manager.build_sync(phase=Phase.answer, query=final_query)
+```
+
+## Module Pointers
+
+- `src/contextweaver/context/manager.py`
+  - `build_route_prompt_sync()` for route-phase prompt + ChoiceCards.
+  - `build_call_prompt_sync()` for selected-schema call prompts.
+  - `ingest_tool_result_sync()` for firewall interception and envelope creation.
+  - `build_sync()` for `interpret` and `answer` context compilation.
+- `src/contextweaver/routing/router.py`
+  - `Router.route()` to rank candidate tools.
+- `src/contextweaver/routing/catalog.py`
+  - `Catalog` and `Catalog.hydrate()` for schema hydration.
+- `src/contextweaver/routing/cards.py`
+  - Choice-card rendering used in route prompts.
+- `src/contextweaver/config.py`
+  - `ContextBudget` with per-phase token limits.
+
+## When To Use Each Phase
+
+| Phase | Primary goal | Typical contents | Budget posture |
+|---|---|---|---|
+| `route` | Choose tools | user intent, policy, compact cards | small |
+| `call` | Generate arguments | selected tool schema, examples, constraints | medium |
+| `interpret` | Understand result | tool call + summarized result + extracted facts | medium |
+| `answer` | Compose final response | relevant history + interpreted findings + policy | largest |
+
+## Running The Example
+
+```bash
+python examples/full_agent_loop.py
+```
+
+What you should see:
+
+1. Four phase sections (`route`, `call`, `interpret`, `answer`).
+2. Compiled prompt text for each phase.
+3. BuildStats output for each phase, including token counts.
+4. Firewall behavior in `interpret` (raw payload size > summarized text size).

--- a/docs/guide_agent_loop.md
+++ b/docs/guide_agent_loop.md
@@ -66,7 +66,7 @@ answer_pack = manager.build_sync(phase=Phase.answer, query=final_query)
 ## When To Use Each Phase
 
 | Phase | Primary goal | Typical contents | Budget posture |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `route` | Choose tools | user intent, policy, compact cards | small |
 | `call` | Generate arguments | selected tool schema, examples, constraints | medium |
 | `interpret` | Understand result | tool call + summarized result + extracted facts | medium |

--- a/examples/full_agent_loop.py
+++ b/examples/full_agent_loop.py
@@ -102,11 +102,19 @@ def _build_catalog() -> Catalog:
 
 
 def _pick_tool(route_ids: list[str], catalog: Catalog) -> str:
-    """Simulate model selection: prefer analytics.metrics.query, then any tool with a schema.
+    """Simulate model selection: pick the first routed tool with an explicit schema.
 
-    Preferring the intended analytics tool ensures that the tool-call text and
-    simulated result ingested later remain internally consistent with the selected
-    tool's schema (the user query concerns daily-active-user trends).
+    This function acts as a deterministic stand-in for an LLM's tool-selection step.
+    It returns the first candidate (in routing-rank order) that carries a full argument
+    schema, so the call-phase prompt can demonstrate schema hydration.  If no candidate
+    has a schema, it falls back to the top-ranked candidate.
+
+    Args:
+        route_ids: Ordered list of candidate tool IDs from the router.
+        catalog: The catalog used to look up item schemas.
+
+    Returns:
+        The selected tool ID.
 
     Raises:
         ValueError: If the router returned no candidate tools.
@@ -115,10 +123,6 @@ def _pick_tool(route_ids: list[str], catalog: Catalog) -> str:
         raise ValueError(
             "Router returned no candidates. Ensure the catalog contains reachable items."
         )
-    # Prefer the intended analytics tool — the query is about DAU trends.
-    if "analytics.metrics.query" in route_ids:
-        return "analytics.metrics.query"
-    # Fall back to the first routed tool that carries an explicit schema.
     for item_id in route_ids:
         if catalog.get(item_id).args_schema:
             return item_id
@@ -126,13 +130,16 @@ def _pick_tool(route_ids: list[str], catalog: Catalog) -> str:
 
 
 def _simulate_large_result(tool_id: str) -> str:
-    """Build a large deterministic JSON payload to trigger firewall summarization."""
+    """Build a large deterministic JSON payload to trigger firewall summarization.
+
+    The payload is generic (not tool-specific) so it remains valid regardless of
+    which tool _pick_tool() selects.
+    """
     rows = []
     for idx in range(1, 101):
         rows.append(
             {
-                "day": f"2026-03-{idx % 30 + 1:02d}",
-                "metric": "daily_active_users",
+                "record_id": idx,
                 "value": 1500 + idx,
                 "tool": tool_id,
             }
@@ -141,7 +148,7 @@ def _simulate_large_result(tool_id: str) -> str:
         "status": "ok",
         "rows": rows,
         "summary": {
-            "window_days": 30,
+            "count": len(rows),
             "max": max(row["value"] for row in rows),
             "min": min(row["value"] for row in rows),
         },
@@ -188,7 +195,9 @@ def main() -> None:
     print(f"routed_candidates: {route_result.candidate_ids}")
 
     selected_tool_id = _pick_tool(route_result.candidate_ids, catalog)
-    selected = catalog.get(selected_tool_id)
+    # Hydrate the selected tool — returns full schema/examples/constraints as HydrationResult.
+    # catalog.hydrate() is the idiomatic post-routing call before building the call-phase prompt.
+    hydrated = catalog.hydrate(selected_tool_id)
     print(f"model_selected_tool_id: {selected_tool_id}")
 
     manager.ingest(
@@ -199,15 +208,16 @@ def main() -> None:
             parent_id="u1",
         )
     )
-    # _pick_tool() guarantees analytics.metrics.query for this DAU query, so the
-    # hardcoded args below are internally consistent with the selected tool's schema.
+    # Build a call text that is internally consistent with the selected tool's schema.
+    # Arguments are derived from the hydrated schema so the call-phase prompt is always valid.
+    props = hydrated.args_schema.get("properties", {})
+    required_keys = hydrated.args_schema.get("required") or list(props.keys())
+    call_args = ", ".join(f"{k}=..." for k in (required_keys or list(props.keys()))[:3])
     manager.ingest(
         ContextItem(
             id="tc1",
             kind=ItemKind.tool_call,
-            text=(
-                f"{selected_tool_id}(metric='daily_active_users', window_days=30, group_by='day')"
-            ),
+            text=f"{selected_tool_id}({call_args})",
             parent_id="u1",
         )
     )
@@ -228,7 +238,7 @@ def main() -> None:
         stats_hf_tokens=call_pack.stats.header_footer_tokens,
         stats_tokens_per_section=call_pack.stats.tokens_per_section,
     )
-    print(f"selected_schema_keys: {sorted(selected.args_schema.get('properties', {}).keys())}")
+    print(f"selected_schema_keys: {sorted(hydrated.args_schema.get('properties', {}).keys())}")
 
     # Execute (simulated): create a large tool result that exceeds firewall threshold.
     large_result = _simulate_large_result(selected_tool_id)

--- a/examples/full_agent_loop.py
+++ b/examples/full_agent_loop.py
@@ -1,0 +1,270 @@
+"""Reference agent loop example demonstrating all four phases.
+
+This script shows a deterministic, in-memory loop:
+1. Route: shortlist candidate tools and show choice cards.
+2. Call: inject only the selected tool schema into a call prompt.
+3. Interpret: ingest a large tool result and let the firewall summarize it.
+4. Answer: build the final response context from the accumulated history.
+"""
+
+from __future__ import annotations
+
+import json
+
+from contextweaver.config import ContextBudget
+from contextweaver.context.manager import ContextManager
+from contextweaver.routing.catalog import Catalog, generate_sample_catalog, load_catalog_dicts
+from contextweaver.routing.router import Router
+from contextweaver.routing.tree import TreeBuilder
+from contextweaver.types import ContextItem, ItemKind, Phase
+
+
+def _token_count(pack_prompt_tokens: dict[str, int], header_footer_tokens: int) -> int:
+    """Compute total tokens represented in BuildStats."""
+    return sum(pack_prompt_tokens.values()) + header_footer_tokens
+
+
+def _print_phase(
+    name: str,
+    prompt: str,
+    stats_total: int,
+    stats_included: int,
+    stats_dropped: int,
+    stats_dedup: int,
+    stats_hf_tokens: int,
+    stats_tokens_per_section: dict[str, int],
+) -> None:
+    """Print prompt text and compact diagnostics for one phase."""
+    print(f"\n{'=' * 80}")
+    print(f"PHASE: {name}")
+    print(f"{'=' * 80}")
+    print(prompt)
+    print("\n--- BuildStats ---")
+    print(f"total_candidates: {stats_total}")
+    print(f"included_count: {stats_included}")
+    print(f"dropped_count: {stats_dropped}")
+    print(f"dedup_removed: {stats_dedup}")
+    print(f"header_footer_tokens: {stats_hf_tokens}")
+    print(f"tokens_per_section: {stats_tokens_per_section}")
+    print(f"token_count: {_token_count(stats_tokens_per_section, stats_hf_tokens)}")
+
+
+def _build_catalog() -> Catalog:
+    """Create a deterministic catalog with >50 tools and explicit schemas on target tools."""
+    raw = generate_sample_catalog(n=60, seed=42)
+
+    # Add full schemas for two tools so call-phase hydration is meaningful.
+    for item in raw:
+        if item["id"] == "analytics.metrics.query":
+            item["args_schema"] = {
+                "type": "object",
+                "properties": {
+                    "metric": {"type": "string", "description": "Metric identifier"},
+                    "window_days": {"type": "integer", "description": "Trailing time window"},
+                    "group_by": {"type": "string", "description": "Aggregation bucket"},
+                },
+                "required": ["metric", "window_days"],
+            }
+            item["examples"] = [
+                "metrics_query(metric='daily_active_users', window_days=30, group_by='day')"
+            ]
+            item["constraints"] = {"max_window_days": 365, "read_only": True}
+        if item["id"] == "billing.reports.revenue":
+            item["args_schema"] = {
+                "type": "object",
+                "properties": {
+                    "start_date": {"type": "string", "description": "ISO date"},
+                    "end_date": {"type": "string", "description": "ISO date"},
+                },
+                "required": ["start_date", "end_date"],
+            }
+            item["examples"] = ["revenue_report(start_date='2026-01-01', end_date='2026-01-31')"]
+            item["constraints"] = {"read_only": True}
+        if item["id"] == "billing.subscriptions.list":
+            item["args_schema"] = {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "description": "Filter status such as active, trialing, or canceled",
+                    },
+                    "limit": {"type": "integer", "description": "Maximum records to return"},
+                },
+                "required": [],
+            }
+            item["examples"] = ["subscriptions_list(status='active', limit=50)"]
+            item["constraints"] = {"read_only": True}
+
+    catalog = Catalog()
+    for item in load_catalog_dicts(raw):
+        catalog.register(item)
+    return catalog
+
+
+def _pick_tool(route_ids: list[str], catalog: Catalog) -> str:
+    """Simulate model selection by choosing the first routed tool with a schema."""
+    for item_id in route_ids:
+        if catalog.get(item_id).args_schema:
+            return item_id
+    return route_ids[0]
+
+
+def _simulate_large_result(tool_id: str) -> str:
+    """Build a large deterministic JSON payload to trigger firewall summarization."""
+    rows = []
+    for idx in range(1, 101):
+        rows.append(
+            {
+                "day": f"2026-03-{idx % 30 + 1:02d}",
+                "metric": "daily_active_users",
+                "value": 1500 + idx,
+                "tool": tool_id,
+            }
+        )
+    payload = {
+        "status": "ok",
+        "rows": rows,
+        "summary": {
+            "window_days": 30,
+            "max": max(row["value"] for row in rows),
+            "min": min(row["value"] for row in rows),
+        },
+    }
+    return json.dumps(payload, sort_keys=True)
+
+
+def main() -> None:
+    """Run the full route -> call -> interpret -> answer loop."""
+    budget = ContextBudget(route=500, call=800, interpret=600, answer=1000)
+    manager = ContextManager(budget=budget)
+
+    catalog = _build_catalog()
+    items = catalog.all()
+    graph = TreeBuilder(max_children=12).build(items)
+    router = Router(graph, items=items, beam_width=3, top_k=6)
+
+    user_query = "What is the trend of daily active users over the last 30 days?"
+    manager.ingest(
+        ContextItem(
+            id="u1",
+            kind=ItemKind.user_turn,
+            text=user_query,
+        )
+    )
+
+    # Phase 1: route prompt + choice cards from a large catalog.
+    route_pack, cards, route_result = manager.build_route_prompt_sync(
+        goal="Select the single best analytics tool for the user request.",
+        query=user_query,
+        router=router,
+    )
+    _print_phase(
+        name="route",
+        prompt=route_pack.prompt,
+        stats_total=route_pack.stats.total_candidates,
+        stats_included=route_pack.stats.included_count,
+        stats_dropped=route_pack.stats.dropped_count,
+        stats_dedup=route_pack.stats.dedup_removed,
+        stats_hf_tokens=route_pack.stats.header_footer_tokens,
+        stats_tokens_per_section=route_pack.stats.tokens_per_section,
+    )
+    print(f"choice_cards: {len(cards)}")
+    print(f"routed_candidates: {route_result.candidate_ids}")
+
+    selected_tool_id = _pick_tool(route_result.candidate_ids, catalog)
+    selected = catalog.get(selected_tool_id)
+    print(f"model_selected_tool_id: {selected_tool_id}")
+
+    manager.ingest(
+        ContextItem(
+            id="a1",
+            kind=ItemKind.agent_msg,
+            text=f"I will call {selected_tool_id} to answer the question.",
+            parent_id="u1",
+        )
+    )
+    manager.ingest(
+        ContextItem(
+            id="tc1",
+            kind=ItemKind.tool_call,
+            text=(
+                f"{selected_tool_id}(metric='daily_active_users', window_days=30, group_by='day')"
+            ),
+            parent_id="u1",
+        )
+    )
+
+    # Phase 2: call prompt with only the selected tool schema injected.
+    call_pack = manager.build_call_prompt_sync(
+        tool_id=selected_tool_id,
+        query=user_query,
+        catalog=catalog,
+    )
+    _print_phase(
+        name="call",
+        prompt=call_pack.prompt,
+        stats_total=call_pack.stats.total_candidates,
+        stats_included=call_pack.stats.included_count,
+        stats_dropped=call_pack.stats.dropped_count,
+        stats_dedup=call_pack.stats.dedup_removed,
+        stats_hf_tokens=call_pack.stats.header_footer_tokens,
+        stats_tokens_per_section=call_pack.stats.tokens_per_section,
+    )
+    print(f"selected_schema_keys: {sorted(selected.args_schema.get('properties', {}).keys())}")
+
+    # Execute (simulated): create a large tool result that exceeds firewall threshold.
+    large_result = _simulate_large_result(selected_tool_id)
+    processed_item, envelope = manager.ingest_tool_result_sync(
+        tool_call_id="tc1",
+        raw_output=large_result,
+        tool_name=selected_tool_id,
+        media_type="application/json",
+        firewall_threshold=1200,
+    )
+
+    # Phase 3: interpret prompt includes firewall summary instead of raw payload.
+    interpret_pack = manager.build_sync(phase=Phase.interpret, query=user_query)
+    _print_phase(
+        name="interpret",
+        prompt=interpret_pack.prompt,
+        stats_total=interpret_pack.stats.total_candidates,
+        stats_included=interpret_pack.stats.included_count,
+        stats_dropped=interpret_pack.stats.dropped_count,
+        stats_dedup=interpret_pack.stats.dedup_removed,
+        stats_hf_tokens=interpret_pack.stats.header_footer_tokens,
+        stats_tokens_per_section=interpret_pack.stats.tokens_per_section,
+    )
+    print(f"raw_result_chars: {len(large_result)}")
+    print(f"summary_chars: {len(processed_item.text)}")
+    artifact_handle = processed_item.artifact_ref.handle if processed_item.artifact_ref else "none"
+    print(f"artifact_ref: {artifact_handle}")
+    print(f"facts_extracted: {len(envelope.facts)}")
+
+    manager.ingest(
+        ContextItem(
+            id="a2",
+            kind=ItemKind.agent_msg,
+            text="I interpreted the metrics and will now draft the final response.",
+            parent_id="u1",
+        )
+    )
+
+    # Phase 4: answer prompt composes final context from prior phases.
+    answer_pack = manager.build_sync(
+        phase=Phase.answer,
+        query="Summarize the 30-day active-user trend for the user.",
+    )
+    _print_phase(
+        name="answer",
+        prompt=answer_pack.prompt,
+        stats_total=answer_pack.stats.total_candidates,
+        stats_included=answer_pack.stats.included_count,
+        stats_dropped=answer_pack.stats.dropped_count,
+        stats_dedup=answer_pack.stats.dedup_removed,
+        stats_hf_tokens=answer_pack.stats.header_footer_tokens,
+        stats_tokens_per_section=answer_pack.stats.tokens_per_section,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/full_agent_loop.py
+++ b/examples/full_agent_loop.py
@@ -102,7 +102,23 @@ def _build_catalog() -> Catalog:
 
 
 def _pick_tool(route_ids: list[str], catalog: Catalog) -> str:
-    """Simulate model selection by choosing the first routed tool with a schema."""
+    """Simulate model selection: prefer analytics.metrics.query, then any tool with a schema.
+
+    Preferring the intended analytics tool ensures that the tool-call text and
+    simulated result ingested later remain internally consistent with the selected
+    tool's schema (the user query concerns daily-active-user trends).
+
+    Raises:
+        ValueError: If the router returned no candidate tools.
+    """
+    if not route_ids:
+        raise ValueError(
+            "Router returned no candidates. Ensure the catalog contains reachable items."
+        )
+    # Prefer the intended analytics tool — the query is about DAU trends.
+    if "analytics.metrics.query" in route_ids:
+        return "analytics.metrics.query"
+    # Fall back to the first routed tool that carries an explicit schema.
     for item_id in route_ids:
         if catalog.get(item_id).args_schema:
             return item_id
@@ -183,6 +199,8 @@ def main() -> None:
             parent_id="u1",
         )
     )
+    # _pick_tool() guarantees analytics.metrics.query for this DAU query, so the
+    # hardcoded args below are internally consistent with the selected tool's schema.
     manager.ingest(
         ContextItem(
             id="tc1",


### PR DESCRIPTION
## Summary

Fixes #24

Adds an end-to-end reference runtime loop across all 4 phases (`route`, `call`, `interpret`, `answer`) plus supporting docs and wiring updates.

## Changes

- Added `examples/full_agent_loop.py` as a standalone, deterministic 4-phase reference loop.
- Added `docs/guide_agent_loop.md` with a flow diagram, pseudo-code, module pointers, and phase guidance.
- Updated `README.md` with a new "Runtime Loop (4 Phases)" section and examples table entry.
- Updated `Makefile` `example` target to include `examples/full_agent_loop.py`.
- Updated `CHANGELOG.md` under `## [Unreleased]`.

## Checklist

- [x] Tests added or updated for every new/changed public function (N/A: no library public API behavior changes)
- [x] `make ci` passes locally (fmt + lint + type + test + example + demo)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docstrings added for all new public APIs (N/A: no new public library APIs)
- [x] Every modified module stays ≤ 300 lines (or a decomposition issue is linked above)
- [x] Related issue linked in the summary above
- [x] Agent-facing docs updated if pipeline, API, or conventions changed (not required for this change scope)

## Notes for reviewers

Validation was run with CI-equivalent commands via the project venv because `make` is not installed in this Windows environment:

- `python -m ruff format --check src/ tests/ examples/`
- `python -m ruff check src/ tests/ examples/`
- `python -m mypy src/`
- `python -m pytest -q`
- `python examples/minimal_loop.py`
- `python examples/full_agent_loop.py`
- `python examples/tool_wrapping.py`
- `python examples/routing_demo.py`
- `python examples/before_after.py`
- `python examples/hydrate_call_demo.py`
- `python examples/mcp_adapter_demo.py`
- `python examples/a2a_adapter_demo.py`
- `python -m contextweaver demo`

All commands completed successfully.