### PR TITLE
feat(docs): add MkDocs API reference site with auto-generated pages (#110)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,48 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package and docs dependencies
+        run: pip install -e ".[docs]"
+
+      - name: Build docs
+        run: mkdocs build --clean
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,11 +5,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: pages
   cancel-in-progress: false
@@ -17,6 +12,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -39,6 +36,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,8 @@ make test     # pytest -q
 make example  # run all example scripts
 make demo     # python -m contextweaver demo
 make ci       # fmt + lint + type + test + example + demo
+make docs     # mkdocs build --clean (docs site)
+make docs-serve  # mkdocs serve (live preview)
 ```
 
 Run `pre-commit install` once after cloning to activate git hooks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Auto-generated API reference documentation site using MkDocs + Material + mkdocstrings (#110)
+  - `mkdocs.yml` — site configuration with Material theme, auto-nav, and mkdocstrings
+  - `docs/gen_ref_pages.py` — build-time script that walks `src/contextweaver` and emits one reference page per public module; new modules are picked up automatically
+  - `docs/index.md` — public landing page for the docs site
+  - `[docs]` extras group in `pyproject.toml` (`mkdocs`, `mkdocs-material`, `mkdocstrings[python]`, `mkdocs-gen-files`, `mkdocs-literate-nav`, `mkdocs-section-index`)
+  - `make docs` builds the site; `make docs-serve` starts a local preview server
+  - `.github/workflows/docs.yml` — publishes to GitHub Pages on every push to `main`
+  - README now links to `https://dgenio.github.io/contextweaver`
 - End-to-end four-phase runtime loop example in `examples/full_agent_loop.py` (#24)
 - Runtime loop guide with flow diagram and phase guidance in `docs/guide_agent_loop.md` (#24)
 - LangChain memory replacement example in `examples/langchain_memory_demo.py` (#170) — demonstrates replacing `InMemoryChatMessageHistory` with phase-specific budgets and the context firewall using a deterministic mock LLM and real `langchain-core` objects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `make docs` builds the site; `make docs-serve` starts a local preview server
   - `.github/workflows/docs.yml` — publishes to GitHub Pages on every push to `main`
   - README now links to `https://dgenio.github.io/contextweaver`
+  - `AGENTS.md` and `docs/agent-context/workflows.md` updated to document `make docs` / `make docs-serve` targets (review: #172)
+
+### Fixed
+- `mkdocs.yml` `edit_uri` corrected from `edit/main/docs/` to `edit/main/` so that auto-generated API reference "Edit" buttons resolve to `src/contextweaver/*.py` rather than the nonexistent `docs/src/...` path (review: #172)
+- `docs/gen_ref_pages.py` module walk restricted to `src/contextweaver` (matches docstring; prevents accidental inclusion of future sibling packages under `src/`) (review: #172)
+- `docs/gen_ref_pages.py` private-module skip now uses `any(part.startswith("_") for part in parts)` to correctly exclude private package directories, not just private leaf modules (review: #172)
 - End-to-end four-phase runtime loop example in `examples/full_agent_loop.py` (#24)
 - Runtime loop guide with flow diagram and phase guidance in `docs/guide_agent_loop.md` (#24)
 - LangChain memory replacement example in `examples/langchain_memory_demo.py` (#170) — demonstrates replacing `InMemoryChatMessageHistory` with phase-specific budgets and the context firewall using a deterministic mock LLM and real `langchain-core` objects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `docs/index.md` — public landing page for the docs site
   - `[docs]` extras group in `pyproject.toml` (`mkdocs`, `mkdocs-material`, `mkdocstrings[python]`, `mkdocs-gen-files`, `mkdocs-literate-nav`, `mkdocs-section-index`)
   - `make docs` builds the site; `make docs-serve` starts a local preview server
-  - `.github/workflows/docs.yml` — publishes to GitHub Pages on every push to `main`
+  - `.github/workflows/docs.yml` — publishes to GitHub Pages on every push to `main`; CI workflow permissions are scoped per-job (build: `contents: read`, deploy: `pages: write` + `id-token: write`)
   - README now links to `https://dgenio.github.io/contextweaver`
-  - `AGENTS.md` and `docs/agent-context/workflows.md` updated to document `make docs` / `make docs-serve` targets (review: #172)
+  - `AGENTS.md` and `docs/agent-context/workflows.md` updated to document `make docs` / `make docs-serve` targets
 
 ### Fixed
-- `mkdocs.yml` `edit_uri` corrected from `edit/main/docs/` to `edit/main/` so that auto-generated API reference "Edit" buttons resolve to `src/contextweaver/*.py` rather than the nonexistent `docs/src/...` path (review: #172)
-- `docs/gen_ref_pages.py` module walk restricted to `src/contextweaver` (matches docstring; prevents accidental inclusion of future sibling packages under `src/`) (review: #172)
-- `docs/gen_ref_pages.py` private-module skip now uses `any(part.startswith("_") for part in parts)` to correctly exclude private package directories, not just private leaf modules (review: #172)
+- `mkdocs.yml` `edit_uri` corrected from `edit/main/docs/` to `edit/main/` so that auto-generated API reference "Edit" buttons resolve to `src/contextweaver/*.py` rather than the nonexistent `docs/src/...` path
+- `docs/gen_ref_pages.py` dunder-module handling (`__init__`, `__main__`) now runs before the private-name filter so package `__init__.py` docstrings are rendered as package index pages in the API reference; the private filter now correctly excludes only non-dunder private modules and package directories
+- `docs/gen_ref_pages.py` module walk restricted to `src/contextweaver` (matches docstring; prevents accidental inclusion of future sibling packages under `src/`)
 - End-to-end four-phase runtime loop example in `examples/full_agent_loop.py` (#24)
 - Runtime loop guide with flow diagram and phase guidance in `docs/guide_agent_loop.md` (#24)
 - LangChain memory replacement example in `examples/langchain_memory_demo.py` (#170) — demonstrates replacing `InMemoryChatMessageHistory` with phase-specific budgets and the context firewall using a deterministic mock LLM and real `langchain-core` objects

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt lint type test example demo ci
+.PHONY: fmt lint type test example demo ci docs docs-serve
 
 fmt:
 	ruff format src/ tests/ examples/
@@ -25,5 +25,11 @@ example:
 
 demo:
 	python -m contextweaver demo
+
+docs:
+	mkdocs build --clean
+
+docs-serve:
+	mkdocs serve
 
 ci: fmt lint type test example demo

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 **500+ tests passing · zero runtime dependencies · deterministic output · Python ≥ 3.10**
 
+[📖 Documentation](https://dgenio.github.io/contextweaver)
+
 ---
 
 ## The Problem

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -10,6 +10,8 @@ make test     # pytest -q
 make example  # run all example scripts
 make demo     # python -m contextweaver demo
 make ci       # fmt + lint + type + test + example + demo  (6 targets)
+make docs     # mkdocs build --clean (docs site — not part of CI)
+make docs-serve  # mkdocs serve (live preview)
 ```
 
 `make ci` runs all six targets in sequence. It is the single validation gate.
@@ -25,6 +27,8 @@ make ci       # fmt + lint + type + test + example + demo  (6 targets)
 | Run all tests | `make test` |
 | Verify examples work | `make example` |
 | Interactive demo | `make demo` |
+| Build docs site | `make docs` |
+| Live docs preview | `make docs-serve` |
 
 **Do not** use `make test` alone as a validation gate. Always run `make ci` before declaring a change complete — it includes example and demo verification that catch integration issues `make test` misses.
 

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -28,20 +28,22 @@ for path in sorted(package_root.rglob("*.py")):
 
     parts = tuple(module_path.parts)
 
-    # Skip private helpers/packages and CLI entry-point
-    if any(part.startswith("_") for part in parts):
+    # Skip the CLI entry-point unconditionally.
+    if parts[-1] == "__main__":
         continue
 
-    if parts[-1] == "__main__":  # pragma: no cover
-        continue
-
-    # Treat __init__ as the index page for the package directory
+    # Treat __init__ as the index page for the package directory.
     if parts[-1] == "__init__":
         parts = parts[:-1]
         doc_path = doc_path.with_name("index.md")
         full_doc_path = full_doc_path.with_name("index.md")
 
     if not parts:
+        continue
+
+    # Skip private helpers and private package directories (non-dunder names only;
+    # __init__ is handled above, __main__ is handled above).
+    if any(p.startswith("_") for p in parts):
         continue
 
     nav[parts] = doc_path.as_posix()

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -1,0 +1,55 @@
+"""Generate the API reference pages and navigation.
+
+This script is executed by mkdocs-gen-files at build time. It walks
+src/contextweaver, skips private modules (names starting with ``_``) and
+the CLI entry-point (``__main__``), and emits one ``::: identifier``
+reference page per public module. It also writes a ``SUMMARY.md`` consumed
+by mkdocs-literate-nav to build the "API Reference" nav section automatically.
+
+New modules added to the package are picked up on the next ``mkdocs build``
+with no manual edits required here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import mkdocs_gen_files
+
+nav = mkdocs_gen_files.Nav()
+
+src = Path("src")
+
+for path in sorted(src.rglob("*.py")):
+    module_path = path.relative_to(src).with_suffix("")
+    doc_path = path.relative_to(src).with_suffix(".md")
+    full_doc_path = Path("reference", doc_path)
+
+    parts = tuple(module_path.parts)
+
+    # Skip private helpers and CLI entry-point
+    if parts[-1].startswith("_"):
+        continue
+
+    if parts[-1] == "__main__":
+        continue  # pragma: no cover
+
+    # Treat __init__ as the index page for the package directory
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+        doc_path = doc_path.with_name("index.md")
+        full_doc_path = full_doc_path.with_name("index.md")
+
+    if not parts:
+        continue
+
+    nav[parts] = doc_path.as_posix()
+
+    with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+        ident = ".".join(parts)
+        fd.write(f"::: {ident}\n")
+
+    mkdocs_gen_files.set_edit_path(full_doc_path, path)
+
+with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
+    nav_file.writelines(nav.build_literate_nav())

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -19,20 +19,21 @@ import mkdocs_gen_files
 nav = mkdocs_gen_files.Nav()
 
 src = Path("src")
+package_root = src / "contextweaver"
 
-for path in sorted(src.rglob("*.py")):
+for path in sorted(package_root.rglob("*.py")):
     module_path = path.relative_to(src).with_suffix("")
     doc_path = path.relative_to(src).with_suffix(".md")
     full_doc_path = Path("reference", doc_path)
 
     parts = tuple(module_path.parts)
 
-    # Skip private helpers and CLI entry-point
-    if parts[-1].startswith("_"):
+    # Skip private helpers/packages and CLI entry-point
+    if any(part.startswith("_") for part in parts):
         continue
 
-    if parts[-1] == "__main__":
-        continue  # pragma: no cover
+    if parts[-1] == "__main__":  # pragma: no cover
+        continue
 
     # Treat __init__ as the index page for the package directory
     if parts[-1] == "__init__":

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,32 @@
+# contextweaver
+
+> Phase-specific, budget-aware context compilation for tool-using AI agents.
+
+**Zero runtime dependencies · deterministic output · Python ≥ 3.10**
+
+---
+
+contextweaver provides two cooperating engines that solve the context window
+problem for tool-using AI agents:
+
+- **Context Engine** — eight-stage pipeline: candidates → dependency closure →
+  sensitivity filter → firewall → scoring → dedup → selection → rendering.
+- **Routing Engine** — bounded DAG + beam search over large tool catalogs,
+  producing compact LLM-friendly `ChoiceCards`.
+
+## Get started
+
+[10-Minute Quickstart](quickstart.md){ .md-button .md-button--primary }
+[API Reference](reference/){ .md-button }
+
+## Navigate
+
+| Section | What you'll find |
+|---|---|
+| [Quickstart](quickstart.md) | Install, first context build, firewall demo, routing demo |
+| [Concepts](concepts.md) | Core type glossary: `ContextItem`, `Phase`, `ChoiceGraph`, … |
+| [Runtime Loop](guide_agent_loop.md) | Four-phase flow diagram and pseudo-code |
+| [MCP Integration](integration_mcp.md) | Tool conversion, session loading, firewall with MCP |
+| [A2A Integration](integration_a2a.md) | Agent cards and multi-agent sessions |
+| [Architecture](architecture.md) | Pipeline details, design rationale, module map |
+| [API Reference](reference/) | Auto-generated reference from source docstrings |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,79 @@
+site_name: contextweaver
+site_url: https://dgenio.github.io/contextweaver
+site_description: >-
+  Phase-specific, budget-aware context compilation for tool-using AI agents.
+  Zero runtime dependencies. Python ≥ 3.10.
+
+repo_url: https://github.com/dgenio/contextweaver
+repo_name: dgenio/contextweaver
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.indexes
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+
+plugins:
+  - search
+  - gen-files:
+      scripts:
+        - docs/gen_ref_pages.py
+  - literate-nav:
+      nav_file: SUMMARY.md
+  - section-index
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            show_root_full_path: false
+            members_order: source
+            separate_signature: true
+            show_signature_annotations: true
+            unwrap_annotated: true
+            filters:
+              - "!^_"
+            merge_init_into_class: true
+            show_if_no_docstring: false
+
+nav:
+  - Home: index.md
+  - Quickstart: quickstart.md
+  - Concepts: concepts.md
+  - Guides:
+      - Runtime Loop: guide_agent_loop.md
+      - MCP Integration: integration_mcp.md
+      - A2A Integration: integration_a2a.md
+  - Architecture: architecture.md
+  - API Reference: reference/
+
+exclude_docs: |
+  agent-context/*
+  gen_ref_pages.py
+
+not_in_nav: |
+  agent-context/*
+  gen_ref_pages.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ site_description: >-
 
 repo_url: https://github.com/dgenio/contextweaver
 repo_name: dgenio/contextweaver
-edit_uri: edit/main/docs/
+edit_uri: edit/main/
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,14 @@ dev = [
 langchain = [
     "langchain-core>=0.3",
 ]
+docs = [
+    "mkdocs>=1.6",
+    "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.25",
+    "mkdocs-gen-files>=0.5",
+    "mkdocs-literate-nav>=0.6",
+    "mkdocs-section-index>=0.3",
+]
 
 [project.scripts]
 contextweaver = "contextweaver.__main__:main"


### PR DESCRIPTION
## Summary

Closes #110.

Adds a full documentation site using MkDocs + Material theme + mkdocstrings. The API reference pages are **auto-generated** at build time by `docs/gen_ref_pages.py`, which walks `src/contextweaver`, skips private modules (`_*`) and the CLI entry-point, and emits one `::: identifier` page per public module. New modules are picked up automatically on the next `mkdocs build` — no manual page maintenance needed.

The site is published to **https://dgenio.github.io/contextweaver** on every push to `main` via a new GitHub Actions workflow.

## Changes

- `mkdocs.yml` _(new)_ — site config: Material theme, search, `gen-files` + `literate-nav` + `section-index` + `mkdocstrings[python]` plugins; nav tree integrating all existing docs; `exclude_docs` to keep `agent-context/` out of the public site
- `docs/gen_ref_pages.py` _(new)_ — build-time script: walks `src/contextweaver/**/*.py`, generates one reference page per public module, writes `reference/SUMMARY.md` for literate-nav
- `docs/index.md` _(new)_ — public landing page for the docs site
- `.github/workflows/docs.yml` _(new)_ — builds with `mkdocs build --clean` and deploys to GitHub Pages on push to `main`; uses OIDC (`id-token: write`, `pages: write`)
- `pyproject.toml` — added `[docs]` extras group: `mkdocs>=1.6`, `mkdocs-material>=9.5`, `mkdocstrings[python]>=0.25`, `mkdocs-gen-files>=0.5`, `mkdocs-literate-nav>=0.6`, `mkdocs-section-index>=0.3`
- `Makefile` — added `make docs` (build) and `make docs-serve` (live preview) targets; both added to `.PHONY`
- `README.md` — added link to `https://dgenio.github.io/contextweaver`
- `CHANGELOG.md` — added entry under `[Unreleased]`

## How verified

- `ruff format` — 82 files unchanged
- `ruff check` — all checks passed
- `mypy src/` — no issues found in 41 source files
- `pytest -q` — 536 passed in 6.21s
- `mkdocs build --clean` — Documentation built in ~13s, exit code 0

## Notes for reviewers

- The `quickstart.md` has a pre-existing `../README.md` link warning from before this PR. It is a pre-existing issue, not introduced here. The workflow uses `--clean` (not `--strict`) to avoid failing on pre-existing doc warnings in other files.
- GitHub Pages settings required (already configured by repo owner): Settings → Pages → Source: GitHub Actions; Settings → Actions → Workflow permissions: Read and write.
- The `agent-context/` directory is excluded from the public site via `exclude_docs` — those are agent-internal guides only.

## Checklist

- [x] Tests added/updated for every new/changed public function — N/A (docs infrastructure only)
- [x] `make ci` passes locally — 536 passed, ruff + mypy clean
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Google-style docstrings on new public APIs — N/A
- [x] Every modified module stays ≤ 300 lines — N/A (config/docs files)
- [x] Related issue linked — Closes #110
- [x] Agent-facing docs updated if pipeline/API/conventions changed — N/A