### PR TITLE
feat(make): add `make llms` target to regenerate llms.txt / llms-full.txt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ make ci       # fmt + lint + type + test + example + demo
 make docs     # mkdocs build --clean (docs site)
 make docs-serve  # mkdocs serve (live preview)
 make benchmark   # run benchmark harness (non-gating; writes benchmarks/results/latest.json)
+make llms        # regenerate llms.txt and llms-full.txt from canonical docs
+make llms-check  # verify llms.txt and llms-full.txt are up to date (exits non-zero on drift)
 ```
 
 Run `pre-commit install` once after cloning to activate git hooks

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt lint type test example demo ci docs docs-serve benchmark
+.PHONY: fmt lint type test example demo ci docs docs-serve benchmark llms llms-check
 
 fmt:
 	ruff format src/ tests/ examples/
@@ -36,3 +36,9 @@ benchmark:
 	python benchmarks/benchmark.py
 
 ci: fmt lint type test example demo
+
+llms:
+	python scripts/gen_llms.py
+
+llms-check:
+	python scripts/gen_llms.py --check

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -13,6 +13,8 @@ make ci       # fmt + lint + type + test + example + demo  (6 targets)
 make docs     # mkdocs build --clean (docs site — not part of CI)
 make docs-serve  # mkdocs serve (live preview)
 make benchmark   # run benchmark harness (non-gating; writes benchmarks/results/latest.json)
+make llms        # regenerate llms.txt and llms-full.txt from canonical docs
+make llms-check  # verify llms.txt and llms-full.txt are up to date (exits non-zero on drift)
 ```
 
 `make ci` runs all six targets in sequence. It is the single validation gate.
@@ -31,6 +33,8 @@ make benchmark   # run benchmark harness (non-gating; writes benchmarks/results/
 | Build docs site | `make docs` |
 | Live docs preview | `make docs-serve` |
 | Run benchmark harness | `make benchmark` (non-gating; writes `benchmarks/results/latest.json`) |
+| Regenerate llms.txt / llms-full.txt | `make llms` (after editing canonical docs) |
+| Check llms.txt / llms-full.txt for drift | `make llms-check` (exits non-zero if regeneration needed) |
 
 **Do not** use `make test` alone as a validation gate. Always run `make ci` before declaring a change complete — it includes example and demo verification that catch integration issues `make test` misses.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -21,9 +21,7 @@
     docs/agent-context/review-checklist.md
     docs/guide_agent_loop.md
 
-  To regenerate: concatenate each file above with a
-  <!-- FILE: <relative-path> --> section marker between them.
-  A `make llms` target is planned (see issue #103); until then regenerate manually.
+  To regenerate: `make llms` (or `python scripts/gen_llms.py`).
 -->
 
 <!-- FILE: README.md -->
@@ -34,9 +32,14 @@
 
 **500+ tests passing · zero runtime dependencies · deterministic output · Python ≥ 3.10**
 
+[📖 Documentation](https://dgenio.github.io/contextweaver)
+
 ---
 
 ## The Problem
+
+Even with 200K-token context windows, dumping everything into the prompt is expensive,
+slow, and degrades output quality. More context ≠ better answers.
 
 Imagine a tool-using agent with a 100-tool catalog and a 50-turn conversation history.
 At each step the agent must answer four questions:
@@ -50,6 +53,8 @@ At each step the agent must answer four questions:
 
 ```
 100 tool schemas (≈50k tokens) + 50 turns (≈30k tokens) = 80k tokens
+Cost: $0.48/request at GPT-4o rates  ·  Latency: 3–5s TTFT
+Quality: LLM loses focus — needle-in-haystack accuracy drops with context size
 Token limit: 8k → 10× overflow
 ```
 
@@ -66,6 +71,7 @@ Agent hallucinates tool calls, repeats questions, forgets context
 Route phase:  5 tool cards (≈500 tokens), no full schemas
 Answer phase: 3 relevant turns + dependency closure (≈2k tokens)
 Result:       2.5k tokens, complete context, deterministic
+Cost:         70% lower  ·  Latency: sub-second  ·  Quality: relevant context only
 ```
 
 See [`examples/before_after.py`](examples/before_after.py) for a runnable side-by-side comparison.
@@ -168,6 +174,20 @@ result = router.route("send a reminder email about unpaid invoices")
 print(result.candidate_ids)
 ```
 
+## Runtime Loop (4 Phases)
+
+For a complete route -> call -> interpret -> answer reference flow, see:
+
+- `examples/full_agent_loop.py` for a runnable end-to-end script.
+- `docs/guide_agent_loop.md` for the flow diagram, pseudo-code, and module map.
+
+The runtime loop example demonstrates:
+
+1. Route-phase prompt assembly with ChoiceCards.
+2. Call-phase prompt assembly with selected tool schema hydration.
+3. Interpret-phase firewall behavior (large tool output summarized into context).
+4. Answer-phase context composition with accumulated history and result envelopes.
+
 ---
 
 ## Framework Integrations
@@ -231,11 +251,13 @@ contextweaver replay --session session.json --phase answer
 | Script | Description |
 |---|---|
 | `minimal_loop.py` | Basic event ingestion → context build |
+| `full_agent_loop.py` | End-to-end route → call → interpret → answer runtime loop |
 | `tool_wrapping.py` | Context firewall in action |
 | `routing_demo.py` | Build catalog → route queries → choice cards |
 | `before_after.py` | Side-by-side token comparison: WITHOUT vs WITH contextweaver |
 | `mcp_adapter_demo.py` | MCP adapter: tool conversion, session loading, firewall |
 | `a2a_adapter_demo.py` | A2A adapter: agent cards, multi-agent sessions |
+| `langchain_memory_demo.py` | LangChain memory replacement: `InMemoryChatMessageHistory` vs contextweaver |
 
 ```bash
 make example   # run all examples
@@ -812,12 +834,12 @@ What just happened:
 
 Available now:
 
-- [README](README.md) for the top-level package overview
-- [Concepts](docs/concepts.md) for phases, the context firewall, and routing terms
-- [Architecture](docs/architecture.md) for the pipeline stages and module layout
-- [MCP Integration](docs/integration_mcp.md) for MCP adapters and session ingestion
-- [A2A Integration](docs/integration_a2a.md) for multi-agent adapter flows
-- [Examples directory](examples/) for larger end-to-end demos
+- [README](../README.md) for the top-level package overview
+- [Concepts](concepts.md) for phases, the context firewall, and routing terms
+- [Architecture](architecture.md) for the pipeline stages and module layout
+- [MCP Integration](integration_mcp.md) for MCP adapters and session ingestion
+- [A2A Integration](integration_a2a.md) for multi-agent adapter flows
+- [Examples directory](../examples/) for larger end-to-end demos
 
 Planned separately:
 
@@ -1121,8 +1143,6 @@ See `examples/a2a_adapter_demo.py` for the full runnable demo.
 
 ---
 
----
-
 <!-- FILE: docs/agent-context/architecture.md -->
 
 # Architecture Guidance
@@ -1208,6 +1228,7 @@ Think of contextweaver as three layers:
 Adapters (`adapters/`) convert external formats (MCP, A2A) into contextweaver types at the boundary.
 
 Changes should flow within a layer. Cross-layer changes (e.g., adding I/O to the data layer) are red flags.
+
 ---
 
 <!-- FILE: docs/agent-context/invariants.md -->
@@ -1307,6 +1328,7 @@ Update this file when:
 - A forbidden shortcut is discovered through a bad change.
 - A safe/unsafe determination changes due to architectural evolution.
 - A cross-cutting rule is added or relaxed.
+
 ---
 
 <!-- FILE: docs/agent-context/workflows.md -->
@@ -1323,6 +1345,8 @@ make test     # pytest -q
 make example  # run all example scripts
 make demo     # python -m contextweaver demo
 make ci       # fmt + lint + type + test + example + demo  (6 targets)
+make docs     # mkdocs build --clean (docs site — not part of CI)
+make docs-serve  # mkdocs serve (live preview)
 ```
 
 `make ci` runs all six targets in sequence. It is the single validation gate.
@@ -1338,6 +1362,8 @@ make ci       # fmt + lint + type + test + example + demo  (6 targets)
 | Run all tests | `make test` |
 | Verify examples work | `make example` |
 | Interactive demo | `make demo` |
+| Build docs site | `make docs` |
+| Live docs preview | `make docs-serve` |
 
 **Do not** use `make test` alone as a validation gate. Always run `make ci` before declaring a change complete — it includes example and demo verification that catch integration issues `make test` misses.
 
@@ -1437,6 +1463,7 @@ When adding a new canonical doc under `docs/agent-context/`, update the navigati
 - `AGENTS.md` (Documentation Map)
 - `.github/copilot-instructions.md` (Canonical References)
 - `.claude/CLAUDE.md` (Canonical References)
+
 ---
 
 <!-- FILE: docs/agent-context/lessons-learned.md -->
@@ -1524,6 +1551,7 @@ Record a new lesson when:
 Do not record lessons for:
 - Typos, formatting issues, or trivial errors.
 - One-off issues that are unlikely to recur.
+
 ---
 
 <!-- FILE: docs/agent-context/review-checklist.md -->
@@ -1611,6 +1639,7 @@ Update this checklist when:
 - New hard rules or invariants are established.
 - New review gates are identified from recurring review feedback.
 - Definition of done changes (sync with [workflows.md](workflows.md)).
+
 ---
 
 <!-- FILE: docs/guide_agent_loop.md -->

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -196,23 +196,10 @@ The runtime loop example demonstrates:
 |---|---|---|
 | MCP | [Guide](docs/integration_mcp.md) | Tool conversion, session loading, firewall |
 | A2A | [Guide](docs/integration_a2a.md) | Agent cards, multi-agent sessions |
-| LlamaIndex | Guide (coming soon) | RAG + tools with budget control |
-| OpenAI Agents SDK | Guide (coming soon) | Function-calling agents with routing |
-| Google ADK | Guide (coming soon) | Gemini tool-use with context budgets |
-| LangChain / LangGraph | Guide (coming soon) | Chain + graph agents with firewall |
-
----
-
-## Why Trust contextweaver?
-
-| Proof point | Detail |
-|---|---|
-| **500+ tests passing** | Context pipeline, routing engine, firewall, adapters, CLI, sensitivity enforcement |
-| **Zero runtime dependencies** | Stdlib-only, Python ≥ 3.10. Works with any LLM provider. No vendor lock-in. |
-| **Deterministic** | Tie-break by ID, sorted keys. Identical inputs always produce identical outputs. |
-| **Protocol-based stores** | `EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore` are `typing.Protocol` interfaces — swap any backend. |
-| **MCP + A2A adapters** | First-class support for both emerging agentic standards. |
-| **`BuildStats` transparency** | Every context build reports exactly what was kept, dropped, deduplicated, and why. |
+| LlamaIndex | Guide (v0.2) | RAG + tools with budget control |
+| OpenAI Agents SDK | Guide (v0.2) | Function-calling agents with routing |
+| Google ADK | Guide (v0.2) | Gemini tool-use with context budgets |
+| LangChain / LangGraph | Guide (v0.2) | Chain + graph agents with firewall |
 
 ---
 
@@ -229,6 +216,171 @@ The runtime loop example demonstrates:
 
 See [`docs/concepts.md`](docs/concepts.md) for the full glossary and
 [`docs/architecture.md`](docs/architecture.md) for pipeline detail and design rationale.
+
+---
+
+## Why Trust contextweaver?
+
+### 1. Test Coverage & Reliability
+
+contextweaver is built for production use with comprehensive quality gates:
+
+- **500+ passing tests** across all modules — context pipeline, routing engine, firewall,
+  adapters, stores, CLI, sensitivity enforcement
+- **mypy strict** type checking — zero errors across all source files
+- **ruff clean** linting — zero warnings
+- **CI pipeline** on every pull request and on pushes to `main` ([see workflows](.github/workflows/))
+- **Deterministic output** — tie-break by ID, sorted keys; identical inputs always produce
+  identical outputs
+
+Run the full suite yourself:
+
+```bash
+git clone https://github.com/dgenio/contextweaver.git
+cd contextweaver
+pip install -e ".[dev]"
+make ci  # fmt + lint + type + test + example + demo (all pass)
+```
+
+> Most agent libraries fail unpredictably when context exceeds token limits. contextweaver's
+> deterministic design and comprehensive test coverage ensure your agent behaves the same way
+> every time — critical for debugging, testing, and production deployment.
+
+### 2. Design Rationale
+
+Every architectural choice was made for a reason:
+
+| Decision | Reason |
+|---|---|
+| **Zero runtime dependencies** | No version conflicts, no supply-chain risks, no bloat. Works in any Python 3.10+ environment. |
+| **Protocol-based interfaces** | `EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore` are `typing.Protocol` — swap backends without forking. |
+| **Async-first context engine** | Async-compatible compilation API for real-time integrations; `build_sync()` wrappers for synchronous callers, with room for future non-blocking execution. |
+| **Phase-specific token budgets** | Route / call / interpret / answer phases each get their own budget — no one-size-fits-all truncation. |
+| **Context firewall** | Large tool outputs stored out-of-band; only compact summaries reach the prompt. |
+| **Dependency closure** | `parent_id` chains keep tool results coherent — tool calls are never separated from their results. |
+
+> These aren't accidental features. They are design decisions optimized for reliability,
+> extensibility, and production use. Zero dependencies means you can adopt contextweaver
+> without disrupting your existing stack.
+
+See [docs/architecture.md](docs/architecture.md) for full pipeline detail and design rationale.
+
+### 3. Standardization via Protocol Support
+
+contextweaver supports both emerging agentic protocols out of the box:
+
+**MCP (Model Context Protocol)** — convert tool definitions and results into native contextweaver types:
+
+- Compatible with any MCP server (Claude Desktop, VS Code, custom servers)
+- Structured content, output schemas, binary artifacts, and per-part annotations all handled
+- `ingest_mcp_result()` for one-call result ingestion with automatic artifact persistence
+
+**A2A (Agent-to-Agent)** — multi-agent session management with unified context:
+
+- Agent cards converted to `SelectableItem` for routing
+- Cross-agent session loading via `load_a2a_session_jsonl()`
+- A2A results stored in `ResultEnvelope` with facts and artifact handles
+
+> contextweaver is positioned to become the standard context management layer for AI agents.
+> Supporting MCP and A2A now means your codebase is future-proof as these protocols mature
+> and gain wider adoption.
+
+- [MCP Integration](docs/integration_mcp.md)
+- [A2A Integration](docs/integration_a2a.md)
+- [MCP Specification](https://modelcontextprotocol.io/)
+
+### 4. Framework Agnostic
+
+contextweaver works with any LLM provider and any agent framework:
+
+- **LLM providers**: OpenAI, Anthropic, Google, open-source models — no API keys required
+  by contextweaver itself
+- **Agent frameworks**: LlamaIndex, LangChain, LangGraph, OpenAI Agents SDK, Google ADK,
+  Pipecat, custom loops
+- **No vendor lock-in**: stdlib-only core; no cloud dependencies; runs anywhere Python 3.10+ runs
+
+<!-- mirrors the Framework Integrations table above; keep in sync -->
+| Framework | Guide | Use Case |
+|---|---|---|
+| MCP | [Guide](docs/integration_mcp.md) | Tool conversion, session loading, firewall |
+| A2A | [Guide](docs/integration_a2a.md) | Agent cards, multi-agent sessions |
+| LlamaIndex | Guide (v0.2) | RAG + tools with budget control |
+| OpenAI Agents SDK | Guide (v0.2) | Function-calling agents with routing |
+| Google ADK | Guide (v0.2) | Gemini tool-use with context budgets |
+| LangChain / LangGraph | Guide (v0.2) | Chain + graph agents with firewall |
+
+> You are not locked into a specific framework or LLM provider. contextweaver is a layer
+> *beneath* frameworks — context management as a composable primitive.
+
+### 5. Versioning & Compatibility
+
+contextweaver follows [Semantic Versioning](https://semver.org/):
+
+- **Breaking changes** to public APIs only in major versions
+- **Deprecation policy**: deprecated public APIs are warned for at least one minor version and removed only in a later major release
+- **API stability**: public APIs in `contextweaver.*` are stable; internal `_*` modules may change
+- **Python support**: 3.10+ (aligned with Python's active security support lifecycle)
+
+| Version | Status | Notes |
+|---|---|---|
+| **0.1.x** | ✅ Current | Foundation engines (context + routing), MCP/A2A adapters, CLI, sensitivity |
+| **0.2.0** | 🚧 In progress (Q2 2026) | Framework integration guides, benchmark suite, distributed stores |
+| **0.3.0** | 📋 Planned (Q3 2026) | DAG visualization, merge compression, LLM-assisted labeler |
+| **1.0.0** | 📋 Planned (Q4 2026) | API freeze, production benchmarks, enterprise features |
+
+> Adopting a library is a long-term commitment. contextweaver's versioning policy ensures you
+> can upgrade safely, and the roadmap shows where it's headed.
+
+### 6. Roadmap & Community
+
+**v0.1 (✅ Complete)**
+
+- Context Engine: 8-stage pipeline (candidates → closure → sensitivity → firewall → score → dedup → select → render)
+- Routing Engine: Catalog, DAG builder, beam-search router, choice cards
+- Protocol adapters: MCP (full content types, structured content, output schemas) and A2A
+- Stores: `EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore` with protocol-based interfaces
+- 500+ passing tests, mypy strict, ruff clean, zero runtime dependencies
+
+**v0.2 (🚧 In Progress — Q2 2026)**
+
+- Framework integration guides: LlamaIndex, LangChain, LangGraph, OpenAI Agents SDK, Google ADK, Pipecat
+- Benchmark suite: token reduction, latency, and accuracy vs. naive concatenation
+- Distributed stores: Redis-backed `EventLog`, S3-backed `ArtifactStore`
+
+**v0.3 (📋 Planned — Q3 2026)**
+
+- DAG visualization: interactive routing graph inspector
+- Merge compression: deduplicate similar tool results across turns
+- LLM-based labeler: auto-generate namespace labels for tool catalogs
+- LLM-based extractor: structured fact extraction with prompt-based schema
+
+**v1.0 (📋 Planned — Q4 2026)**
+
+- API freeze: no breaking changes in 1.x releases
+- Production benchmarks: 1M+ turn deployments
+- Enterprise features: audit logging, compliance tags, PII redaction
+
+**Community:**
+
+- [GitHub Discussions](https://github.com/dgenio/contextweaver/discussions) — ask questions, share patterns
+- [GitHub Issues](https://github.com/dgenio/contextweaver/issues) — report bugs, request features
+- [CHANGELOG](CHANGELOG.md) — track every release
+
+> contextweaver is under active development with a clear roadmap. v0.1 is feature-complete
+> for basic use cases; v0.2 adds production-ready integrations; v1.0 is the API stability milestone.
+
+### Comparison
+
+| Approach | Token Control | Tool Routing | Firewall | Framework Agnostic | Dependencies |
+|---|---|---|---|---|---|
+| **Naive concatenation** | ❌ No | ❌ No | ❌ No | ✅ Yes | None |
+| **LangChain ConversationBufferMemory** | ❌ No | ❌ No | ❌ No | ❌ No (LangChain only) | Many |
+| **LangChain ConversationSummaryMemory** | ⚠️ LLM-based | ❌ No | ❌ No | ❌ No (LangChain only) | Many |
+| **LlamaIndex ContextManager** | ⚠️ Partial | ❌ No | ❌ No | ❌ No (LlamaIndex only) | Many |
+| **contextweaver** | ✅ Yes (phase-specific budgets) | ✅ Yes (bounded DAG) | ✅ Yes (out-of-band storage) | ✅ Yes | None |
+
+> Most frameworks offer memory classes, but they don't enforce token budgets, route tools, or
+> handle large outputs. contextweaver provides all three as a composable, framework-agnostic layer.
 
 ---
 
@@ -340,7 +492,7 @@ the "context window problem" for tool-using AI agents.
 | `summarize/` | Rule engine and structured fact extraction |
 | `context/` | Full context compilation pipeline |
 | `routing/` | Catalog, DAG builder, beam-search router, card renderer |
-| `adapters/` | MCP and A2A protocol adapters |
+| `adapters/` | MCP, FastMCP, and A2A protocol adapters |
 | `__main__.py` | CLI entry point (7 subcommands) |
 
 ## Context Engine pipeline
@@ -1225,7 +1377,7 @@ Think of contextweaver as three layers:
 2. **Store layer** (`store/`, `protocols.py`) — stateful but simple append-only/read interfaces.
 3. **Pipeline layer** (`context/`, `routing/`, `summarize/`) — orchestration logic that reads from stores and produces output types.
 
-Adapters (`adapters/`) convert external formats (MCP, A2A) into contextweaver types at the boundary.
+Adapters (`adapters/`) convert external formats (MCP, FastMCP, A2A) into contextweaver types at the boundary.
 
 Changes should flow within a layer. Cross-layer changes (e.g., adding I/O to the data layer) are red flags.
 
@@ -1347,6 +1499,9 @@ make demo     # python -m contextweaver demo
 make ci       # fmt + lint + type + test + example + demo  (6 targets)
 make docs     # mkdocs build --clean (docs site — not part of CI)
 make docs-serve  # mkdocs serve (live preview)
+make benchmark   # run benchmark harness (non-gating; writes benchmarks/results/latest.json)
+make llms        # regenerate llms.txt and llms-full.txt from canonical docs
+make llms-check  # verify llms.txt and llms-full.txt are up to date (exits non-zero on drift)
 ```
 
 `make ci` runs all six targets in sequence. It is the single validation gate.
@@ -1364,6 +1519,9 @@ make docs-serve  # mkdocs serve (live preview)
 | Interactive demo | `make demo` |
 | Build docs site | `make docs` |
 | Live docs preview | `make docs-serve` |
+| Run benchmark harness | `make benchmark` (non-gating; writes `benchmarks/results/latest.json`) |
+| Regenerate llms.txt / llms-full.txt | `make llms` (after editing canonical docs) |
+| Check llms.txt / llms-full.txt for drift | `make llms-check` (exits non-zero if regeneration needed) |
 
 **Do not** use `make test` alone as a validation gate. Always run `make ci` before declaring a change complete — it includes example and demo verification that catch integration issues `make test` misses.
 

--- a/scripts/gen_llms.py
+++ b/scripts/gen_llms.py
@@ -3,8 +3,8 @@
 
 Run via `make llms`. Both output files are deterministic and should
 match the committed copies byte-for-byte after each documentation
-change. CI calls this same script with `--check` to fail builds when
-drift is introduced.
+change. Intended for CI to run with `--check` to fail builds when
+drift is introduced; CI integration is deferred to a follow-up.
 
 Layout of each output:
 

--- a/scripts/gen_llms.py
+++ b/scripts/gen_llms.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Regenerate llms.txt and llms-full.txt from source documentation.
+
+Run via `make llms`. Both output files are deterministic and should
+match the committed copies byte-for-byte after each documentation
+change. CI calls this same script with `--check` to fail builds when
+drift is introduced.
+
+Layout of each output:
+
+* `llms-full.txt` — concatenation of every doc listed in
+  ``LLMS_FULL_FILES``, separated by ``---`` rules and per-file
+  ``<!-- FILE: <path> -->`` markers, prefixed by a generated header
+  block that lists the source files (so a reader of the file can find
+  the originals without consulting the script).
+* `llms.txt` — the llmstxt.org index: header, link sections, and a
+  one-line description per linked target. Links are produced from the
+  ``LLMS_INDEX`` data structure below.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Order matters — this is the concatenation order used in llms-full.txt.
+# Add new docs here when shipping a new file under docs/ or a new
+# top-level guide so llms-full.txt stays in sync.
+LLMS_FULL_FILES: list[str] = [
+    "README.md",
+    "docs/architecture.md",
+    "docs/concepts.md",
+    "docs/quickstart.md",
+    "docs/integration_mcp.md",
+    "docs/integration_a2a.md",
+    "docs/agent-context/architecture.md",
+    "docs/agent-context/invariants.md",
+    "docs/agent-context/workflows.md",
+    "docs/agent-context/lessons-learned.md",
+    "docs/agent-context/review-checklist.md",
+    "docs/guide_agent_loop.md",
+]
+
+LLMS_FULL_HEADER = """\
+# contextweaver — Full Documentation
+
+> Dynamic context management for tool-using AI agents.
+
+---
+
+<!--
+  GENERATED FILE — do not edit by hand.
+
+  Source files (concatenated in order):
+{file_list}
+
+  To regenerate: `make llms` (or `python scripts/gen_llms.py`).
+-->
+"""
+
+LLMS_INDEX_HEADER = """\
+# contextweaver
+
+> Dynamic context management for tool-using AI agents.
+
+contextweaver is a Python library that provides two integrated engines: a
+phase-specific, budget-aware Context Engine and a bounded-choice Routing Engine
+for large tool catalogs. Zero runtime dependencies, deterministic output,
+Python ≥ 3.10.
+"""
+
+# llmstxt.org index sections. Each entry is (link_text, target_path,
+# one_line_description). Order within each section is preserved.
+LLMS_INDEX: list[tuple[str, list[tuple[str, str, str]]]] = [
+    (
+        "Docs",
+        [
+            ("Architecture", "docs/architecture.md", "Package layout, pipeline stages, design principles"),
+            ("Concepts", "docs/concepts.md", "ContextItem, phases, context firewall, ChoiceGraph, sensitivity enforcement, and more"),
+            ("Quickstart", "docs/quickstart.md", "10-minute guide to context builds, firewall, and routing"),
+            ("MCP Integration", "docs/integration_mcp.md", "MCP adapter functions, JSONL format, end-to-end example"),
+            ("A2A Integration", "docs/integration_a2a.md", "A2A adapter functions, multi-agent sessions"),
+            ("Agent Loop Guide", "docs/guide_agent_loop.md", "Flow diagram and phase guidance for building a complete agent loop"),
+        ],
+    ),
+    (
+        "Agent Context",
+        [
+            ("Agent Architecture", "docs/agent-context/architecture.md", "Non-obvious architectural guidance, design tradeoffs, and async/sync boundaries"),
+            ("Invariants", "docs/agent-context/invariants.md", "Hard constraints and forbidden shortcuts in the codebase"),
+            ("Workflows", "docs/agent-context/workflows.md", "Authoritative commands, sequencing, and definition of done"),
+            ("Lessons Learned", "docs/agent-context/lessons-learned.md", "Recurring failure patterns and how to avoid them"),
+            ("Review Checklist", "docs/agent-context/review-checklist.md", "Self-check and review gates for contributors"),
+        ],
+    ),
+    (
+        "API",
+        [
+            ("Types", "src/contextweaver/types.py", "Core dataclasses and enums (SelectableItem, ContextItem, Phase, ItemKind, Sensitivity)"),
+            ("Config", "src/contextweaver/config.py", "Configuration dataclasses (ContextBudget, ContextPolicy, ScoringConfig)"),
+            ("Protocols", "src/contextweaver/protocols.py", "Protocol interfaces (TokenEstimator, EventHook, Summarizer, Extractor)"),
+            ("Envelope", "src/contextweaver/envelope.py", "Result types (ResultEnvelope, BuildStats, ContextPack, ChoiceCard, HydrationResult)"),
+            ("Context Manager", "src/contextweaver/context/manager.py", "Main entry point for context builds (build, build_sync, ingest, ingest_tool_result)"),
+            ("Router", "src/contextweaver/routing/router.py", "Beam search routing over ChoiceGraph"),
+            ("Catalog", "src/contextweaver/routing/catalog.py", "Tool catalog management and hydration"),
+        ],
+    ),
+    (
+        "Examples",
+        [
+            ("Minimal Loop", "examples/minimal_loop.py", "Basic event ingestion → context build"),
+            ("Tool Wrapping", "examples/tool_wrapping.py", "Context firewall in action"),
+            ("Routing Demo", "examples/routing_demo.py", "Build catalog → route queries → choice cards"),
+            ("Before/After", "examples/before_after.py", "Comparing raw vs. firewall-processed context"),
+            ("MCP Adapter Demo", "examples/mcp_adapter_demo.py", "End-to-end MCP session ingestion and context build"),
+            ("A2A Adapter Demo", "examples/a2a_adapter_demo.py", "End-to-end A2A multi-agent session demo"),
+            ("Hydrate Call Demo", "examples/hydrate_call_demo.py", "Enrich a tool call with context-aware hydration"),
+            ("Full Agent Loop", "examples/full_agent_loop.py", "End-to-end 4-phase runtime loop (route → call → interpret → answer)"),
+            ("LangChain Memory Demo", "examples/langchain_memory_demo.py", "Replacing LangChain InMemoryChatMessageHistory with contextweaver budgets"),
+        ],
+    ),
+]
+
+
+def _read_file_stripped(path: Path) -> str:
+    """Return file contents with trailing whitespace stripped.
+
+    Sources end with a newline by convention; the concatenated
+    `llms-full.txt` instead uses explicit `---` rules between files,
+    so the trailing newline is consumed by the separator.
+    """
+    return path.read_text(encoding="utf-8").rstrip()
+
+
+def render_llms_full() -> str:
+    file_list_lines = [f"    {p}" for p in LLMS_FULL_FILES]
+    header = LLMS_FULL_HEADER.format(file_list="\n".join(file_list_lines))
+
+    parts: list[str] = [header]
+    for i, rel in enumerate(LLMS_FULL_FILES):
+        absolute = REPO_ROOT / rel
+        if not absolute.is_file():
+            raise FileNotFoundError(f"Source not found: {rel}")
+        if i == 0:
+            parts.append(f"\n<!-- FILE: {rel} -->\n\n{_read_file_stripped(absolute)}")
+        else:
+            parts.append(f"\n\n---\n\n<!-- FILE: {rel} -->\n\n{_read_file_stripped(absolute)}")
+    return "".join(parts)
+
+
+def render_llms_index() -> str:
+    parts: list[str] = [LLMS_INDEX_HEADER]
+    for section_title, entries in LLMS_INDEX:
+        parts.append(f"\n## {section_title}\n\n")
+        for label, path, desc in entries:
+            parts.append(f"- [{label}]({path}): {desc}\n")
+    return "".join(parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if regenerated output differs from the committed files",
+    )
+    args = parser.parse_args(argv)
+
+    full_target = REPO_ROOT / "llms-full.txt"
+    index_target = REPO_ROOT / "llms.txt"
+
+    full_new = render_llms_full()
+    index_new = render_llms_index()
+
+    if args.check:
+        drift: list[str] = []
+        for target, new in ((full_target, full_new), (index_target, index_new)):
+            current = target.read_text(encoding="utf-8") if target.exists() else ""
+            if current != new:
+                drift.append(target.name)
+        if drift:
+            print(
+                f"llms drift detected in: {', '.join(drift)}. "
+                "Run `make llms` and commit the result.",
+                file=sys.stderr,
+            )
+            return 1
+        print("llms.txt and llms-full.txt are up to date")
+        return 0
+
+    full_target.write_text(full_new, encoding="utf-8")
+    index_target.write_text(index_new, encoding="utf-8")
+    print(f"Wrote {full_target.name} ({len(full_new)} bytes)")
+    print(f"Wrote {index_target.name} ({len(index_new)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #173. PR #160 (issue #103) shipped `llms.txt` and `llms-full.txt` but deferred the sync mechanism — which is exactly the drift the issue calls out:

- `docs/guide_agent_loop.md`, `examples/full_agent_loop.py`, and `examples/langchain_memory_demo.py` landed on main from #169 / #171 with no update to either output file.
- The README's `## The Problem` section was rewritten ("Even with 200K-token context windows…") without `llms-full.txt` picking it up.

## What's in the PR

- **`scripts/gen_llms.py`** — single Python entrypoint that holds the ordered list of source files for `llms-full.txt` and a curated llmstxt.org index data structure for `llms.txt`. Renders both deterministically. `--check` mode exits non-zero on drift.
- **`make llms`** — runs `scripts/gen_llms.py` (regenerates both files in place).
- **`make llms-check`** — runs `scripts/gen_llms.py --check` (zero-exit if up to date, useful for CI).
- **Regenerated `llms-full.txt`** — pulls in the missed README and guide content. `llms.txt` was already correct as committed, so it stays byte-identical.

## Acceptance criteria

- [x] `make llms` target in `Makefile` regenerates `llms.txt` and `llms-full.txt` from source.
- [x] Running `make llms` produces byte-identical output to the committed files (verified via `git diff` after commit — `make llms-check` returns clean).
- [ ] CI step — left out of this PR. To wire it up, add `make llms-check` to the `ci` target (or as a separate workflow step). I left it out so you can choose whether `make ci` should hard-fail on drift or just warn.

## Test plan

- [x] `python scripts/gen_llms.py` writes both files.
- [x] `python scripts/gen_llms.py --check` returns `llms.txt and llms-full.txt are up to date` after the commit.
- [x] `git diff` is empty after a fresh `make llms` on the committed branch.
- [x] Adding a stray edit to either file (then re-running `--check`) correctly returns exit 1.

Closes #173