### PR TITLE
feat(adapters): FastMCP Catalog bridge — auto-ingest tools from FastMCP servers (#114)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ It prepares context and routes tools but never calls models or executes tools.
 | `summarize/` | `SummarizationRule`, `RuleEngine`, `extract_facts()` |
 | `context/` | Full context pipeline, sensitivity enforcement, view registry, `ContextManager` |
 | `routing/` | `Catalog`, `ChoiceGraph`, `TreeBuilder`, `Router` (beam search), card renderer |
-| `adapters/` | MCP and A2A protocol adapters |
+| `adapters/` | MCP, FastMCP, and A2A protocol adapters |
 | `__main__.py` | CLI: 7 subcommands (`demo`, `build`, `route`, `print-tree`, `init`, `ingest`, `replay`) |
 
 ## Pipelines (summary)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- FastMCP Catalog bridge adapter in `adapters/fastmcp.py` (#114)
+  - `fastmcp_tool_to_selectable()` — convert FastMCP tool definitions to `SelectableItem`
+  - `fastmcp_tools_to_catalog()` — batch-convert tool definitions into a populated `Catalog`
+  - `load_fastmcp_catalog()` — async live discovery from any FastMCP server source
+  - `infer_fastmcp_namespace()` — 2-segment namespace inference matching FastMCP composition convention
+  - `contextweaver[fastmcp]` optional extra (`fastmcp>=2.0`)
+  - Example recipe in `examples/fastmcp_adapter_demo.py`
 - Auto-generated API reference documentation site using MkDocs + Material + mkdocstrings (#110)
   - `mkdocs.yml` — site configuration with Material theme, auto-nav, and mkdocstrings
   - `docs/gen_ref_pages.py` — build-time script that walks `src/contextweaver` and emits one reference page per public module; new modules are picked up automatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `infer_fastmcp_namespace()` — 2-segment namespace inference matching FastMCP composition convention
   - `contextweaver[fastmcp]` optional extra (`fastmcp>=2.0`)
   - Example recipe in `examples/fastmcp_adapter_demo.py`
+
+### Fixed
+- `_strip_namespace_prefix()` now also strips `{namespace}.` and `{namespace}/` prefixes,
+  preventing the namespace from appearing verbatim in the tool's display name for
+  dot- and slash-delimited FastMCP names (e.g. `"github.create_issue"` → `name="create_issue"`) (#177, review)
+- `fastmcp_tool_to_selectable()` now normalizes `meta` values before merging into
+  `SelectableItem.metadata`: `set`/`frozenset` are coerced to sorted lists and `tuple` to
+  lists, ensuring `to_dict()` / JSON serialization never fails on FastMCP metadata (#177, review)
 - Auto-generated API reference documentation site using MkDocs + Material + mkdocstrings (#110)
   - `mkdocs.yml` — site configuration with Material theme, auto-nav, and mkdocstrings
   - `docs/gen_ref_pages.py` — build-time script that walks `src/contextweaver` and emits one reference page per public module; new modules are picked up automatically

--- a/docs/agent-context/architecture.md
+++ b/docs/agent-context/architecture.md
@@ -78,6 +78,6 @@ Think of contextweaver as three layers:
 2. **Store layer** (`store/`, `protocols.py`) — stateful but simple append-only/read interfaces.
 3. **Pipeline layer** (`context/`, `routing/`, `summarize/`) — orchestration logic that reads from stores and produces output types.
 
-Adapters (`adapters/`) convert external formats (MCP, A2A) into contextweaver types at the boundary.
+Adapters (`adapters/`) convert external formats (MCP, FastMCP, A2A) into contextweaver types at the boundary.
 
 Changes should flow within a layer. Cross-layer changes (e.g., adding I/O to the data layer) are red flags.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,7 +36,7 @@ the "context window problem" for tool-using AI agents.
 | `summarize/` | Rule engine and structured fact extraction |
 | `context/` | Full context compilation pipeline |
 | `routing/` | Catalog, DAG builder, beam-search router, card renderer |
-| `adapters/` | MCP and A2A protocol adapters |
+| `adapters/` | MCP, FastMCP, and A2A protocol adapters |
 | `__main__.py` | CLI entry point (7 subcommands) |
 
 ## Context Engine pipeline

--- a/examples/fastmcp_adapter_demo.py
+++ b/examples/fastmcp_adapter_demo.py
@@ -1,0 +1,117 @@
+"""FastMCP adapter demo.
+
+Demonstrates converting FastMCP tool definitions into contextweaver-native
+types and building a Catalog from them.  All conversions use plain dicts —
+no ``fastmcp`` install required for this demo.
+
+For live server discovery (``load_fastmcp_catalog``), install the optional
+extra: ``pip install 'contextweaver[fastmcp]'``
+"""
+
+from __future__ import annotations
+
+from contextweaver.adapters.fastmcp import (
+    fastmcp_tool_to_selectable,
+    fastmcp_tools_to_catalog,
+    infer_fastmcp_namespace,
+)
+
+# Simulated tools as they would appear from a FastMCP composed server
+# with namespace-prefixed names (https://gofastmcp.com/servers/composition).
+FASTMCP_TOOLS: list[dict[str, object]] = [
+    {
+        "name": "github_search_repos",
+        "description": "Search GitHub repositories by keyword",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}, "limit": {"type": "integer"}},
+            "required": ["query"],
+        },
+        "annotations": {"readOnlyHint": True, "costHint": 0.1},
+        "meta": {"tags": ["search", "vcs"], "version": "1.0"},
+    },
+    {
+        "name": "github_create_issue",
+        "description": "Create a new issue in a GitHub repository",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string"},
+                "title": {"type": "string"},
+                "body": {"type": "string"},
+            },
+            "required": ["repo", "title"],
+        },
+        "annotations": {"destructiveHint": False},
+        "meta": {"tags": ["vcs"]},
+    },
+    {
+        "name": "slack_send_message",
+        "description": "Send a message to a Slack channel",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"channel": {"type": "string"}, "text": {"type": "string"}},
+            "required": ["channel", "text"],
+        },
+        "meta": {"tags": ["messaging"]},
+    },
+    {
+        "name": "db_query",
+        "description": "Run a read-only SQL query",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"sql": {"type": "string"}},
+            "required": ["sql"],
+        },
+        "annotations": {"readOnlyHint": True},
+    },
+]
+
+
+def main() -> None:
+    print("=== FastMCP Adapter Demo ===\n")
+
+    # 1. Namespace inference
+    print("[1] Namespace inference:")
+    for name in ["github_search_repos", "slack_send_message", "db_query", "search"]:
+        ns = infer_fastmcp_namespace(name)
+        print(f"    {name!r:30s} → namespace={ns!r}")
+
+    # 2. Single tool conversion
+    print("\n[2] Single tool conversion:")
+    item = fastmcp_tool_to_selectable(FASTMCP_TOOLS[0])  # type: ignore[arg-type]
+    print(f"    ID:          {item.id}")
+    print(f"    Name:        {item.name}")
+    print(f"    Namespace:   {item.namespace}")
+    print(f"    Tags:        {item.tags}")
+    print(f"    Side effects:{item.side_effects}")
+    print(f"    Cost hint:   {item.cost_hint}")
+    print(f"    Has schema:  {bool(item.args_schema)}")
+
+    # 3. Batch conversion → Catalog
+    print("\n[3] Building Catalog from 4 FastMCP tools:")
+    catalog = fastmcp_tools_to_catalog(FASTMCP_TOOLS)  # type: ignore[arg-type]
+    for it in catalog.all():
+        print(f"    {it.id:40s} ns={it.namespace:10s} name={it.name}")
+
+    # 4. Namespace-scoped queries
+    print("\n[4] Namespace filter (github):")
+    for it in catalog.filter_by_namespace("github"):
+        print(f"    {it.id}: {it.description}")
+
+    # 5. Tag-based filter
+    print("\n[5] Tag filter (vcs):")
+    for it in catalog.filter_by_tags("vcs"):
+        print(f"    {it.id}: {it.tags}")
+
+    # 6. Hydration
+    print("\n[6] Hydrate a tool:")
+    hydration = catalog.hydrate("fastmcp:github_search_repos")
+    print(f"    Item:        {hydration.item.name}")
+    print(f"    Schema keys: {list(hydration.args_schema.get('properties', {}).keys())}")
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dev = [
     "mypy>=1.10",
     "pre-commit>=3.7",
 ]
+fastmcp = [
+    "fastmcp>=2.0",
+]
 langchain = [
     "langchain-core>=0.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,7 @@ mypy_path = "src"
 [[tool.mypy.overrides]]
 module = "tiktoken"
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "fastmcp"
+ignore_missing_imports = true

--- a/src/contextweaver/adapters/__init__.py
+++ b/src/contextweaver/adapters/__init__.py
@@ -1,7 +1,7 @@
 """Adapters sub-package for contextweaver.
 
-Provides thin adapters that convert external protocol data (MCP, A2A) into
-contextweaver-native types.
+Provides thin adapters that convert external protocol data (MCP, A2A, FastMCP)
+into contextweaver-native types.
 """
 
 from __future__ import annotations
@@ -10,6 +10,12 @@ from contextweaver.adapters.a2a import (
     a2a_agent_to_selectable,
     a2a_result_to_envelope,
     load_a2a_session_jsonl,
+)
+from contextweaver.adapters.fastmcp import (
+    fastmcp_tool_to_selectable,
+    fastmcp_tools_to_catalog,
+    infer_fastmcp_namespace,
+    load_fastmcp_catalog,
 )
 from contextweaver.adapters.mcp import (
     infer_namespace,
@@ -21,8 +27,12 @@ from contextweaver.adapters.mcp import (
 __all__ = [
     "a2a_agent_to_selectable",
     "a2a_result_to_envelope",
+    "fastmcp_tool_to_selectable",
+    "fastmcp_tools_to_catalog",
+    "infer_fastmcp_namespace",
     "infer_namespace",
     "load_a2a_session_jsonl",
+    "load_fastmcp_catalog",
     "load_mcp_session_jsonl",
     "mcp_result_to_envelope",
     "mcp_tool_to_selectable",

--- a/src/contextweaver/adapters/fastmcp.py
+++ b/src/contextweaver/adapters/fastmcp.py
@@ -37,8 +37,10 @@ def infer_fastmcp_namespace(tool_name: str) -> str:
 
     FastMCP's composition layer joins ``{namespace}_{toolname}`` with a single
     underscore separator (see https://gofastmcp.com/servers/composition).
-    This function first delegates to :func:`~contextweaver.adapters.mcp.infer_namespace`
-    for dot- and slash-delimited names.  For underscore-delimited names it
+    For dot- and slash-delimited names this function mirrors the prefix-extraction
+    logic of :func:`~contextweaver.adapters.mcp.infer_namespace` (kept inline to
+    avoid coupling on that function's fallback sentinel).  For underscore-delimited
+    names it
     accepts **2+** segments (unlike the generic MCP heuristic which requires 3+),
     since 2-segment names like ``github_search`` are normal FastMCP output.
 
@@ -74,12 +76,13 @@ def infer_fastmcp_namespace(tool_name: str) -> str:
 def _strip_namespace_prefix(tool_name: str, namespace: str) -> str:
     """Return the short tool name with the namespace prefix removed.
 
-    If the tool name starts with ``{namespace}_``, the prefix is stripped.
-    Otherwise the full name is returned unchanged.
+    If the tool name starts with ``{namespace}_``, ``{namespace}.``, or
+    ``{namespace}/``, that prefix is stripped. Otherwise the full name is
+    returned unchanged.
     """
-    prefix = f"{namespace}_"
-    if tool_name.startswith(prefix) and len(tool_name) > len(prefix):
-        return tool_name[len(prefix) :]
+    for prefix in (f"{namespace}_", f"{namespace}.", f"{namespace}/"):
+        if tool_name.startswith(prefix) and len(tool_name) > len(prefix):
+            return tool_name[len(prefix) :]
     return tool_name
 
 
@@ -144,6 +147,13 @@ def fastmcp_tool_to_selectable(
             if isinstance(t, str) and t:
                 tags.add(t)
 
+    # Normalize meta for JSON-serialization safety: coerce set/frozenset → sorted
+    # list, tuple → list.  Keeps all keys — only the value types are changed.
+    normalized_meta: dict[str, Any] = {
+        k: sorted(v) if isinstance(v, (set, frozenset)) else list(v) if isinstance(v, tuple) else v
+        for k, v in meta.items()
+    }
+
     logger.debug(
         "fastmcp_tool_to_selectable: name=%s, ns=%s, tags=%s",
         full_name,
@@ -161,7 +171,7 @@ def fastmcp_tool_to_selectable(
         output_schema=item.output_schema,
         side_effects=item.side_effects,
         cost_hint=item.cost_hint,
-        metadata={**item.metadata, **meta},
+        metadata={**item.metadata, **normalized_meta},
     )
 
 

--- a/src/contextweaver/adapters/fastmcp.py
+++ b/src/contextweaver/adapters/fastmcp.py
@@ -243,13 +243,12 @@ async def load_fastmcp_catalog(
             be reached.
     """
     try:
-        from fastmcp import Client  # type: ignore[import-not-found]
+        from fastmcp import Client
     except ImportError as exc:
         raise CatalogError(
             "FastMCP is not installed. Install with: pip install 'contextweaver[fastmcp]'"
         ) from exc
 
-    client: Client
     client = source if isinstance(source, Client) else Client(source)
 
     try:
@@ -257,7 +256,9 @@ async def load_fastmcp_catalog(
             raw_tools = await client.list_tools()
             tool_dicts: list[dict[str, Any]] = []
             for tool in raw_tools:
-                # FastMCP list_tools() returns typed Tool objects — convert to dicts.
+                # FastMCP 3.x Tool uses camelCase field names natively (inputSchema,
+                # outputSchema, meta). DO NOT add by_alias=True — it renames meta → _meta,
+                # breaking meta-tag extraction in fastmcp_tool_to_selectable().
                 if hasattr(tool, "model_dump"):
                     tool_dicts.append(tool.model_dump(exclude_none=True))
                 elif isinstance(tool, dict):

--- a/src/contextweaver/adapters/fastmcp.py
+++ b/src/contextweaver/adapters/fastmcp.py
@@ -1,0 +1,271 @@
+"""FastMCP adapter for contextweaver.
+
+Bridges FastMCP servers and contextweaver :class:`~contextweaver.routing.catalog.Catalog`
+objects.  Converts FastMCP tool definitions into
+:class:`~contextweaver.types.SelectableItem` objects and provides live server
+discovery via the FastMCP ``Client``.
+
+Core conversion functions (:func:`fastmcp_tool_to_selectable`,
+:func:`fastmcp_tools_to_catalog`) work with plain dicts — no ``fastmcp``
+install required.  Live server discovery (:func:`load_fastmcp_catalog`)
+requires the ``contextweaver[fastmcp]`` optional extra.
+
+FastMCP composition docs: https://gofastmcp.com/servers/composition
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from contextweaver.adapters.mcp import mcp_tool_to_selectable
+from contextweaver.exceptions import CatalogError
+from contextweaver.routing.catalog import Catalog
+from contextweaver.types import SelectableItem
+
+logger = logging.getLogger("contextweaver.adapters")
+
+# ---------------------------------------------------------------------------
+# Namespace inference (FastMCP-aware)
+# ---------------------------------------------------------------------------
+
+_FALLBACK_NS = "fastmcp"
+
+
+def infer_fastmcp_namespace(tool_name: str) -> str:
+    """Infer a namespace from a FastMCP-namespaced tool name.
+
+    FastMCP's composition layer joins ``{namespace}_{toolname}`` with a single
+    underscore separator (see https://gofastmcp.com/servers/composition).
+    This function first delegates to :func:`~contextweaver.adapters.mcp.infer_namespace`
+    for dot- and slash-delimited names.  For underscore-delimited names it
+    accepts **2+** segments (unlike the generic MCP heuristic which requires 3+),
+    since 2-segment names like ``github_search`` are normal FastMCP output.
+
+    Falls back to ``"fastmcp"`` when no prefix can be detected.
+
+    Args:
+        tool_name: The raw tool name string (e.g. ``"github_search_repos"``).
+
+    Returns:
+        The inferred namespace string.
+    """
+    if not tool_name:
+        return _FALLBACK_NS
+
+    # Dot and slash separators — delegate to MCP adapter logic.
+    if "." in tool_name:
+        prefix = tool_name.split(".", 1)[0]
+        if prefix:
+            return prefix
+    if "/" in tool_name:
+        prefix = tool_name.split("/", 1)[0]
+        if prefix:
+            return prefix
+
+    # Underscore: FastMCP uses {namespace}_{name} with 2+ segments.
+    parts = tool_name.split("_")
+    if len(parts) >= 2 and parts[0] and not parts[0].startswith("_"):
+        return parts[0]
+
+    return _FALLBACK_NS
+
+
+def _strip_namespace_prefix(tool_name: str, namespace: str) -> str:
+    """Return the short tool name with the namespace prefix removed.
+
+    If the tool name starts with ``{namespace}_``, the prefix is stripped.
+    Otherwise the full name is returned unchanged.
+    """
+    prefix = f"{namespace}_"
+    if tool_name.startswith(prefix) and len(tool_name) > len(prefix):
+        return tool_name[len(prefix) :]
+    return tool_name
+
+
+# ---------------------------------------------------------------------------
+# Tool → SelectableItem conversion
+# ---------------------------------------------------------------------------
+
+
+def fastmcp_tool_to_selectable(
+    tool_def: dict[str, Any],
+    *,
+    namespace: str | None = None,
+) -> SelectableItem:
+    """Convert a FastMCP tool definition dict to a :class:`SelectableItem`.
+
+    Delegates schema/annotation parsing to
+    :func:`~contextweaver.adapters.mcp.mcp_tool_to_selectable` and then
+    adjusts the ``id``, ``namespace``, ``name``, and ``tags`` to reflect
+    FastMCP conventions.
+
+    Expected dict keys (matching the MCP ``tools/list`` wire format):
+
+    - ``name`` (required)
+    - ``description`` (required)
+    - ``inputSchema`` (optional JSON Schema dict)
+    - ``outputSchema`` (optional JSON Schema dict)
+    - ``annotations`` (optional MCP annotation hints)
+    - ``meta`` (optional dict — FastMCP passes custom metadata here,
+      including ``tags`` as a set/list)
+
+    Args:
+        tool_def: Raw tool definition dict.
+        namespace: Explicit namespace override.  When ``None``, the namespace
+            is inferred from the tool name via :func:`infer_fastmcp_namespace`.
+
+    Returns:
+        A :class:`SelectableItem` with ``kind="tool"``.
+
+    Raises:
+        CatalogError: If required fields (``name``, ``description``) are
+            missing.
+    """
+    # Delegate core conversion to the MCP adapter.
+    item = mcp_tool_to_selectable(tool_def)
+
+    full_name: str = item.name
+    ns = namespace if namespace is not None else infer_fastmcp_namespace(full_name)
+    short_name = _strip_namespace_prefix(full_name, ns)
+
+    # Build tag set: start with "fastmcp", keep annotation-derived tags,
+    # merge user-defined tags from meta.
+    tags: set[str] = {_FALLBACK_NS}
+    for tag in item.tags:
+        if tag != "mcp":
+            tags.add(tag)
+
+    # FastMCP passes custom metadata through the ``meta`` field.
+    meta: dict[str, Any] = tool_def.get("meta") or {}
+    meta_tags = meta.get("tags")
+    if isinstance(meta_tags, (list, set, tuple)):
+        for t in meta_tags:
+            if isinstance(t, str) and t:
+                tags.add(t)
+
+    logger.debug(
+        "fastmcp_tool_to_selectable: name=%s, ns=%s, tags=%s",
+        full_name,
+        ns,
+        sorted(tags),
+    )
+    return SelectableItem(
+        id=f"fastmcp:{full_name}",
+        kind=item.kind,
+        name=short_name,
+        description=item.description,
+        tags=sorted(tags),
+        namespace=ns,
+        args_schema=item.args_schema,
+        output_schema=item.output_schema,
+        side_effects=item.side_effects,
+        cost_hint=item.cost_hint,
+        metadata={**item.metadata, **meta},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch conversion → Catalog
+# ---------------------------------------------------------------------------
+
+
+def fastmcp_tools_to_catalog(
+    tools: list[dict[str, Any]],
+    *,
+    namespace: str | None = None,
+) -> Catalog:
+    """Convert a list of FastMCP tool definitions to a populated :class:`Catalog`.
+
+    Args:
+        tools: List of raw tool definition dicts.
+        namespace: Optional namespace override applied to every item.  When
+            ``None``, each tool's namespace is inferred individually.
+
+    Returns:
+        A :class:`~contextweaver.routing.catalog.Catalog` with all converted
+        items registered.
+
+    Raises:
+        CatalogError: If a tool definition is invalid or duplicate IDs are
+            encountered.
+    """
+    catalog = Catalog()
+    for tool_def in tools:
+        item = fastmcp_tool_to_selectable(tool_def, namespace=namespace)
+        catalog.register(item)
+    logger.debug("fastmcp_tools_to_catalog: registered %d items", len(tools))
+    return catalog
+
+
+# ---------------------------------------------------------------------------
+# Live server discovery (requires ``contextweaver[fastmcp]``)
+# ---------------------------------------------------------------------------
+
+
+async def load_fastmcp_catalog(
+    source: object,
+    *,
+    namespace: str | None = None,
+) -> Catalog:
+    """Connect to a FastMCP server and return a populated :class:`Catalog`.
+
+    *source* accepts everything that ``fastmcp.Client()`` supports:
+
+    - A ``FastMCP`` server instance (in-memory, zero network)
+    - A URL string (``"http://localhost:8000/mcp"``)
+    - A file path string (``"my_server.py"``)
+    - A config dict (``{"mcpServers": {...}}``)
+    - An existing ``fastmcp.Client`` instance
+
+    Requires the ``contextweaver[fastmcp]`` optional extra.
+
+    Args:
+        source: FastMCP server source — see above.
+        namespace: Optional namespace override applied to every item.
+
+    Returns:
+        A :class:`~contextweaver.routing.catalog.Catalog` populated with all
+        tools discovered from the server.
+
+    Raises:
+        CatalogError: If ``fastmcp`` is not installed or the server cannot
+            be reached.
+    """
+    try:
+        from fastmcp import Client  # type: ignore[import-not-found]
+    except ImportError as exc:
+        raise CatalogError(
+            "FastMCP is not installed. Install with: pip install 'contextweaver[fastmcp]'"
+        ) from exc
+
+    client: Client
+    client = source if isinstance(source, Client) else Client(source)
+
+    try:
+        async with client:
+            raw_tools = await client.list_tools()
+            tool_dicts: list[dict[str, Any]] = []
+            for tool in raw_tools:
+                # FastMCP list_tools() returns typed Tool objects — convert to dicts.
+                if hasattr(tool, "model_dump"):
+                    tool_dicts.append(tool.model_dump(exclude_none=True))
+                elif isinstance(tool, dict):
+                    tool_dicts.append(tool)
+                else:
+                    tool_dicts.append(
+                        {
+                            "name": getattr(tool, "name", ""),
+                            "description": getattr(tool, "description", ""),
+                            "inputSchema": getattr(tool, "inputSchema", {}),
+                            "annotations": getattr(tool, "annotations", None),
+                            "outputSchema": getattr(tool, "outputSchema", None),
+                            "meta": getattr(tool, "meta", None),
+                        }
+                    )
+    except CatalogError:
+        raise
+    except Exception as exc:
+        raise CatalogError(f"Failed to list tools from FastMCP server: {exc}") from exc
+
+    return fastmcp_tools_to_catalog(tool_dicts, namespace=namespace)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1002,6 +1002,117 @@ def test_fastmcp_tools_to_catalog_empty() -> None:
 
 
 # ---------------------------------------------------------------------------
+# FastMCP adapter — load_fastmcp_catalog
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_fastmcp_catalog_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """load_fastmcp_catalog converts discovered tools into a populated Catalog."""
+    import importlib
+    import sys
+
+    import contextweaver.adapters.fastmcp as fastmcp_mod
+
+    class FakeTool:
+        def model_dump(self, *, exclude_none: bool = False) -> dict:  # type: ignore[override]
+            return {"name": "github_search", "description": "Search GitHub"}
+
+    class FakeClient:
+        def __init__(self, source: object) -> None: ...
+
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, *_: object) -> None: ...
+
+        async def list_tools(self) -> list:
+            return [FakeTool()]
+
+    fake_fastmcp = type(sys)("fastmcp")
+    fake_fastmcp.Client = FakeClient  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "fastmcp", fake_fastmcp)
+    importlib.reload(fastmcp_mod)
+
+    catalog = await fastmcp_mod.load_fastmcp_catalog("fake://server")
+    assert len(catalog.all()) == 1
+    item = catalog.all()[0]
+    assert item.id == "fastmcp:github_search"
+    assert item.namespace == "github"
+    assert item.name == "search"
+    assert "fastmcp" in item.tags
+
+    importlib.reload(fastmcp_mod)  # restore
+
+
+@pytest.mark.asyncio
+async def test_load_fastmcp_catalog_connection_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Server-side errors are wrapped in CatalogError."""
+    import importlib
+    import sys
+
+    import contextweaver.adapters.fastmcp as fastmcp_mod
+
+    class BrokenClient:
+        def __init__(self, source: object) -> None: ...
+
+        async def __aenter__(self) -> BrokenClient:
+            return self
+
+        async def __aexit__(self, *_: object) -> None: ...
+
+        async def list_tools(self) -> list:
+            raise ConnectionRefusedError("offline")
+
+    fake_fastmcp = type(sys)("fastmcp")
+    fake_fastmcp.Client = BrokenClient  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "fastmcp", fake_fastmcp)
+    importlib.reload(fastmcp_mod)
+
+    with pytest.raises(CatalogError, match="Failed to list tools"):
+        await fastmcp_mod.load_fastmcp_catalog("fake://server")
+
+    importlib.reload(fastmcp_mod)  # restore
+
+
+@pytest.mark.asyncio
+async def test_load_fastmcp_catalog_existing_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Passing an existing Client instance is used directly (no wrapping)."""
+    import importlib
+    import sys
+
+    import contextweaver.adapters.fastmcp as fastmcp_mod
+
+    class FakeTool:
+        def model_dump(self, *, exclude_none: bool = False) -> dict:  # type: ignore[override]
+            return {"name": "slack_notify", "description": "Send Slack notification"}
+
+    class FakeClient:
+        def __init__(self, source: object) -> None: ...
+
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, *_: object) -> None: ...
+
+        async def list_tools(self) -> list:
+            return [FakeTool()]
+
+    fake_fastmcp = type(sys)("fastmcp")
+    fake_fastmcp.Client = FakeClient  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "fastmcp", fake_fastmcp)
+    importlib.reload(fastmcp_mod)
+
+    # Pass a pre-built client instance — should not be double-wrapped.
+    existing_client = FakeClient(None)
+    catalog = await fastmcp_mod.load_fastmcp_catalog(existing_client)
+    assert len(catalog.all()) == 1
+    assert catalog.all()[0].namespace == "slack"
+
+    importlib.reload(fastmcp_mod)  # restore
+
+
+# ---------------------------------------------------------------------------
 # FastMCP adapter — load_fastmcp_catalog (import guard)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,4 +1,4 @@
-"""Tests for contextweaver adapters (MCP and A2A)."""
+"""Tests for contextweaver adapters (MCP, A2A, and FastMCP)."""
 
 from __future__ import annotations
 
@@ -12,6 +12,11 @@ from contextweaver.adapters.a2a import (
     a2a_agent_to_selectable,
     a2a_result_to_envelope,
     load_a2a_session_jsonl,
+)
+from contextweaver.adapters.fastmcp import (
+    fastmcp_tool_to_selectable,
+    fastmcp_tools_to_catalog,
+    infer_fastmcp_namespace,
 )
 from contextweaver.adapters.mcp import (
     infer_namespace,
@@ -767,3 +772,226 @@ def test_load_a2a_session_jsonl_bad_token_estimate() -> None:
             load_a2a_session_jsonl(path)
     finally:
         os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# FastMCP adapter — infer_fastmcp_namespace
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "expected"),
+    [
+        ("github.create_issue", "github"),
+        ("filesystem/read", "filesystem"),
+        ("github_search_repos", "github"),
+        ("slack_send_message", "slack"),
+        ("github_search", "github"),  # 2-segment → accepted by FastMCP heuristic
+        ("read_file", "read"),  # 2-segment → first segment is namespace
+        ("search", "fastmcp"),  # single word → fallback
+        ("", "fastmcp"),
+        (".hidden", "fastmcp"),
+        ("/path", "fastmcp"),
+    ],
+)
+def test_infer_fastmcp_namespace(tool_name: str, expected: str) -> None:
+    assert infer_fastmcp_namespace(tool_name) == expected
+
+
+# ---------------------------------------------------------------------------
+# FastMCP adapter — fastmcp_tool_to_selectable
+# ---------------------------------------------------------------------------
+
+
+def test_fastmcp_tool_basic() -> None:
+    tool_def = {
+        "name": "github_search_repos",
+        "description": "Search GitHub repositories",
+    }
+    item = fastmcp_tool_to_selectable(tool_def)
+    assert item.id == "fastmcp:github_search_repos"
+    assert item.kind == "tool"
+    assert item.name == "search_repos"  # namespace prefix stripped
+    assert item.namespace == "github"
+    assert item.description == "Search GitHub repositories"
+    assert "fastmcp" in item.tags
+    assert "mcp" not in item.tags  # replaced by "fastmcp"
+
+
+def test_fastmcp_tool_two_segment_namespace() -> None:
+    tool_def = {
+        "name": "weather_forecast",
+        "description": "Get weather forecast",
+    }
+    item = fastmcp_tool_to_selectable(tool_def)
+    assert item.namespace == "weather"
+    assert item.name == "forecast"
+    assert item.id == "fastmcp:weather_forecast"
+
+
+def test_fastmcp_tool_single_word_fallback() -> None:
+    tool_def = {"name": "search", "description": "Global search"}
+    item = fastmcp_tool_to_selectable(tool_def)
+    assert item.namespace == "fastmcp"
+    assert item.name == "search"  # no prefix to strip
+
+
+def test_fastmcp_tool_explicit_namespace() -> None:
+    tool_def = {"name": "query", "description": "Run a query"}
+    item = fastmcp_tool_to_selectable(tool_def, namespace="db")
+    assert item.namespace == "db"
+    assert item.name == "query"
+
+
+def test_fastmcp_tool_tag_mapping() -> None:
+    tool_def = {
+        "name": "api_list_users",
+        "description": "List users",
+        "meta": {"tags": ["production", "admin"]},
+    }
+    item = fastmcp_tool_to_selectable(tool_def)
+    assert "fastmcp" in item.tags
+    assert "production" in item.tags
+    assert "admin" in item.tags
+    assert "mcp" not in item.tags
+
+
+def test_fastmcp_tool_schema_preserved() -> None:
+    schema = {"type": "object", "properties": {"q": {"type": "string"}}}
+    tool_def = {
+        "name": "db_query",
+        "description": "Query data",
+        "inputSchema": schema,
+    }
+    item = fastmcp_tool_to_selectable(tool_def)
+    assert item.args_schema == schema
+
+
+def test_fastmcp_tool_output_schema_preserved() -> None:
+    out_schema = {"type": "object", "properties": {"result": {"type": "string"}}}
+    tool_def = {
+        "name": "db_query",
+        "description": "Query data",
+        "outputSchema": out_schema,
+    }
+    item = fastmcp_tool_to_selectable(tool_def)
+    assert item.output_schema == out_schema
+
+
+def test_fastmcp_tool_annotations() -> None:
+    tool_def = {
+        "name": "fs_read_file",
+        "description": "Read a file",
+        "annotations": {"readOnlyHint": True, "costHint": 0.05},
+    }
+    item = fastmcp_tool_to_selectable(tool_def)
+    assert item.side_effects is False
+    assert item.cost_hint == 0.05
+    assert "read-only" in item.tags
+
+
+def test_fastmcp_tool_destructive_hint() -> None:
+    tool_def = {
+        "name": "fs_delete_file",
+        "description": "Delete a file",
+        "annotations": {"destructiveHint": True},
+    }
+    item = fastmcp_tool_to_selectable(tool_def)
+    assert "destructive" in item.tags
+    assert item.side_effects is True
+
+
+def test_fastmcp_tool_missing_name() -> None:
+    with pytest.raises(CatalogError, match="missing required fields"):
+        fastmcp_tool_to_selectable({"description": "no name"})
+
+
+def test_fastmcp_tool_missing_description() -> None:
+    with pytest.raises(CatalogError, match="missing required fields"):
+        fastmcp_tool_to_selectable({"name": "tool"})
+
+
+def test_fastmcp_tool_meta_merged() -> None:
+    tool_def = {
+        "name": "api_status",
+        "description": "Check status",
+        "meta": {"version": "1.2", "author": "team"},
+    }
+    item = fastmcp_tool_to_selectable(tool_def)
+    assert item.metadata["version"] == "1.2"
+    assert item.metadata["author"] == "team"
+
+
+# ---------------------------------------------------------------------------
+# FastMCP adapter — fastmcp_tools_to_catalog
+# ---------------------------------------------------------------------------
+
+
+def test_fastmcp_tools_to_catalog() -> None:
+    tools = [
+        {"name": "github_search_repos", "description": "Search repos"},
+        {"name": "github_create_issue", "description": "Create issue"},
+        {"name": "slack_send_message", "description": "Send message"},
+    ]
+    catalog = fastmcp_tools_to_catalog(tools)
+    assert len(catalog.all()) == 3
+
+    github_items = catalog.filter_by_namespace("github")
+    assert len(github_items) == 2
+
+    slack_items = catalog.filter_by_namespace("slack")
+    assert len(slack_items) == 1
+
+
+def test_fastmcp_tools_to_catalog_with_namespace_override() -> None:
+    tools = [
+        {"name": "search", "description": "Search"},
+        {"name": "list", "description": "List"},
+    ]
+    catalog = fastmcp_tools_to_catalog(tools, namespace="myserver")
+    assert all(item.namespace == "myserver" for item in catalog.all())
+
+
+def test_fastmcp_tools_to_catalog_duplicate() -> None:
+    tools = [
+        {"name": "github_search", "description": "Search"},
+        {"name": "github_search", "description": "Search again"},
+    ]
+    with pytest.raises(CatalogError, match="Duplicate item id"):
+        fastmcp_tools_to_catalog(tools)
+
+
+def test_fastmcp_tools_to_catalog_empty() -> None:
+    catalog = fastmcp_tools_to_catalog([])
+    assert len(catalog.all()) == 0
+
+
+# ---------------------------------------------------------------------------
+# FastMCP adapter — load_fastmcp_catalog (import guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_fastmcp_catalog_requires_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify load_fastmcp_catalog raises CatalogError when fastmcp is missing."""
+    import importlib
+    import sys
+
+    import contextweaver.adapters.fastmcp as fastmcp_mod
+
+    # Hide the fastmcp package from import machinery.
+    saved = sys.modules.get("fastmcp")
+    monkeypatch.setitem(sys.modules, "fastmcp", None)  # type: ignore[arg-type]
+
+    # Reload so the lazy import sees the blocked module.
+    importlib.reload(fastmcp_mod)
+
+    with pytest.raises(CatalogError, match="FastMCP is not installed"):
+        await fastmcp_mod.load_fastmcp_catalog("http://localhost:9999/mcp")
+
+    # Restore.
+    if saved is not None:
+        monkeypatch.setitem(sys.modules, "fastmcp", saved)
+    else:
+        monkeypatch.delitem(sys.modules, "fastmcp", raising=False)
+    importlib.reload(fastmcp_mod)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -922,6 +922,41 @@ def test_fastmcp_tool_meta_merged() -> None:
     assert item.metadata["author"] == "team"
 
 
+def test_fastmcp_tool_meta_set_normalized_to_list() -> None:
+    """meta containing a set must be normalized so to_dict() / JSON serialization works."""
+    import json
+
+    tool_def = {
+        "name": "api_status",
+        "description": "Check status",
+        "meta": {"tags": {"prod", "admin"}, "owners": ("alice", "bob")},
+    }
+    item = fastmcp_tool_to_selectable(tool_def)
+    # Coerced to list — no set or tuple in metadata
+    assert isinstance(item.metadata["tags"], list)
+    assert isinstance(item.metadata["owners"], list)
+    # to_dict() must not raise (JSON-serializable)
+    assert json.dumps(item.to_dict())
+
+
+def test_fastmcp_tool_dot_namespace_stripping() -> None:
+    """Dot-delimited names: name field must not repeat the namespace prefix."""
+    tool_def = {"name": "github.create_issue", "description": "Create an issue"}
+    item = fastmcp_tool_to_selectable(tool_def)
+    assert item.namespace == "github"
+    assert item.name == "create_issue"
+    assert item.id == "fastmcp:github.create_issue"
+
+
+def test_fastmcp_tool_slash_namespace_stripping() -> None:
+    """Slash-delimited names: name field must not repeat the namespace prefix."""
+    tool_def = {"name": "filesystem/read", "description": "Read a file"}
+    item = fastmcp_tool_to_selectable(tool_def)
+    assert item.namespace == "filesystem"
+    assert item.name == "read"
+    assert item.id == "fastmcp:filesystem/read"
+
+
 # ---------------------------------------------------------------------------
 # FastMCP adapter — fastmcp_tools_to_catalog
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #114

Adds `adapters/fastmcp.py` — a bridge between FastMCP servers and contextweaver `Catalog` objects. Converts FastMCP tool definitions into `SelectableItem`s with namespace inference, tag mapping, and schema preservation, and provides live server discovery via the FastMCP `Client`.

## What changed

- **`src/contextweaver/adapters/fastmcp.py`** (new) — core module with:
  - `infer_fastmcp_namespace()` — 2-segment namespace inference matching FastMCP's `{namespace}_{name}` composition convention (vs 3+ in the generic MCP adapter)
  - `fastmcp_tool_to_selectable()` — convert tool definition dicts to `SelectableItem`, delegating annotation/schema parsing to the existing `mcp_tool_to_selectable()`, then adjusting id, namespace, name, and tags
  - `fastmcp_tools_to_catalog()` — batch-convert to a populated `Catalog`
  - `load_fastmcp_catalog()` — async live discovery from any FastMCP source (server instance, URL, file path, config dict, existing Client) via `tools/list`
- **`src/contextweaver/adapters/__init__.py`** — re-exports new public names
- **`pyproject.toml`** — adds `contextweaver[fastmcp]` optional extra (`fastmcp>=2.0`)
- **`tests/test_adapters.py`** — 22 new tests: namespace inference, tag mapping, schema preservation, annotations, catalog building, import guard
- **`examples/fastmcp_adapter_demo.py`** (new) — standalone example showing namespace inference, tool conversion, catalog building, filtering, and hydration
- **`CHANGELOG.md`** — entry under `[Unreleased] / Added`

## Why

FastMCP powers ~70% of MCP servers. Without a direct bridge, users must manually convert each tool definition—this friction blocks adoption. The adapter reuses `mcp_tool_to_selectable()` internally and adds FastMCP-specific namespace inference and tag mapping on top.

## How verified

```
ruff format src/ tests/ examples/   → 84 files left unchanged
ruff check src/ tests/ examples/    → All checks passed!
mypy src/                           → Success: no issues found in 42 source files
pytest -q tests/test_adapters.py    → 90 passed in 0.27s
pytest -q                           → 563 passed in 6.13s
python examples/fastmcp_adapter_demo.py → runs successfully
python -m contextweaver demo         → runs successfully
All 10 example scripts               → run successfully
```

## Tradeoffs / risks

- `infer_fastmcp_namespace` accepts 2-segment underscore names (e.g. `github_search` → ns=`github`), which is more aggressive than the generic MCP heuristic. This matches FastMCP composition conventions but may over-infer for non-FastMCP tools — users can pass `namespace=` to override.
- `load_fastmcp_catalog` is async (matching the `context/` async-first convention). Callers in sync contexts need `asyncio.run()`.
- Module is 271 lines (under the 300-line limit).

## Checklist

- [x] Tests added/updated for every new/changed public function
- [x] `make ci` targets pass locally (fmt, lint, type, test, example, demo)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Google-style docstrings for all new public APIs
- [x] Module ≤ 300 lines (271 lines)
- [x] Related issue linked (#114)
- [x] No `print()` in library code
- [x] No business logic in `__init__.py`