### PR TITLE
feat(config): serde on all config classes, dedup_threshold, store protocols, config decompose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,8 @@ It prepares context and routes tools but never calls models or executes tools.
 | `types.py` | Core dataclasses and enums: `SelectableItem`, `ContextItem`, `Phase`, `ItemKind`, `Sensitivity` |
 | `envelope.py` | Result types: `ResultEnvelope`, `BuildStats`, `ContextPack`, `ChoiceCard`, `HydrationResult` |
 | `config.py` | Configuration: `ContextBudget`, `ContextPolicy`, `ScoringConfig` |
-| `protocols.py` | Protocol interfaces: `TokenEstimator`, `EventHook`, `Summarizer`, `Extractor`, … |
+| `profiles.py` | Routing and profile config: `RoutingConfig`, `ProfileConfig`, named presets |
+| `protocols.py` | Protocol interfaces: `TokenEstimator`, `EventHook`, `Summarizer`, `Extractor`, `EpisodicStore`, `FactStore`, … |
 | `exceptions.py` | Custom exception hierarchy (all errors inherit `ContextWeaverError`) |
 | `_utils.py` | Text similarity primitives: `tokenize()`, `jaccard()`, `TfIdfScorer` |
 | `serde.py` | Serialisation helpers for `to_dict` / `from_dict` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ It prepares context and routes tools but never calls models or executes tools.
 | `envelope.py` | Result types: `ResultEnvelope`, `BuildStats`, `ContextPack`, `ChoiceCard`, `HydrationResult` |
 | `config.py` | Configuration: `ContextBudget`, `ContextPolicy`, `ScoringConfig` |
 | `profiles.py` | Routing and profile config: `RoutingConfig`, `ProfileConfig`, named presets |
-| `protocols.py` | Protocol interfaces: `TokenEstimator`, `EventHook`, `Summarizer`, `Extractor`, `EpisodicStore`, `FactStore`, … |
+| `protocols.py` | Protocol interfaces: `TokenEstimator`, `EventHook`, `Summarizer`, `Extractor`, `RedactionHook`, `Labeler` (store protocols re-exported from `store/protocols.py`) |
+| `store/protocols.py` | Store-layer protocols: `EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore` |
 | `exceptions.py` | Custom exception hierarchy (all errors inherit `ContextWeaverError`) |
 | `_utils.py` | Text similarity primitives: `tokenize()`, `jaccard()`, `TfIdfScorer` |
 | `serde.py` | Serialisation helpers for `to_dict` / `from_dict` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,18 +14,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `to_dict()` / `from_dict()` on `ContextPolicy`, `ContextBudget`, and
   `ScoringConfig` — completes the repo-standard serialisation methods on all
   config dataclasses (#184)
-- `EpisodicStore` and `FactStore` protocols in `protocols.py` — formal
-  `@runtime_checkable` protocol interfaces matching the `InMemory*` method
-  signatures; `StoreBundle` type hints widened to protocol types (#40)
+- `EpisodicStore` and `FactStore` protocols — formal `@runtime_checkable`
+  protocol interfaces matching the `InMemory*` method signatures; `StoreBundle`
+  type hints widened to protocol types (#40)
+- `store/protocols.py` module — store-layer protocols (`EventLog`,
+  `ArtifactStore`, `EpisodicStore`, `FactStore`) extracted from `protocols.py`
+  to stay within the ≤300-line guideline; still importable from
+  `contextweaver.protocols` and `contextweaver` for backward compatibility
 - `profiles.py` module — `RoutingConfig` and `ProfileConfig` extracted from
-  `config.py` to stay within the ≤300-line guideline; re-exported from
-  `config.py` for backward compatibility (#179)
+  `config.py` to stay within the ≤300-line guideline; importable from
+  `contextweaver.profiles` and `contextweaver` (#179)
 
 ### Changed
 - `ProfileConfig.to_dict()` / `from_dict()` now include `policy` (previously
-  excluded because `ContextPolicy` lacked serialisation) (#184)
+  excluded because `ContextPolicy` lacked serialisation); docstring expanded
+  to make the round-trip contract explicit (#184)
 - `ContextManager.episodic_store` / `fact_store` properties now return protocol
   types (`EpisodicStore` / `FactStore`) instead of concrete `InMemory*` types (#40)
+- `StoreBundle.to_dict()` / `from_dict()` docstrings now spell out the
+  silent-`None` round-trip behaviour for custom backends that lack a
+  `to_dict()` method
+- `RoutingConfig` / `ProfileConfig` are no longer re-exported from
+  `contextweaver.config`; import them from `contextweaver.profiles` or
+  `contextweaver`. Dropping the re-export resolves a circular-import smell
+  between `config.py` and `profiles.py`
 
 ### Fixed
 - Replaced 3 bare `ValueError` raises in `context/sensitivity.py` with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `ScoringConfig.dedup_threshold` field — exposes the Jaccard dedup threshold
+  (default 0.85) via configuration; `ContextManager` now passes it through to
+  `deduplicate_candidates()` (#182)
+- `to_dict()` / `from_dict()` on `ContextPolicy`, `ContextBudget`, and
+  `ScoringConfig` — completes the repo-standard serialisation methods on all
+  config dataclasses (#184)
+- `EpisodicStore` and `FactStore` protocols in `protocols.py` — formal
+  `@runtime_checkable` protocol interfaces matching the `InMemory*` method
+  signatures; `StoreBundle` type hints widened to protocol types (#40)
+- `profiles.py` module — `RoutingConfig` and `ProfileConfig` extracted from
+  `config.py` to stay within the ≤300-line guideline; re-exported from
+  `config.py` for backward compatibility (#179)
+
+### Changed
+- `ProfileConfig.to_dict()` / `from_dict()` now include `policy` (previously
+  excluded because `ContextPolicy` lacked serialisation) (#184)
+- `ContextManager.episodic_store` / `fact_store` properties now return protocol
+  types (`EpisodicStore` / `FactStore`) instead of concrete `InMemory*` types (#40)
+
+### Fixed
+- Replaced 3 bare `ValueError` raises in `context/sensitivity.py` with
+  `PolicyViolationError` / `ConfigError` (#183)
+- Replaced bare `ValueError` in `routing/router.py` (`confidence_gap` validation)
+  with `ConfigError` (#183)
+
 ## [0.2.0] - 2026-04-17
 
 ### Added

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -198,13 +198,7 @@ Important items that should be distinct are treated as duplicates.
 **Cause:** Default Jaccard similarity threshold is **0.85**. Items with ≥ 85 %
 token overlap are collapsed.
 
-> **Note:** Deduplication threshold configuration is tracked in
-> [#182](https://github.com/dgenio/contextweaver/issues/182).
-> Until that ships, the only workaround is to subclass `ContextManager`
-> and override `_build()` to pass a custom `similarity_threshold` to
-> `deduplicate_candidates()`.
-
-Once [#182](https://github.com/dgenio/contextweaver/issues/182) ships, the fix will be:
+**Fix:** Configure `dedup_threshold` on `ScoringConfig`:
 ```python
 from contextweaver.config import ScoringConfig
 from contextweaver.context.manager import ContextManager

--- a/src/contextweaver/__init__.py
+++ b/src/contextweaver/__init__.py
@@ -52,8 +52,10 @@ from contextweaver.exceptions import (
     RouteError,
 )
 from contextweaver.protocols import (
+    EpisodicStore,
     EventHook,
     Extractor,
+    FactStore,
     Labeler,
     RedactionHook,
     Summarizer,
@@ -123,8 +125,10 @@ __all__ = [
     "RoutingConfig",
     "ScoringConfig",
     # protocols
+    "EpisodicStore",
     "EventHook",
     "Extractor",
+    "FactStore",
     "Labeler",
     "RedactionHook",
     "Summarizer",

--- a/src/contextweaver/__init__.py
+++ b/src/contextweaver/__init__.py
@@ -20,15 +20,9 @@ Quick start::
 
 from __future__ import annotations
 
-from contextweaver import config, envelope, exceptions, protocols, types
+from contextweaver import config, envelope, exceptions, profiles, protocols, types
 from contextweaver._utils import TfIdfScorer, jaccard
-from contextweaver.config import (
-    ContextBudget,
-    ContextPolicy,
-    ProfileConfig,
-    RoutingConfig,
-    ScoringConfig,
-)
+from contextweaver.config import ContextBudget, ContextPolicy, ScoringConfig
 from contextweaver.context.manager import ContextManager
 from contextweaver.context.sensitivity import MaskRedactionHook, register_redaction_hook
 from contextweaver.context.views import ViewRegistry, drilldown_tool_spec, generate_views
@@ -51,6 +45,7 @@ from contextweaver.exceptions import (
     PolicyViolationError,
     RouteError,
 )
+from contextweaver.profiles import ProfileConfig, RoutingConfig
 from contextweaver.protocols import (
     EpisodicStore,
     EventHook,
@@ -99,6 +94,7 @@ __all__ = [
     "config",
     "envelope",
     "exceptions",
+    "profiles",
     "protocols",
     "types",
     # utilities

--- a/src/contextweaver/config.py
+++ b/src/contextweaver/config.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from contextweaver.exceptions import ConfigError
 from contextweaver.types import ItemKind, Phase, Sensitivity
 
 # ---------------------------------------------------------------------------
@@ -28,6 +27,29 @@ class ScoringConfig:
     tag_match_weight: float = 0.25
     kind_priority_weight: float = 0.35
     token_cost_penalty: float = 0.1
+    dedup_threshold: float = 0.85
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-compatible dict."""
+        return {
+            "recency_weight": self.recency_weight,
+            "tag_match_weight": self.tag_match_weight,
+            "kind_priority_weight": self.kind_priority_weight,
+            "token_cost_penalty": self.token_cost_penalty,
+            "dedup_threshold": self.dedup_threshold,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ScoringConfig:
+        """Deserialise from a JSON-compatible dict."""
+        _d = cls()
+        return cls(
+            recency_weight=float(data.get("recency_weight", _d.recency_weight)),
+            tag_match_weight=float(data.get("tag_match_weight", _d.tag_match_weight)),
+            kind_priority_weight=float(data.get("kind_priority_weight", _d.kind_priority_weight)),
+            token_cost_penalty=float(data.get("token_cost_penalty", _d.token_cost_penalty)),
+            dedup_threshold=float(data.get("dedup_threshold", _d.dedup_threshold)),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -57,6 +79,26 @@ class ContextBudget:
             The maximum number of tokens allowed in the compiled context.
         """
         return int(getattr(self, phase.value))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-compatible dict."""
+        return {
+            "route": self.route,
+            "call": self.call,
+            "interpret": self.interpret,
+            "answer": self.answer,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ContextBudget:
+        """Deserialise from a JSON-compatible dict."""
+        _d = cls()
+        return cls(
+            route=int(data.get("route", _d.route)),
+            call=int(data.get("call", _d.call)),
+            interpret=int(data.get("interpret", _d.interpret)),
+            answer=int(data.get("answer", _d.answer)),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -120,189 +162,59 @@ class ContextPolicy:
     redaction_hooks: list[str] = field(default_factory=list)
     extra: dict[str, Any] = field(default_factory=dict)
 
-
-# ---------------------------------------------------------------------------
-# Routing configuration
-# ---------------------------------------------------------------------------
-
-# Named-preset definitions: (beam_width, max_depth, top_k, confidence_gap, max_children, answer)
-_ROUTING_PRESETS: dict[str, tuple[int, int, int, float, int, int]] = {
-    "fast": (1, 4, 5, 0.20, 15, 3000),
-    "balanced": (2, 8, 10, 0.15, 20, 6000),
-    "accurate": (4, 12, 20, 0.10, 30, 8000),
-}
-
-
-@dataclass
-class RoutingConfig:
-    """Parameters that control the beam-search router.
-
-    Attributes:
-        beam_width: Number of beams to keep at each tree level.
-        max_depth: Maximum tree depth to traverse.
-        top_k: Maximum number of results to return.
-        confidence_gap: Minimum score gap between rank-1 and rank-2 to
-            consider the top pick confident.  Must be in ``[0.0, 1.0]``.
-        max_children: Maximum number of children per graph node.
-    """
-
-    beam_width: int = 2
-    max_depth: int = 8
-    top_k: int = 10
-    confidence_gap: float = 0.15
-    max_children: int = 20
-
-    def routing_kwargs(self) -> dict[str, Any]:
-        """Return router constructor kwargs (excludes *max_children*).
-
-        Returns:
-            A dict suitable for ``**``-unpacking into :class:`~contextweaver.routing.router.Router`.
-        """
-        return {
-            "beam_width": self.beam_width,
-            "max_depth": self.max_depth,
-            "top_k": self.top_k,
-            "confidence_gap": self.confidence_gap,
-        }
-
     def to_dict(self) -> dict[str, Any]:
         """Serialise to a JSON-compatible dict."""
         return {
-            "beam_width": self.beam_width,
-            "max_depth": self.max_depth,
-            "top_k": self.top_k,
-            "confidence_gap": self.confidence_gap,
-            "max_children": self.max_children,
+            "allowed_kinds_per_phase": {
+                phase.value: [k.value for k in kinds]
+                for phase, kinds in self.allowed_kinds_per_phase.items()
+            },
+            "max_items_per_kind": {k.value: v for k, v in self.max_items_per_kind.items()},
+            "sensitivity_floor": self.sensitivity_floor.value,
+            "sensitivity_action": self.sensitivity_action,
+            "redaction_hooks": list(self.redaction_hooks),
+            "extra": dict(self.extra),
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> RoutingConfig:
+    def from_dict(cls, data: dict[str, Any]) -> ContextPolicy:
         """Deserialise from a JSON-compatible dict."""
+        allowed_raw = data.get("allowed_kinds_per_phase")
+        allowed: dict[Phase, list[ItemKind]] | None = None
+        if allowed_raw is not None:
+            allowed = {
+                Phase(phase_str): [ItemKind(k) for k in kinds]
+                for phase_str, kinds in allowed_raw.items()
+            }
+
+        max_raw = data.get("max_items_per_kind")
+        max_items: dict[ItemKind, int] | None = None
+        if max_raw is not None:
+            max_items = {ItemKind(k): int(v) for k, v in max_raw.items()}
+
         _d = cls()
         return cls(
-            beam_width=int(data.get("beam_width", _d.beam_width)),
-            max_depth=int(data.get("max_depth", _d.max_depth)),
-            top_k=int(data.get("top_k", _d.top_k)),
-            confidence_gap=float(data.get("confidence_gap", _d.confidence_gap)),
-            max_children=int(data.get("max_children", _d.max_children)),
+            allowed_kinds_per_phase=allowed if allowed is not None else _d.allowed_kinds_per_phase,
+            max_items_per_kind=max_items if max_items is not None else _d.max_items_per_kind,
+            sensitivity_floor=Sensitivity(data["sensitivity_floor"])
+            if "sensitivity_floor" in data
+            else _d.sensitivity_floor,
+            sensitivity_action=str(data.get("sensitivity_action", _d.sensitivity_action)),
+            redaction_hooks=list(data.get("redaction_hooks", _d.redaction_hooks)),
+            extra=dict(data.get("extra", _d.extra)),
         )
 
 
 # ---------------------------------------------------------------------------
-# Profile — bundles all config objects + named presets
+# Re-exports from profiles.py (public API compatibility)
 # ---------------------------------------------------------------------------
 
+from contextweaver.profiles import ProfileConfig, RoutingConfig  # noqa: E402
 
-@dataclass
-class ProfileConfig:
-    """Unified configuration profile bundling all contextweaver config objects.
-
-    Use :meth:`from_preset` to get a named starting-point configuration, then
-    override individual fields as needed.
-
-    Example::
-
-        profile = ProfileConfig.from_preset("fast")
-        router = Router(graph, items=catalog.all(), **profile.routing.routing_kwargs())
-
-    Attributes:
-        budget: Per-phase token budgets for the context engine.
-        policy: Policy constraints for the context engine.
-        scoring: Scoring weights for candidate ranking.
-        routing: Beam-search parameters for the routing engine.
-    """
-
-    budget: ContextBudget = field(default_factory=ContextBudget)
-    policy: ContextPolicy = field(default_factory=ContextPolicy)
-    scoring: ScoringConfig = field(default_factory=ScoringConfig)
-    routing: RoutingConfig = field(default_factory=RoutingConfig)
-
-    @classmethod
-    def from_preset(cls, name: str) -> ProfileConfig:
-        """Construct a :class:`ProfileConfig` from a named preset.
-
-        Supported presets:
-
-        * ``"fast"`` — minimal search breadth; lowest latency and token cost.
-        * ``"balanced"`` — matches the :class:`~contextweaver.routing.router.Router`
-          constructor defaults; good general-purpose starting point.
-        * ``"accurate"`` — wide beam search; highest recall at higher cost.
-
-        Args:
-            name: One of ``"fast"``, ``"balanced"``, or ``"accurate"``.
-
-        Returns:
-            A fully populated :class:`ProfileConfig`.
-
-        Raises:
-            ConfigError: If *name* is not a recognised preset.
-        """
-        if name not in _ROUTING_PRESETS:
-            valid = ", ".join(f'"{k}"' for k in sorted(_ROUTING_PRESETS))
-            raise ConfigError(f"Unknown preset {name!r}. Valid presets: {valid}.")
-
-        beam_width, max_depth, top_k, confidence_gap, max_children, answer = _ROUTING_PRESETS[name]
-
-        return cls(
-            budget=ContextBudget(answer=answer),
-            routing=RoutingConfig(
-                beam_width=beam_width,
-                max_depth=max_depth,
-                top_k=top_k,
-                confidence_gap=confidence_gap,
-                max_children=max_children,
-            ),
-        )
-
-    def to_dict(self) -> dict[str, Any]:
-        """Serialise to a JSON-compatible dict.
-
-        Note:
-            The ``policy`` field is intentionally excluded because
-            :class:`ContextPolicy` contains enum-keyed dicts that are not
-            trivially JSON-serialisable.  Callers round-tripping via
-            :meth:`from_dict` will receive a fresh :class:`ContextPolicy`
-            with default values.
-        """
-        return {
-            "budget": {
-                "route": self.budget.route,
-                "call": self.budget.call,
-                "interpret": self.budget.interpret,
-                "answer": self.budget.answer,
-            },
-            "scoring": {
-                "recency_weight": self.scoring.recency_weight,
-                "tag_match_weight": self.scoring.tag_match_weight,
-                "kind_priority_weight": self.scoring.kind_priority_weight,
-                "token_cost_penalty": self.scoring.token_cost_penalty,
-            },
-            "routing": self.routing.to_dict(),
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> ProfileConfig:
-        """Deserialise from a JSON-compatible dict.
-
-        Note:
-            The ``policy`` field is not serialised by :meth:`to_dict` and will
-            be reset to :class:`ContextPolicy` defaults on round-trip.
-        """
-        b = data.get("budget", {})
-        s = data.get("scoring", {})
-        _b = ContextBudget()
-        _s = ScoringConfig()
-        budget = ContextBudget(
-            route=int(b.get("route", _b.route)),
-            call=int(b.get("call", _b.call)),
-            interpret=int(b.get("interpret", _b.interpret)),
-            answer=int(b.get("answer", _b.answer)),
-        )
-        scoring = ScoringConfig(
-            recency_weight=float(s.get("recency_weight", _s.recency_weight)),
-            tag_match_weight=float(s.get("tag_match_weight", _s.tag_match_weight)),
-            kind_priority_weight=float(s.get("kind_priority_weight", _s.kind_priority_weight)),
-            token_cost_penalty=float(s.get("token_cost_penalty", _s.token_cost_penalty)),
-        )
-        routing = RoutingConfig.from_dict(data.get("routing", {}))
-        return cls(budget=budget, scoring=scoring, routing=routing)
+__all__ = [
+    "ContextBudget",
+    "ContextPolicy",
+    "ProfileConfig",
+    "RoutingConfig",
+    "ScoringConfig",
+]

--- a/src/contextweaver/config.py
+++ b/src/contextweaver/config.py
@@ -205,16 +205,8 @@ class ContextPolicy:
         )
 
 
-# ---------------------------------------------------------------------------
-# Re-exports from profiles.py (public API compatibility)
-# ---------------------------------------------------------------------------
-
-from contextweaver.profiles import ProfileConfig, RoutingConfig  # noqa: E402
-
 __all__ = [
     "ContextBudget",
     "ContextPolicy",
-    "ProfileConfig",
-    "RoutingConfig",
     "ScoringConfig",
 ]

--- a/src/contextweaver/context/manager.py
+++ b/src/contextweaver/context/manager.py
@@ -31,9 +31,11 @@ from contextweaver.envelope import ContextPack, ResultEnvelope
 from contextweaver.protocols import (
     ArtifactStore,
     CharDivFourEstimator,
+    EpisodicStore,
     EventHook,
     EventLog,
     Extractor,
+    FactStore,
     NoOpHook,
     Summarizer,
     TokenEstimator,
@@ -97,10 +99,8 @@ class ContextManager:
         self._artifact_store: ArtifactStore = (
             artifact_store or _stores.artifact_store or InMemoryArtifactStore()
         )
-        self._episodic_store: InMemoryEpisodicStore = (
-            _stores.episodic_store or InMemoryEpisodicStore()
-        )
-        self._fact_store: InMemoryFactStore = _stores.fact_store or InMemoryFactStore()
+        self._episodic_store: EpisodicStore = _stores.episodic_store or InMemoryEpisodicStore()
+        self._fact_store: FactStore = _stores.fact_store or InMemoryFactStore()
         self._budget = budget or ContextBudget()
         self._policy = policy or ContextPolicy()
         self._scoring = scoring_config or ScoringConfig()
@@ -125,12 +125,12 @@ class ContextManager:
         return self._artifact_store
 
     @property
-    def episodic_store(self) -> InMemoryEpisodicStore:
+    def episodic_store(self) -> EpisodicStore:
         """The underlying episodic store."""
         return self._episodic_store
 
     @property
-    def fact_store(self) -> InMemoryFactStore:
+    def fact_store(self) -> FactStore:
         """The underlying fact store."""
         return self._fact_store
 
@@ -448,7 +448,9 @@ class ContextManager:
         scored = score_candidates(candidates, query, _tags, self._scoring)
 
         # 6. Dedup
-        scored, dedup_removed = deduplicate_candidates(scored)
+        scored, dedup_removed = deduplicate_candidates(
+            scored, similarity_threshold=self._scoring.dedup_threshold
+        )
 
         # Pre-build episodic + fact injection text so we can estimate its
         # token cost and subtract it from the budget *before* selection.

--- a/src/contextweaver/context/sensitivity.py
+++ b/src/contextweaver/context/sensitivity.py
@@ -20,6 +20,7 @@ import logging
 from dataclasses import replace
 
 from contextweaver.config import ContextPolicy
+from contextweaver.exceptions import ConfigError, PolicyViolationError
 from contextweaver.protocols import RedactionHook
 from contextweaver.types import ContextItem, Sensitivity
 
@@ -57,7 +58,7 @@ def register_redaction_hook(name: str, hook: RedactionHook) -> None:
     """
     if name in _HOOK_REGISTRY:
         msg = f"Redaction hook {name!r} is already registered"
-        raise ValueError(msg)
+        raise PolicyViolationError(msg)
     _HOOK_REGISTRY[name] = hook
 
 
@@ -105,7 +106,7 @@ def _resolve_hooks(names: list[str]) -> list[RedactionHook]:
         hook = _HOOK_REGISTRY.get(name)
         if hook is None:
             msg = f"Unknown redaction hook {name!r}. Available: {sorted(_HOOK_REGISTRY)}"
-            raise ValueError(msg)
+            raise ConfigError(msg)
         hooks.append(hook)
     return hooks
 
@@ -131,7 +132,7 @@ def apply_sensitivity_filter(
 
     if action not in _VALID_ACTIONS:
         msg = f"Unknown sensitivity_action {action!r}. Valid: {sorted(_VALID_ACTIONS)}"
-        raise ValueError(msg)
+        raise ConfigError(msg)
 
     # Resolve redaction hooks once (only needed in redact mode).
     hooks: list[RedactionHook] = []

--- a/src/contextweaver/context/sensitivity.py
+++ b/src/contextweaver/context/sensitivity.py
@@ -54,7 +54,7 @@ def register_redaction_hook(name: str, hook: RedactionHook) -> None:
         hook: An object implementing the :class:`RedactionHook` protocol.
 
     Raises:
-        ValueError: If *name* is already registered.
+        PolicyViolationError: If *name* is already registered.
     """
     if name in _HOOK_REGISTRY:
         msg = f"Redaction hook {name!r} is already registered"
@@ -99,7 +99,7 @@ def _resolve_hooks(names: list[str]) -> list[RedactionHook]:
         Resolved :class:`RedactionHook` instances.
 
     Raises:
-        ValueError: If a name cannot be resolved.
+        ConfigError: If a name cannot be resolved.
     """
     hooks: list[RedactionHook] = []
     for name in names:

--- a/src/contextweaver/profiles.py
+++ b/src/contextweaver/profiles.py
@@ -137,7 +137,14 @@ class ProfileConfig:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialise to a JSON-compatible dict."""
+        """Serialise to a JSON-compatible dict.
+
+        All four sub-configs are included: ``budget``, ``policy``, ``scoring``,
+        and ``routing``. ``policy`` is now serialised in full (it was
+        intentionally excluded in earlier versions because :class:`ContextPolicy`
+        lacked ``to_dict``); the round-trip through :meth:`from_dict` is
+        lossless for default and custom values alike.
+        """
         return {
             "budget": self.budget.to_dict(),
             "policy": self.policy.to_dict(),

--- a/src/contextweaver/profiles.py
+++ b/src/contextweaver/profiles.py
@@ -1,0 +1,155 @@
+"""Routing and profile configuration for contextweaver.
+
+Contains :class:`RoutingConfig` (beam-search parameters) and
+:class:`ProfileConfig` (unified configuration bundle with named presets).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from contextweaver.config import ContextBudget, ContextPolicy, ScoringConfig
+from contextweaver.exceptions import ConfigError
+
+# Named-preset definitions: (beam_width, max_depth, top_k, confidence_gap, max_children, answer)
+_ROUTING_PRESETS: dict[str, tuple[int, int, int, float, int, int]] = {
+    "fast": (1, 4, 5, 0.20, 15, 3000),
+    "balanced": (2, 8, 10, 0.15, 20, 6000),
+    "accurate": (4, 12, 20, 0.10, 30, 8000),
+}
+
+
+@dataclass
+class RoutingConfig:
+    """Parameters that control the beam-search router.
+
+    Attributes:
+        beam_width: Number of beams to keep at each tree level.
+        max_depth: Maximum tree depth to traverse.
+        top_k: Maximum number of results to return.
+        confidence_gap: Minimum score gap between rank-1 and rank-2 to
+            consider the top pick confident.  Must be in ``[0.0, 1.0]``.
+        max_children: Maximum number of children per graph node.
+    """
+
+    beam_width: int = 2
+    max_depth: int = 8
+    top_k: int = 10
+    confidence_gap: float = 0.15
+    max_children: int = 20
+
+    def routing_kwargs(self) -> dict[str, Any]:
+        """Return router constructor kwargs (excludes *max_children*).
+
+        Returns:
+            A dict suitable for ``**``-unpacking into :class:`~contextweaver.routing.router.Router`.
+        """
+        return {
+            "beam_width": self.beam_width,
+            "max_depth": self.max_depth,
+            "top_k": self.top_k,
+            "confidence_gap": self.confidence_gap,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-compatible dict."""
+        return {
+            "beam_width": self.beam_width,
+            "max_depth": self.max_depth,
+            "top_k": self.top_k,
+            "confidence_gap": self.confidence_gap,
+            "max_children": self.max_children,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RoutingConfig:
+        """Deserialise from a JSON-compatible dict."""
+        _d = cls()
+        return cls(
+            beam_width=int(data.get("beam_width", _d.beam_width)),
+            max_depth=int(data.get("max_depth", _d.max_depth)),
+            top_k=int(data.get("top_k", _d.top_k)),
+            confidence_gap=float(data.get("confidence_gap", _d.confidence_gap)),
+            max_children=int(data.get("max_children", _d.max_children)),
+        )
+
+
+@dataclass
+class ProfileConfig:
+    """Unified configuration profile bundling all contextweaver config objects.
+
+    Use :meth:`from_preset` to get a named starting-point configuration, then
+    override individual fields as needed.
+
+    Example::
+
+        profile = ProfileConfig.from_preset("fast")
+        router = Router(graph, items=catalog.all(), **profile.routing.routing_kwargs())
+
+    Attributes:
+        budget: Per-phase token budgets for the context engine.
+        policy: Policy constraints for the context engine.
+        scoring: Scoring weights for candidate ranking.
+        routing: Beam-search parameters for the routing engine.
+    """
+
+    budget: ContextBudget = field(default_factory=ContextBudget)
+    policy: ContextPolicy = field(default_factory=ContextPolicy)
+    scoring: ScoringConfig = field(default_factory=ScoringConfig)
+    routing: RoutingConfig = field(default_factory=RoutingConfig)
+
+    @classmethod
+    def from_preset(cls, name: str) -> ProfileConfig:
+        """Construct a :class:`ProfileConfig` from a named preset.
+
+        Supported presets:
+
+        * ``"fast"`` — minimal search breadth; lowest latency and token cost.
+        * ``"balanced"`` — matches the :class:`~contextweaver.routing.router.Router`
+          constructor defaults; good general-purpose starting point.
+        * ``"accurate"`` — wide beam search; highest recall at higher cost.
+
+        Args:
+            name: One of ``"fast"``, ``"balanced"``, or ``"accurate"``.
+
+        Returns:
+            A fully populated :class:`ProfileConfig`.
+
+        Raises:
+            ConfigError: If *name* is not a recognised preset.
+        """
+        if name not in _ROUTING_PRESETS:
+            valid = ", ".join(f'"{k}"' for k in sorted(_ROUTING_PRESETS))
+            raise ConfigError(f"Unknown preset {name!r}. Valid presets: {valid}.")
+
+        beam_width, max_depth, top_k, confidence_gap, max_children, answer = _ROUTING_PRESETS[name]
+
+        return cls(
+            budget=ContextBudget(answer=answer),
+            routing=RoutingConfig(
+                beam_width=beam_width,
+                max_depth=max_depth,
+                top_k=top_k,
+                confidence_gap=confidence_gap,
+                max_children=max_children,
+            ),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-compatible dict."""
+        return {
+            "budget": self.budget.to_dict(),
+            "policy": self.policy.to_dict(),
+            "scoring": self.scoring.to_dict(),
+            "routing": self.routing.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProfileConfig:
+        """Deserialise from a JSON-compatible dict."""
+        budget = ContextBudget.from_dict(data.get("budget", {}))
+        policy = ContextPolicy.from_dict(data.get("policy", {}))
+        scoring = ScoringConfig.from_dict(data.get("scoring", {}))
+        routing = RoutingConfig.from_dict(data.get("routing", {}))
+        return cls(budget=budget, policy=policy, scoring=scoring, routing=routing)

--- a/src/contextweaver/protocols.py
+++ b/src/contextweaver/protocols.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from contextweaver.envelope import ContextPack
+    from contextweaver.store.episodic import Episode
+    from contextweaver.store.facts import Fact
     from contextweaver.types import ArtifactRef, ContextItem, ItemKind, SelectableItem
 
 
@@ -134,9 +136,96 @@ class ArtifactStore(Protocol):
         ...
 
 
-# FUTURE: EpisodicStore and FactStore protocols — the concrete InMemory*
-# classes currently define latest/delete/list_keys without protocol
-# declarations.  Add formal protocols once the API surface stabilises.
+# ---------------------------------------------------------------------------
+# EpisodicStore
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class EpisodicStore(Protocol):
+    """Read/write interface to the episodic memory store.
+
+    The episodic store holds compressed summaries of past agent episodes
+    (conversations / task runs).
+    """
+
+    def add(self, episode: Episode) -> None:
+        """Append *episode* to the store."""
+        ...
+
+    def get(self, episode_id: str) -> Episode | None:
+        """Return the episode with *episode_id*, or ``None`` if not found."""
+        ...
+
+    def search(self, query: str, top_k: int = 5) -> list[Episode]:
+        """Return the *top_k* most relevant episodes for *query*."""
+        ...
+
+    def all(self) -> list[Episode]:
+        """Return all episodes in insertion order."""
+        ...
+
+    def latest(self, n: int = 3) -> list[tuple[str, str, dict[str, Any]]]:
+        """Return the *n* most recently added episodes.
+
+        Returns:
+            A list of ``(episode_id, summary, metadata)`` tuples, most-recent first.
+        """
+        ...
+
+    def delete(self, episode_id: str) -> None:
+        """Remove the episode with *episode_id*.
+
+        Raises:
+            ItemNotFoundError: If no episode with *episode_id* exists.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# FactStore
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class FactStore(Protocol):
+    """Read/write interface to the fact memory store.
+
+    The fact store holds short, structured memory facts (key/value assertions)
+    that can be injected into context as ``memory_fact`` items.
+    """
+
+    def put(self, fact: Fact) -> None:
+        """Insert or replace the fact identified by ``fact.fact_id``."""
+        ...
+
+    def get(self, fact_id: str) -> Fact:
+        """Return the fact with *fact_id*.
+
+        Raises:
+            ItemNotFoundError: If no fact with *fact_id* exists.
+        """
+        ...
+
+    def get_by_key(self, key: str) -> list[Fact]:
+        """Return all facts whose ``key`` matches *key*."""
+        ...
+
+    def list_keys(self, prefix: str = "") -> list[str]:
+        """Return all distinct fact keys, optionally filtered by *prefix*."""
+        ...
+
+    def delete(self, fact_id: str) -> None:
+        """Remove the fact identified by *fact_id*.
+
+        Raises:
+            ItemNotFoundError: If no fact with *fact_id* exists.
+        """
+        ...
+
+    def all(self) -> list[Fact]:
+        """Return all facts sorted by ``fact_id``."""
+        ...
 
 
 # ---------------------------------------------------------------------------

--- a/src/contextweaver/protocols.py
+++ b/src/contextweaver/protocols.py
@@ -2,230 +2,26 @@
 
 Downstream code should depend on the protocols, not the concrete defaults,
 so that stores, hooks, and summarisers remain swappable.
+
+Store-layer protocols (:class:`EventLog`, :class:`ArtifactStore`,
+:class:`EpisodicStore`, :class:`FactStore`) live in
+:mod:`contextweaver.store.protocols` and are re-exported here for backward
+compatibility — keep using ``from contextweaver.protocols import …`` if you
+prefer the historical path.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from contextweaver.store.protocols import ArtifactStore as ArtifactStore
+from contextweaver.store.protocols import EpisodicStore as EpisodicStore
+from contextweaver.store.protocols import EventLog as EventLog
+from contextweaver.store.protocols import FactStore as FactStore
+
 if TYPE_CHECKING:
     from contextweaver.envelope import ContextPack
-    from contextweaver.store.episodic import Episode
-    from contextweaver.store.facts import Fact
-    from contextweaver.types import ArtifactRef, ContextItem, ItemKind, SelectableItem
-
-
-# ---------------------------------------------------------------------------
-# EventLog
-# ---------------------------------------------------------------------------
-
-
-@runtime_checkable
-class EventLog(Protocol):
-    """Read/write interface to the ordered event log.
-
-    The event log is the ordered sequence of :class:`~contextweaver.types.ContextItem`
-    objects that makes up a conversation / agent session.
-    """
-
-    def append(self, item: ContextItem) -> None:
-        """Append *item* to the log.
-
-        Raises:
-            DuplicateItemError: If an item with the same ``id`` already exists.
-        """
-        ...
-
-    def get(self, item_id: str) -> ContextItem:
-        """Return the item with *item_id*.
-
-        Raises:
-            ItemNotFoundError: If no item with *item_id* exists.
-        """
-        ...
-
-    def all(self) -> list[ContextItem]:
-        """Return all items in insertion order."""
-        ...
-
-    def filter_by_kind(self, *kinds: ItemKind) -> list[ContextItem]:
-        """Return all items whose ``kind`` is in *kinds*."""
-        ...
-
-    def tail(self, n: int) -> list[ContextItem]:
-        """Return the last *n* items."""
-        ...
-
-    def children(self, parent_id: str) -> list[ContextItem]:
-        """Return all items whose ``parent_id`` equals *parent_id*."""
-        ...
-
-    def parent(self, item_id: str) -> ContextItem | None:
-        """Return the parent of *item_id*, or ``None``."""
-        ...
-
-    def query(
-        self,
-        kinds: list[ItemKind] | None = None,
-        since: int | None = None,
-        limit: int | None = None,
-    ) -> list[ContextItem]:
-        """Flexible query over the event log."""
-        ...
-
-    def count(self) -> int:
-        """Return the number of items in the log."""
-        ...
-
-    def __len__(self) -> int: ...
-
-
-# ---------------------------------------------------------------------------
-# ArtifactStore
-# ---------------------------------------------------------------------------
-
-
-@runtime_checkable
-class ArtifactStore(Protocol):
-    """Read/write interface to the out-of-band artifact store.
-
-    Raw tool outputs are stored here; the LLM context pipeline receives only
-    :class:`~contextweaver.types.ArtifactRef` handles and summaries.
-    """
-
-    def put(
-        self,
-        handle: str,
-        content: bytes,
-        media_type: str = "application/octet-stream",
-        label: str = "",
-    ) -> ArtifactRef:
-        """Store *content* and return an :class:`~contextweaver.types.ArtifactRef`."""
-        ...
-
-    def get(self, handle: str) -> bytes:
-        """Retrieve the raw bytes for *handle*.
-
-        Raises:
-            ArtifactNotFoundError: If *handle* is not in the store.
-        """
-        ...
-
-    def ref(self, handle: str) -> ArtifactRef:
-        """Return the :class:`~contextweaver.types.ArtifactRef` metadata for *handle*."""
-        ...
-
-    def list_refs(self) -> list[ArtifactRef]:
-        """Return all stored :class:`~contextweaver.types.ArtifactRef` objects."""
-        ...
-
-    def delete(self, handle: str) -> None:
-        """Remove the artifact identified by *handle*."""
-        ...
-
-    def exists(self, handle: str) -> bool:
-        """Return ``True`` if *handle* is in the store."""
-        ...
-
-    def metadata(self, handle: str) -> ArtifactRef:
-        """Return the :class:`~contextweaver.types.ArtifactRef` for *handle*."""
-        ...
-
-    def drilldown(self, handle: str, selector: dict[str, Any]) -> str:
-        """Return a subset of the artifact's content according to *selector*."""
-        ...
-
-
-# ---------------------------------------------------------------------------
-# EpisodicStore
-# ---------------------------------------------------------------------------
-
-
-@runtime_checkable
-class EpisodicStore(Protocol):
-    """Read/write interface to the episodic memory store.
-
-    The episodic store holds compressed summaries of past agent episodes
-    (conversations / task runs).
-    """
-
-    def add(self, episode: Episode) -> None:
-        """Append *episode* to the store."""
-        ...
-
-    def get(self, episode_id: str) -> Episode | None:
-        """Return the episode with *episode_id*, or ``None`` if not found."""
-        ...
-
-    def search(self, query: str, top_k: int = 5) -> list[Episode]:
-        """Return the *top_k* most relevant episodes for *query*."""
-        ...
-
-    def all(self) -> list[Episode]:
-        """Return all episodes in insertion order."""
-        ...
-
-    def latest(self, n: int = 3) -> list[tuple[str, str, dict[str, Any]]]:
-        """Return the *n* most recently added episodes.
-
-        Returns:
-            A list of ``(episode_id, summary, metadata)`` tuples, most-recent first.
-        """
-        ...
-
-    def delete(self, episode_id: str) -> None:
-        """Remove the episode with *episode_id*.
-
-        Raises:
-            ItemNotFoundError: If no episode with *episode_id* exists.
-        """
-        ...
-
-
-# ---------------------------------------------------------------------------
-# FactStore
-# ---------------------------------------------------------------------------
-
-
-@runtime_checkable
-class FactStore(Protocol):
-    """Read/write interface to the fact memory store.
-
-    The fact store holds short, structured memory facts (key/value assertions)
-    that can be injected into context as ``memory_fact`` items.
-    """
-
-    def put(self, fact: Fact) -> None:
-        """Insert or replace the fact identified by ``fact.fact_id``."""
-        ...
-
-    def get(self, fact_id: str) -> Fact:
-        """Return the fact with *fact_id*.
-
-        Raises:
-            ItemNotFoundError: If no fact with *fact_id* exists.
-        """
-        ...
-
-    def get_by_key(self, key: str) -> list[Fact]:
-        """Return all facts whose ``key`` matches *key*."""
-        ...
-
-    def list_keys(self, prefix: str = "") -> list[str]:
-        """Return all distinct fact keys, optionally filtered by *prefix*."""
-        ...
-
-    def delete(self, fact_id: str) -> None:
-        """Remove the fact identified by *fact_id*.
-
-        Raises:
-            ItemNotFoundError: If no fact with *fact_id* exists.
-        """
-        ...
-
-    def all(self) -> list[Fact]:
-        """Return all facts sorted by ``fact_id``."""
-        ...
+    from contextweaver.types import ContextItem, SelectableItem
 
 
 # ---------------------------------------------------------------------------

--- a/src/contextweaver/routing/router.py
+++ b/src/contextweaver/routing/router.py
@@ -73,7 +73,7 @@ class Router:
             from this config object.
 
     Raises:
-        ValueError: If *confidence_gap* is outside ``[0.0, 1.0]``.
+        ConfigError: If *confidence_gap* is outside ``[0.0, 1.0]``.
     """
 
     def __init__(

--- a/src/contextweaver/routing/router.py
+++ b/src/contextweaver/routing/router.py
@@ -11,8 +11,8 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from contextweaver._utils import TfIdfScorer, jaccard, tokenize
-from contextweaver.config import RoutingConfig
 from contextweaver.exceptions import ConfigError, RouteError
+from contextweaver.profiles import RoutingConfig
 from contextweaver.routing.graph import ChoiceGraph
 from contextweaver.types import SelectableItem
 

--- a/src/contextweaver/routing/router.py
+++ b/src/contextweaver/routing/router.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from contextweaver._utils import TfIdfScorer, jaccard, tokenize
 from contextweaver.config import RoutingConfig
-from contextweaver.exceptions import RouteError
+from contextweaver.exceptions import ConfigError, RouteError
 from contextweaver.routing.graph import ChoiceGraph
 from contextweaver.types import SelectableItem
 
@@ -94,7 +94,7 @@ class Router:
             top_k = routing_config.top_k
             confidence_gap = routing_config.confidence_gap
         if not 0.0 <= confidence_gap <= 1.0:
-            raise ValueError(f"confidence_gap must be in [0.0, 1.0], got {confidence_gap}")
+            raise ConfigError(f"confidence_gap must be in [0.0, 1.0], got {confidence_gap}")
         self._graph = graph
         self._beam_width = beam_width
         self._max_depth = max_depth

--- a/src/contextweaver/store/bundle.py
+++ b/src/contextweaver/store/bundle.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from contextweaver.store.artifacts import InMemoryArtifactStore
 from contextweaver.store.episodic import InMemoryEpisodicStore
 from contextweaver.store.event_log import InMemoryEventLog
 from contextweaver.store.facts import InMemoryFactStore
+
+if TYPE_CHECKING:
+    from contextweaver.protocols import ArtifactStore, EpisodicStore, EventLog, FactStore
 
 
 @dataclass
@@ -19,18 +22,28 @@ class StoreBundle:
     any store left as ``None`` at build time.
     """
 
-    artifact_store: InMemoryArtifactStore | None = field(default=None)
-    event_log: InMemoryEventLog | None = field(default=None)
-    episodic_store: InMemoryEpisodicStore | None = field(default=None)
-    fact_store: InMemoryFactStore | None = field(default=None)
+    artifact_store: ArtifactStore | None = field(default=None)
+    event_log: EventLog | None = field(default=None)
+    episodic_store: EpisodicStore | None = field(default=None)
+    fact_store: FactStore | None = field(default=None)
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialise non-None stores to a JSON-compatible dict."""
+        """Serialise non-None stores to a JSON-compatible dict.
+
+        Only works with store implementations that provide a ``to_dict()``
+        method (e.g. the built-in InMemory stores).
+        """
+
+        def _ser(store: object) -> object:
+            if store is not None and hasattr(store, "to_dict"):
+                return store.to_dict()  # pyright: ignore[reportAttributeAccessIssue]
+            return None
+
         return {
-            "artifact_store": self.artifact_store.to_dict() if self.artifact_store else None,
-            "event_log": self.event_log.to_dict() if self.event_log else None,
-            "episodic_store": self.episodic_store.to_dict() if self.episodic_store else None,
-            "fact_store": self.fact_store.to_dict() if self.fact_store else None,
+            "artifact_store": _ser(self.artifact_store),
+            "event_log": _ser(self.event_log),
+            "episodic_store": _ser(self.episodic_store),
+            "fact_store": _ser(self.fact_store),
         }
 
     @classmethod

--- a/src/contextweaver/store/bundle.py
+++ b/src/contextweaver/store/bundle.py
@@ -30,8 +30,13 @@ class StoreBundle:
     def to_dict(self) -> dict[str, Any]:
         """Serialise non-None stores to a JSON-compatible dict.
 
-        Only works with store implementations that provide a ``to_dict()``
-        method (e.g. the built-in InMemory stores).
+        Only the built-in ``InMemory*`` backends (and any custom backend that
+        provides a ``to_dict()`` method) are serialised. Custom backends
+        without ``to_dict()`` are silently emitted as ``None`` — round-tripping
+        a :class:`StoreBundle` containing such backends through
+        :meth:`from_dict` will lose their state and reconstruct empty
+        ``InMemory*`` defaults instead. If your custom backend needs to
+        persist state, give it a ``to_dict()``/``from_dict()`` pair.
         """
 
         def _ser(store: object) -> object:
@@ -48,7 +53,14 @@ class StoreBundle:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> StoreBundle:
-        """Deserialise from a JSON-compatible dict produced by :meth:`to_dict`."""
+        """Deserialise from a JSON-compatible dict produced by :meth:`to_dict`.
+
+        Reconstructs the built-in ``InMemory*`` backends from non-``None``
+        payloads. ``None`` entries (which include custom backends that lacked
+        ``to_dict()`` at serialisation time — see :meth:`to_dict`) yield
+        ``None`` fields; the engine then creates fresh in-memory defaults at
+        build time, so any state held in the original custom backend is lost.
+        """
         raw_artifact = data.get("artifact_store")
         raw_event_log = data.get("event_log")
         raw_episodic = data.get("episodic_store")

--- a/src/contextweaver/store/protocols.py
+++ b/src/contextweaver/store/protocols.py
@@ -1,0 +1,230 @@
+"""Store-layer protocol definitions for contextweaver.
+
+Backend-agnostic interfaces for the four optional stores used by the Context
+Engine (event log, artifacts, episodic memory, fact memory). Concrete
+implementations live alongside this module under :mod:`contextweaver.store`.
+
+Re-exported from :mod:`contextweaver.protocols` for backward compatibility.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from contextweaver.store.episodic import Episode
+    from contextweaver.store.facts import Fact
+    from contextweaver.types import ArtifactRef, ContextItem, ItemKind
+
+
+# ---------------------------------------------------------------------------
+# EventLog
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class EventLog(Protocol):
+    """Read/write interface to the ordered event log.
+
+    The event log is the ordered sequence of :class:`~contextweaver.types.ContextItem`
+    objects that makes up a conversation / agent session.
+    """
+
+    def append(self, item: ContextItem) -> None:
+        """Append *item* to the log.
+
+        Raises:
+            DuplicateItemError: If an item with the same ``id`` already exists.
+        """
+        ...
+
+    def get(self, item_id: str) -> ContextItem:
+        """Return the item with *item_id*.
+
+        Raises:
+            ItemNotFoundError: If no item with *item_id* exists.
+        """
+        ...
+
+    def all(self) -> list[ContextItem]:
+        """Return all items in insertion order."""
+        ...
+
+    def filter_by_kind(self, *kinds: ItemKind) -> list[ContextItem]:
+        """Return all items whose ``kind`` is in *kinds*."""
+        ...
+
+    def tail(self, n: int) -> list[ContextItem]:
+        """Return the last *n* items."""
+        ...
+
+    def children(self, parent_id: str) -> list[ContextItem]:
+        """Return all items whose ``parent_id`` equals *parent_id*."""
+        ...
+
+    def parent(self, item_id: str) -> ContextItem | None:
+        """Return the parent of *item_id*, or ``None``."""
+        ...
+
+    def query(
+        self,
+        kinds: list[ItemKind] | None = None,
+        since: int | None = None,
+        limit: int | None = None,
+    ) -> list[ContextItem]:
+        """Flexible query over the event log."""
+        ...
+
+    def count(self) -> int:
+        """Return the number of items in the log."""
+        ...
+
+    def __len__(self) -> int: ...
+
+
+# ---------------------------------------------------------------------------
+# ArtifactStore
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class ArtifactStore(Protocol):
+    """Read/write interface to the out-of-band artifact store.
+
+    Raw tool outputs are stored here; the LLM context pipeline receives only
+    :class:`~contextweaver.types.ArtifactRef` handles and summaries.
+    """
+
+    def put(
+        self,
+        handle: str,
+        content: bytes,
+        media_type: str = "application/octet-stream",
+        label: str = "",
+    ) -> ArtifactRef:
+        """Store *content* and return an :class:`~contextweaver.types.ArtifactRef`."""
+        ...
+
+    def get(self, handle: str) -> bytes:
+        """Retrieve the raw bytes for *handle*.
+
+        Raises:
+            ArtifactNotFoundError: If *handle* is not in the store.
+        """
+        ...
+
+    def ref(self, handle: str) -> ArtifactRef:
+        """Return the :class:`~contextweaver.types.ArtifactRef` metadata for *handle*."""
+        ...
+
+    def list_refs(self) -> list[ArtifactRef]:
+        """Return all stored :class:`~contextweaver.types.ArtifactRef` objects."""
+        ...
+
+    def delete(self, handle: str) -> None:
+        """Remove the artifact identified by *handle*."""
+        ...
+
+    def exists(self, handle: str) -> bool:
+        """Return ``True`` if *handle* is in the store."""
+        ...
+
+    def metadata(self, handle: str) -> ArtifactRef:
+        """Return the :class:`~contextweaver.types.ArtifactRef` for *handle*."""
+        ...
+
+    def drilldown(self, handle: str, selector: dict[str, Any]) -> str:
+        """Return a subset of the artifact's content according to *selector*."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# EpisodicStore
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class EpisodicStore(Protocol):
+    """Read/write interface to the episodic memory store.
+
+    The episodic store holds compressed summaries of past agent episodes
+    (conversations / task runs).
+    """
+
+    def add(self, episode: Episode) -> None:
+        """Append *episode* to the store."""
+        ...
+
+    def get(self, episode_id: str) -> Episode | None:
+        """Return the episode with *episode_id*, or ``None`` if not found."""
+        ...
+
+    def search(self, query: str, top_k: int = 5) -> list[Episode]:
+        """Return the *top_k* most relevant episodes for *query*."""
+        ...
+
+    def all(self) -> list[Episode]:
+        """Return all episodes in insertion order."""
+        ...
+
+    def latest(self, n: int = 3) -> list[tuple[str, str, dict[str, Any]]]:
+        """Return the *n* most recently added episodes.
+
+        Returns:
+            A list of ``(episode_id, summary, metadata)`` tuples, most-recent first.
+        """
+        ...
+
+    def delete(self, episode_id: str) -> None:
+        """Remove the episode with *episode_id*.
+
+        Raises:
+            ItemNotFoundError: If no episode with *episode_id* exists.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# FactStore
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class FactStore(Protocol):
+    """Read/write interface to the fact memory store.
+
+    The fact store holds short, structured memory facts (key/value assertions)
+    that can be injected into context as ``memory_fact`` items.
+    """
+
+    def put(self, fact: Fact) -> None:
+        """Insert or replace the fact identified by ``fact.fact_id``."""
+        ...
+
+    def get(self, fact_id: str) -> Fact:
+        """Return the fact with *fact_id*.
+
+        Raises:
+            ItemNotFoundError: If no fact with *fact_id* exists.
+        """
+        ...
+
+    def get_by_key(self, key: str) -> list[Fact]:
+        """Return all facts whose ``key`` matches *key*."""
+        ...
+
+    def list_keys(self, prefix: str = "") -> list[str]:
+        """Return all distinct fact keys, optionally filtered by *prefix*."""
+        ...
+
+    def delete(self, fact_id: str) -> None:
+        """Remove the fact identified by *fact_id*.
+
+        Raises:
+            ItemNotFoundError: If no fact with *fact_id* exists.
+        """
+        ...
+
+    def all(self) -> list[Fact]:
+        """Return all facts sorted by ``fact_id``."""
+        ...

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,7 @@ from contextweaver.config import (
     ScoringConfig,
 )
 from contextweaver.exceptions import ConfigError
-from contextweaver.types import ItemKind, Phase
+from contextweaver.types import ItemKind, Phase, Sensitivity
 
 
 def test_context_budget_defaults() -> None:
@@ -209,3 +209,105 @@ def test_profile_routing_kwargs_keys() -> None:
     p = ProfileConfig.from_preset("accurate")
     kwargs = p.routing.routing_kwargs()
     assert set(kwargs.keys()) == {"beam_width", "max_depth", "top_k", "confidence_gap"}
+
+
+# ---------------------------------------------------------------------------
+# ScoringConfig — to_dict / from_dict (#184) and dedup_threshold (#182)
+# ---------------------------------------------------------------------------
+
+
+def test_scoring_config_dedup_threshold_default() -> None:
+    cfg = ScoringConfig()
+    assert cfg.dedup_threshold == 0.85
+
+
+def test_scoring_config_roundtrip() -> None:
+    cfg = ScoringConfig(
+        recency_weight=0.4,
+        tag_match_weight=0.2,
+        kind_priority_weight=0.3,
+        token_cost_penalty=0.05,
+        dedup_threshold=0.9,
+    )
+    restored = ScoringConfig.from_dict(cfg.to_dict())
+    assert restored == cfg
+
+
+def test_scoring_config_from_dict_defaults() -> None:
+    assert ScoringConfig.from_dict({}) == ScoringConfig()
+
+
+# ---------------------------------------------------------------------------
+# ContextBudget — to_dict / from_dict (#184)
+# ---------------------------------------------------------------------------
+
+
+def test_context_budget_roundtrip() -> None:
+    b = ContextBudget(route=1500, call=2500, interpret=3500, answer=5500)
+    restored = ContextBudget.from_dict(b.to_dict())
+    assert restored == b
+
+
+def test_context_budget_from_dict_defaults() -> None:
+    assert ContextBudget.from_dict({}) == ContextBudget()
+
+
+# ---------------------------------------------------------------------------
+# ContextPolicy — to_dict / from_dict (#184)
+# ---------------------------------------------------------------------------
+
+
+def test_context_policy_roundtrip() -> None:
+    policy = ContextPolicy(
+        sensitivity_floor=Sensitivity.restricted,
+        sensitivity_action="redact",
+        redaction_hooks=["mask"],
+        extra={"custom_key": "custom_val"},
+    )
+    restored = ContextPolicy.from_dict(policy.to_dict())
+    assert restored.sensitivity_floor == Sensitivity.restricted
+    assert restored.sensitivity_action == "redact"
+    assert restored.redaction_hooks == ["mask"]
+    assert restored.extra == {"custom_key": "custom_val"}
+
+
+def test_context_policy_roundtrip_allowed_kinds() -> None:
+    policy = ContextPolicy()
+    d = policy.to_dict()
+    restored = ContextPolicy.from_dict(d)
+    assert restored.allowed_kinds_per_phase.keys() == policy.allowed_kinds_per_phase.keys()
+    for phase in Phase:
+        assert restored.allowed_kinds_per_phase[phase] == policy.allowed_kinds_per_phase[phase]
+
+
+def test_context_policy_roundtrip_max_items_per_kind() -> None:
+    policy = ContextPolicy(max_items_per_kind={ItemKind.user_turn: 10, ItemKind.tool_call: 20})
+    restored = ContextPolicy.from_dict(policy.to_dict())
+    assert restored.max_items_per_kind[ItemKind.user_turn] == 10
+    assert restored.max_items_per_kind[ItemKind.tool_call] == 20
+
+
+def test_context_policy_from_dict_defaults() -> None:
+    p = ContextPolicy.from_dict({})
+    default = ContextPolicy()
+    assert p.sensitivity_floor == default.sensitivity_floor
+    assert p.sensitivity_action == default.sensitivity_action
+
+
+# ---------------------------------------------------------------------------
+# ProfileConfig — full roundtrip with policy (#184)
+# ---------------------------------------------------------------------------
+
+
+def test_profile_config_full_roundtrip_includes_policy() -> None:
+    original = ProfileConfig(
+        policy=ContextPolicy(
+            sensitivity_floor=Sensitivity.restricted,
+            extra={"test": True},
+        ),
+        scoring=ScoringConfig(dedup_threshold=0.92),
+    )
+    restored = ProfileConfig.from_dict(original.to_dict())
+    assert restored.policy.sensitivity_floor == Sensitivity.restricted
+    assert restored.policy.extra == {"test": True}
+    assert restored.scoring.dedup_threshold == 0.92

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,14 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from contextweaver.config import (
-    ContextBudget,
-    ContextPolicy,
-    ProfileConfig,
-    RoutingConfig,
-    ScoringConfig,
-)
+from contextweaver.config import ContextBudget, ContextPolicy, ScoringConfig
 from contextweaver.exceptions import ConfigError
+from contextweaver.profiles import ProfileConfig, RoutingConfig
 from contextweaver.types import ItemKind, Phase, Sensitivity
 
 

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -52,3 +52,21 @@ def test_threshold_one_keeps_all_unless_identical() -> None:
     # Jaccard < 1.0 so both kept
     assert len(kept) == 2
     assert removed == 0
+
+
+def test_custom_threshold_less_aggressive() -> None:
+    """A higher threshold keeps near-duplicates that the default would remove."""
+    text_a = "search database records quickly using query"
+    text_b = "search database records quickly using queries"
+    items = [
+        (1.0, _item("i1", text_a)),
+        (0.9, _item("i2", text_b)),
+    ]
+    # Default (0.85) would remove the near-duplicate
+    _, removed_default = deduplicate_candidates(items, similarity_threshold=0.85)
+    # Very high threshold keeps both
+    kept_high, removed_high = deduplicate_candidates(items, similarity_threshold=0.99)
+    assert removed_high == 0
+    assert len(kept_high) == 2
+    # Default should be more aggressive
+    assert removed_default >= removed_high

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -56,17 +56,24 @@ def test_threshold_one_keeps_all_unless_identical() -> None:
 
 def test_custom_threshold_less_aggressive() -> None:
     """A higher threshold keeps near-duplicates that the default would remove."""
-    text_a = "search database records quickly using query"
-    text_b = "search database records quickly using queries"
+    # Jaccard similarity ≈ 0.89 — above 0.85 default but below 0.99.
+    text_a = (
+        "alpha bravo charlie delta echo foxtrot golf hotel"
+        " india juliet kilo lima mike november oscar papa query"
+    )
+    text_b = (
+        "alpha bravo charlie delta echo foxtrot golf hotel"
+        " india juliet kilo lima mike november oscar papa quebec"
+    )
     items = [
         (1.0, _item("i1", text_a)),
         (0.9, _item("i2", text_b)),
     ]
-    # Default (0.85) would remove the near-duplicate
+    # Default (0.85) should remove the near-duplicate (0.89 >= 0.85)
     _, removed_default = deduplicate_candidates(items, similarity_threshold=0.85)
-    # Very high threshold keeps both
+    # Very high threshold keeps both (0.89 < 0.99)
     kept_high, removed_high = deduplicate_candidates(items, similarity_threshold=0.99)
     assert removed_high == 0
     assert len(kept_high) == 2
-    # Default should be more aggressive
-    assert removed_default >= removed_high
+    # Default must be strictly more aggressive
+    assert removed_default > removed_high

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -164,3 +164,19 @@ def test_artifact_store_is_runtime_checkable() -> None:
 
     store = InMemoryArtifactStore()
     assert isinstance(store, ArtifactStore)
+
+
+def test_episodic_store_is_runtime_checkable() -> None:
+    from contextweaver.protocols import EpisodicStore
+    from contextweaver.store.episodic import InMemoryEpisodicStore
+
+    store = InMemoryEpisodicStore()
+    assert isinstance(store, EpisodicStore)
+
+
+def test_fact_store_is_runtime_checkable() -> None:
+    from contextweaver.protocols import FactStore
+    from contextweaver.store.facts import InMemoryFactStore
+
+    store = InMemoryFactStore()
+    assert isinstance(store, FactStore)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from contextweaver.config import RoutingConfig
-from contextweaver.exceptions import RouteError
+from contextweaver.exceptions import ConfigError, RouteError
 from contextweaver.routing.graph import ChoiceGraph
 from contextweaver.routing.router import Router, RouteResult
 from contextweaver.routing.tree import TreeBuilder
@@ -140,14 +140,14 @@ def test_confidence_gap_valid_range() -> None:
 def test_confidence_gap_below_zero_raises() -> None:
     items = _build_catalog_items()
     graph = TreeBuilder().build(items)
-    with pytest.raises(ValueError, match="confidence_gap"):
+    with pytest.raises(ConfigError, match="confidence_gap"):
         Router(graph, confidence_gap=-0.1)
 
 
 def test_confidence_gap_above_one_raises() -> None:
     items = _build_catalog_items()
     graph = TreeBuilder().build(items)
-    with pytest.raises(ValueError, match="confidence_gap"):
+    with pytest.raises(ConfigError, match="confidence_gap"):
         Router(graph, confidence_gap=1.5)
 
 

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import pytest
 
-from contextweaver.config import RoutingConfig
 from contextweaver.exceptions import ConfigError, RouteError
+from contextweaver.profiles import RoutingConfig
 from contextweaver.routing.graph import ChoiceGraph
 from contextweaver.routing.router import Router, RouteResult
 from contextweaver.routing.tree import TreeBuilder

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -13,6 +13,7 @@ from contextweaver.context.sensitivity import (
     apply_sensitivity_filter,
     register_redaction_hook,
 )
+from contextweaver.exceptions import ConfigError, PolicyViolationError
 from contextweaver.store.event_log import InMemoryEventLog
 from contextweaver.types import ContextItem, ItemKind, Phase, Sensitivity
 
@@ -208,7 +209,7 @@ def test_unknown_hook_name_raises() -> None:
         redaction_hooks=["nonexistent"],
     )
     item = _item("x", Sensitivity.confidential)
-    with pytest.raises(ValueError, match="Unknown redaction hook"):
+    with pytest.raises(ConfigError, match="Unknown redaction hook"):
         apply_sensitivity_filter([item], policy)
 
 
@@ -218,7 +219,7 @@ def test_unknown_sensitivity_action_raises() -> None:
         sensitivity_action="dorp",
     )
     item = _item("x", Sensitivity.confidential)
-    with pytest.raises(ValueError, match="Unknown sensitivity_action"):
+    with pytest.raises(ConfigError, match="Unknown sensitivity_action"):
         apply_sensitivity_filter([item], policy)
 
 
@@ -336,6 +337,6 @@ def test_register_custom_hook_and_use_in_redact_mode() -> None:
 
 
 def test_register_duplicate_hook_raises() -> None:
-    """Registering a hook with an existing name raises ValueError."""
-    with pytest.raises(ValueError, match="already registered"):
+    """Registering a hook with an existing name raises PolicyViolationError."""
+    with pytest.raises(PolicyViolationError, match="already registered"):
         register_redaction_hook("mask", MaskRedactionHook())


### PR DESCRIPTION
## Summary

Closes #182, closes #183, closes #184, closes #40, closes #179

Implements five grouped issues from the v0.2.1 milestone:

1. **#184** — `to_dict()`/`from_dict()` on `ContextPolicy`, `ContextBudget`, `ScoringConfig`
2. **#182** — `ScoringConfig.dedup_threshold` field; wired through `ContextManager`
3. **#183** — Replace bare `ValueError` raises with `ContextWeaverError`-family exceptions
4. **#40** — `EpisodicStore` and `FactStore` protocols added (now living in `store/protocols.py`)
5. **#179** — Decompose `config.py` → extract `RoutingConfig`/`ProfileConfig` to new `profiles.py`

## Changes

**#184 — Config serialization:**
- `ScoringConfig.to_dict()` / `from_dict()` — all float fields
- `ContextBudget.to_dict()` / `from_dict()` — all int fields
- `ContextPolicy.to_dict()` / `from_dict()` — `Phase`/`ItemKind` enum keys serialized via `.value`; `Sensitivity` floor round-trips via `Sensitivity()`; `extra` dict preserved
- `ProfileConfig.to_dict()` / `from_dict()` updated to include `policy` field (previously excluded); delegates to per-class methods; docstring expanded to make the round-trip contract explicit

**#182 — Configurable dedup threshold:**
- `ScoringConfig.dedup_threshold: float = 0.85` added
- `ContextManager._build()` passes `self._scoring.dedup_threshold` to `deduplicate_candidates()`
- `docs/troubleshooting.md` Issue 5 updated: removed "future workaround" note; actionable snippet now live

**#183 — Exception convention enforcement:**
- `sensitivity.py` L60: `ValueError` → `PolicyViolationError` (duplicate hook registration)
- `sensitivity.py` L108: `ValueError` → `ConfigError` (unknown hook name)
- `sensitivity.py` L134: `ValueError` → `ConfigError` (unknown sensitivity_action)
- `routing/router.py` L97: `ValueError` → `ConfigError` (`confidence_gap` validation)

**#40 — Store protocols:**
- `EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore` `@runtime_checkable` protocols formalized in `src/contextweaver/store/protocols.py`
- Match `InMemoryEventLog` / `InMemoryArtifactStore` / `InMemoryEpisodicStore` / `InMemoryFactStore` method signatures exactly
- `StoreBundle` field types widened to protocol types
- `ContextManager._episodic_store` / `._fact_store` and their properties widened to protocol types
- All four protocols re-exported from `contextweaver.protocols` and `contextweaver` for backward compatibility

**#179 — config.py decomposition:**
- `RoutingConfig`, `ProfileConfig`, `_ROUTING_PRESETS` extracted to new `src/contextweaver/profiles.py`
- `config.py` reduced from ~358 lines to 212 lines
- `AGENTS.md` module map updated with `profiles.py` and `store/protocols.py` entries

## Review-driven follow-up

Addressed in [`6a0bee0`](https://github.com/dgenio/contextweaver/commit/6a0bee0d9b228b7021c2fd9c1d21f2a47632abdb), responding to the audit-grade self-review:

- **Decompose `protocols.py` (was 396 lines)** — store-layer protocols (`EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore`) moved to a new `src/contextweaver/store/protocols.py` (230 lines). `protocols.py` is now 192 lines. Both under the ≤300-line invariant. Aliased re-exports preserve `from contextweaver.protocols import EventLog, …` and `from contextweaver import EpisodicStore, …`.
- **Drop `config.py` ↔ `profiles.py` circular re-export** — bottom-of-file `from contextweaver.profiles import ProfileConfig, RoutingConfig  # noqa: E402` block removed from `config.py`. Public access flows through `contextweaver.__init__` only. Internal callers migrated: `routing/router.py`, `tests/test_router.py`, `tests/test_config.py`.
- **`StoreBundle.to_dict()` / `from_dict()` docstrings** spell out the silent-`None` round-trip caveat for custom backends without `to_dict()`.
- **`ProfileConfig.to_dict()` docstring** expanded to list all four serialised sub-configs and the round-trip contract.

## Checklist

- [x] Tests added or updated for every new/changed public function
- [x] `make ci` passes locally (fmt + lint + type + test + example + demo)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docstrings added for all new public APIs (Google-style)
- [x] Every modified module stays ≤ 300 lines (or a decomposition issue is linked above)
- [x] Related issue linked in the summary above
- [x] Agent-facing docs updated if pipeline, API, or conventions changed

## Notes for reviewers

**Type checking:** `mypy src/` reports 1 pre-existing error in `adapters/fastmcp.py:252` (`Client` overload mismatch) that predates this PR. All files touched by this PR are error-free.

**`StoreBundle.to_dict()`:** Uses `hasattr(store, "to_dict")` guard since the field type is now a protocol (which doesn't declare `to_dict`). Custom backend implementations that don't provide `to_dict` serialise as `None` — `to_dict()`/`from_dict()` docstrings make the round-trip data-loss explicit so it doesn't surprise users.

**One minor breaking change for direct `config` callers:** `from contextweaver.config import RoutingConfig, ProfileConfig` no longer works (the bottom-of-file re-export was dropped to remove the circular-import smell). Use `from contextweaver import RoutingConfig, ProfileConfig` (recommended) or `from contextweaver.profiles import RoutingConfig, ProfileConfig`. All other public paths are unchanged. Exception-type changes (`ValueError` → custom) are technically breaking for callers catching `ValueError` specifically, but `ContextWeaverError` subclasses remain catchable via `except Exception` or `except ContextWeaverError`.

**Verification (post-`6a0bee0`):**
```
ruff format --check src/ tests/ examples/   → 90 files already formatted
ruff check src/ tests/ examples/            → All checks passed
mypy src/ --no-incremental                  → 1 pre-existing error (fastmcp.py), 0 in changed files
pytest -q                                   → 621 passed in 8.06s
python -m contextweaver demo                → Demo complete (exit 0)
python examples/*.py                        → 9/9 exit 0
```

**Files changed (17 after follow-up):**

*Source:*
- `src/contextweaver/config.py` — serde methods on `ContextBudget` / `ContextPolicy` / `ScoringConfig` (212 lines; circular re-export removed)
- `src/contextweaver/profiles.py` — **new** `RoutingConfig` / `ProfileConfig` (162 lines; expanded `ProfileConfig.to_dict` docstring)
- `src/contextweaver/protocols.py` — kept: `TokenEstimator`, `EventHook`, `Summarizer`, `Extractor`, `RedactionHook`, `Labeler` (192 lines; store protocols re-exported via alias)
- `src/contextweaver/store/protocols.py` — **new** `EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore` protocols (230 lines)
- `src/contextweaver/context/manager.py` — `dedup_threshold` passthrough; protocol types
- `src/contextweaver/context/sensitivity.py` — exception types
- `src/contextweaver/routing/router.py` — `ConfigError`; import migrated to `contextweaver.profiles`
- `src/contextweaver/store/bundle.py` — protocol field types; `to_dict`/`from_dict` docstrings
- `src/contextweaver/__init__.py` — export `EpisodicStore`, `FactStore`, `profiles` submodule, `ProfileConfig`/`RoutingConfig` from `contextweaver.profiles`

*Tests:*
- `tests/test_config.py` — 12 new round-trip tests; imports migrated
- `tests/test_dedup.py` — custom threshold test (Jaccard ≈ 0.89; strict-inequality assertion)
- `tests/test_protocols.py` — `EpisodicStore`/`FactStore` conformance tests
- `tests/test_router.py` — `ConfigError` assertion; imports migrated
- `tests/test_sensitivity.py` — `PolicyViolationError`/`ConfigError` assertions

*Docs/config:*
- `docs/troubleshooting.md` — Issue 5 updated
- `AGENTS.md` — module map updated (`profiles.py` + `store/protocols.py` entries)
- `CHANGELOG.md` — `[Unreleased]` section
