### PR TITLE
feat(infra): hybrid core deps + extras, metrics/OTel/YAML/BM25/fuzzy retrieval

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,7 +46,7 @@ violate these boundaries will be rejected. Before modifying code, check:
 - **Routing Engine** — sync-only, pure computation. Do not make async.
 - **Sensitivity enforcement** (`context/sensitivity.py`) — security-grade code.
   Never weaken defaults. See `.github/instructions/sensitivity.instructions.md`.
-- **Zero runtime deps** in core (`install_requires` is empty). Optional extras are acceptable.
+- **Minimal core runtime deps.** Core install: `tiktoken`, `PyYAML`, `rank-bm25`. Heavy or runtime-specific packages live under optional extras (`[cli]`, `[otel]`, `[retrieval]`, `[ann]`, `[graph]`, `[fastmcp]`, `[langchain]`) and use guarded imports. New core deps require broad ecosystem use + small wheel + a default the library would otherwise approximate.
 
 ## Canonical References
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ These are strongly recommended. Engineering judgment applies — deviate with go
 - **Google-style docstrings** on all public classes and functions.
 - **100-character line length** (enforced by ruff).
 - **≤ 300 lines per module** — exempt: `types.py`, `envelope.py`, `__main__.py`.
-- **Zero runtime dependencies** in core (`install_requires` is empty). Optional dependency groups via extras (e.g., `[dev]`) are acceptable.
+- **Minimal core runtime dependencies.** The core install pulls only `tiktoken`, `PyYAML`, and `rank-bm25` — each is broadly used in GenAI stacks and unblocks default behaviour. Adding a new core dependency requires explicit justification: broad ecosystem use, small wheel, and a default the library would otherwise have to approximate. Heavy or runtime-specific packages (CLI, OpenTelemetry, fuzzy retrieval, ANN, NetworkX, FastMCP, LangChain) live under `[project.optional-dependencies]` and are loaded via guarded imports.
 
 ## Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Minimal core dependencies and extras infrastructure** (#49, #50, #54, #55)
+  - `pyproject.toml` `dependencies = ["tiktoken>=0.5", "PyYAML>=6.0", "rank-bm25>=0.2"]`
+    — three small, broadly-used packages that unblock default behaviour the library
+    would otherwise have to approximate (exact token counts, YAML configs, BM25 retrieval).
+  - New optional extras: `[cli]` (typer + rich), `[retrieval]` (rapidfuzz),
+    `[ann]` (hnswlib, reserved), `[otel]` (opentelemetry), `[graph]` (networkx, reserved),
+    `[all]` (union convenience).
+  - mypy overrides for every new optional package so missing extras don't break type checks.
+- **YAML catalog and graph support** (#54)
+  - `contextweaver.routing.catalog.load_catalog_yaml()` — load a catalog from a YAML file.
+  - `contextweaver.routing.catalog.load_catalog()` — auto-detect JSON vs. YAML by file
+    extension (`.yaml` / `.yml` → YAML, anything else → JSON).
+  - `save_graph()` / `load_graph()` in `routing.graph_io` now auto-detect format from
+    the file extension and emit deterministic YAML (`sort_keys=True`).
+  - `examples/sample_catalog.yaml` — runnable YAML version of `sample_catalog.json`.
+- **BM25 and fuzzy retrieval backends** (#55)
+  - `contextweaver._utils.BM25Scorer` — BM25 scorer backed by `rank-bm25` (core dep);
+    same `fit` / `score` / `score_all` interface as `TfIdfScorer`.
+  - `contextweaver._utils.FuzzyScorer` — fuzzy string-similarity scorer backed by
+    `rapidfuzz`; available when `contextweaver[retrieval]` is installed,
+    `FuzzyScorer is None` otherwise.
+  - `Router(scorer_backend="bm25" | "tfidf" | "fuzzy")` — keyword-only parameter to
+    select a scorer by name; default remains `"tfidf"` for backward compatibility.
+    Unknown backend names raise `ConfigError`.
+- **Production observability primitives** (#10)
+  - New `contextweaver.metrics` module with `MetricsCollector` (thread-safe
+    accumulator with `summary()` + `reset()`) and `MetricsHook` (concrete
+    `EventHook` implementation that feeds a collector).
+  - `ContextManager(metrics=...)` — optional `MetricsCollector` parameter; when
+    present, full `RouteResult` is recorded after every routing call (capturing
+    candidate count, top score, and confidence gap).
+  - `ContextManager.metrics` property exposes the configured collector (or `None`).
+  - Counters tracked: total builds, total routes, total prompt tokens, dedup
+    removals, firewall interceptions, items excluded, budget overruns, and a
+    merged `drop_reasons` map.
+- **OpenTelemetry integration** (#57)
+  - New `contextweaver.extras.otel.OTelEventHook` — `EventHook` implementation
+    that emits OTel spans (`contextweaver.context.build`, `contextweaver.context.firewall`,
+    `contextweaver.context.exclude`, `contextweaver.routing.route`) and metrics
+    (`contextweaver.tokens.used` gauge, `contextweaver.firewall.interceptions` counter,
+    `contextweaver.items.excluded` counter, `contextweaver.budget.exceeded` counter,
+    `contextweaver.routing.candidates` histogram).
+  - Available via `pip install 'contextweaver[otel]'`. Importing the module
+    without the extra raises an `ImportError` carrying the exact install hint.
+- **Enhanced CLI rendering via `[cli]` extra** (#52)
+  - `__main__.py` `print-tree` subcommand uses `rich.tree` for coloured output
+    when typer + rich are installed (`pip install 'contextweaver[cli]'`);
+    stdlib argparse + plain ASCII path remains byte-identical when the extra
+    is absent.
+- **Public API exports**
+  - Top-level: `MetricsCollector`, `MetricsHook`, `BM25Scorer`, `FuzzyScorer`,
+    `load_catalog`, `load_catalog_yaml`.
+
+### Changed
+
+- **Documentation: minimal-core-deps reframe** (#53)
+  - README front-matter: `"zero runtime dependencies"` → `"minimal core dependencies"`,
+    `"deterministic output"` → `"deterministic by default"`.
+  - README installation section gains an extras table covering every optional
+    capability shipped today.
+  - `AGENTS.md` style rule rewritten: zero core runtime deps + extras model;
+    new core deps require broad ecosystem use, small wheel, and unblocked
+    default behaviour.
+  - `CONTRIBUTING.md` and `.github/copilot-instructions.md` updated to match.
+- `TiktokenEstimator` simplified — `tiktoken` is now a core dep, so the
+  try/except-stub fallback is gone. The estimator still degrades gracefully
+  to `CharDivFourEstimator` when the tiktoken encoding download fails (offline
+  / air-gapped environments) and logs a warning naming `TIKTOKEN_CACHE_DIR`
+  as the workaround.
+
+### Notes
+
+- `_utils.py` (392 lines), `routing/catalog.py` (410 lines) and `routing/router.py`
+  (~400 lines) are over the 300-line module guideline. These files were already
+  approaching or over the limit before this PR; decomposition is tracked under
+  the routing-pipeline epic (#56).
+- `EventHook.on_route_completed` retains its `list[str]` (tool ids) signature for
+  backward compatibility. Full `RouteResult` metrics (top score, confidence gap)
+  flow through `ContextManager.metrics` instead of the hook.
+
 ## [0.2.0] - 2026-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `pyproject.toml` `dependencies = ["tiktoken>=0.5", "PyYAML>=6.0", "rank-bm25>=0.2"]`
     — three small, broadly-used packages that unblock default behaviour the library
     would otherwise have to approximate (exact token counts, YAML configs, BM25 retrieval).
-  - New optional extras: `[cli]` (typer + rich), `[retrieval]` (rapidfuzz),
+  - New optional extras: `[cli]` (rich), `[retrieval]` (rapidfuzz),
     `[ann]` (hnswlib, reserved), `[otel]` (opentelemetry), `[graph]` (networkx, reserved),
     `[all]` (union convenience).
   - mypy overrides for every new optional package so missing extras don't break type checks.
@@ -49,14 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New `contextweaver.extras.otel.OTelEventHook` — `EventHook` implementation
     that emits OTel spans (`contextweaver.context.build`, `contextweaver.context.firewall`,
     `contextweaver.context.exclude`, `contextweaver.routing.route`) and metrics
-    (`contextweaver.tokens.used` gauge, `contextweaver.firewall.interceptions` counter,
+    (`contextweaver.tokens.used` histogram, `contextweaver.firewall.interceptions` counter,
     `contextweaver.items.excluded` counter, `contextweaver.budget.exceeded` counter,
     `contextweaver.routing.candidates` histogram).
   - Available via `pip install 'contextweaver[otel]'`. Importing the module
     without the extra raises an `ImportError` carrying the exact install hint.
 - **Enhanced CLI rendering via `[cli]` extra** (#52)
   - `__main__.py` `print-tree` subcommand uses `rich.tree` for coloured output
-    when typer + rich are installed (`pip install 'contextweaver[cli]'`);
+    when rich is installed (`pip install 'contextweaver[cli]'`);
     stdlib argparse + plain ASCII path remains byte-identical when the extra
     is absent.
 - **Public API exports**
@@ -223,6 +223,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PolicyViolationError` / `ConfigError` (#183)
 - Replaced bare `ValueError` in `routing/router.py` (`confidence_gap` validation)
   with `ConfigError` (#183)
+- `BM25Scorer.fit()` now feeds `BM25Okapi` a per-document token list that
+  preserves term frequency. The previous implementation called
+  `sorted(tokenize(doc))` on a `set`, which collapsed duplicates and degraded
+  BM25 to a binary-match scorer. A new `contextweaver._utils.tokenize_list()`
+  helper applies the same normalisation pipeline as `tokenize()` but returns
+  a `list[str]`; `tokenize()` now delegates to it for the unique-set view.
+  (review #188)
+- `MetricsCollector` no longer accumulates per-route values in unbounded
+  lists. Route-level statistics are tracked as running sums + maxima so
+  memory stays O(1) in long-running processes. `summary()` keys are
+  preserved and gain three new entries (`max_candidates_per_route`,
+  `max_top_score`, `max_confidence_gap`). (review #188)
+- `OTelEventHook` now records `contextweaver.tokens.used` as a histogram
+  instead of a gauge. The synchronous `create_gauge` instrument only
+  landed in `opentelemetry-api>=1.27`, but the `[otel]` extra pins
+  `>=1.20`. Histograms are portable across the entire supported range and
+  give callers per-build token distributions instead of a latest-value
+  cache. (review #188)
 
 ### Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,12 @@ All CI checks must pass before a PR can be merged.
 ## Style guide
 
 - **Python ≥ 3.10** — use `X | Y` union syntax, `match` statements where appropriate.
-- **Zero runtime dependencies** — do not add any `install_requires` entries.
+- **Minimal core runtime dependencies** — the core ships with `tiktoken`, `PyYAML`, and
+  `rank-bm25`. Adding a new entry to `dependencies` in `pyproject.toml` requires broad
+  ecosystem use, a small wheel, and a default the library would otherwise approximate.
+  Heavy or runtime-specific packages go under `[project.optional-dependencies]` (e.g.
+  `cli`, `otel`, `retrieval`, `ann`, `graph`) and must be loaded via guarded imports
+  (`try: import x ... except ImportError: ...`).
 - **Type hints everywhere** — all public functions and methods must be fully annotated.
 - **Docstrings** — use Google-style docstrings on all public classes and functions.
 - **Line length** — 100 characters maximum (enforced by ruff).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Phase-specific, budget-aware context compilation for tool-using AI agents.
 
-**500+ tests passing · zero runtime dependencies · deterministic output · Python ≥ 3.10**
+**600+ tests passing · minimal core dependencies · deterministic by default · Python ≥ 3.10**
 
 [📖 Documentation](https://dgenio.github.io/contextweaver)
 
@@ -97,6 +97,23 @@ contextweaver provides two cooperating engines:
 ```bash
 pip install contextweaver
 ```
+
+`contextweaver` ships with a minimal, opinionated core: `tiktoken`,
+`PyYAML`, and `rank-bm25`. These power accurate token budgeting, YAML
+catalog/config files, and the default lexical retrieval backend.
+
+Optional capabilities are gated behind extras so the core install stays small:
+
+| Extra | What it adds |
+|---|---|
+| `contextweaver[cli]` | Rich-formatted CLI (typer + rich) |
+| `contextweaver[retrieval]` | Fuzzy lexical matching backend (rapidfuzz) |
+| `contextweaver[otel]` | OpenTelemetry tracing + metrics export |
+| `contextweaver[ann]` | Approximate-nearest-neighbour backend (reserved) |
+| `contextweaver[graph]` | NetworkX-backed graph ops (reserved) |
+| `contextweaver[fastmcp]` | FastMCP catalog adapter |
+| `contextweaver[langchain]` | LangChain integration helpers |
+| `contextweaver[all]` | All optional capabilities |
 
 Or from source:
 
@@ -199,13 +216,14 @@ techniques, and performance optimisation tips.
 
 contextweaver is built for production use with comprehensive quality gates:
 
-- **500+ passing tests** across all modules — context pipeline, routing engine, firewall,
+- **600+ passing tests** across all modules — context pipeline, routing engine, firewall,
   adapters, stores, CLI, sensitivity enforcement
 - **mypy strict** type checking — zero errors across all source files
 - **ruff clean** linting — zero warnings
 - **CI pipeline** on every pull request and on pushes to `main` ([see workflows](.github/workflows/))
-- **Deterministic output** — tie-break by ID, sorted keys; identical inputs always produce
-  identical outputs
+- **Deterministic by default** — tie-break by ID, sorted keys; identical inputs always
+  produce identical outputs. Configurable retrieval backends (TF-IDF, BM25, fuzzy)
+  preserve determinism within each mode.
 
 Run the full suite yourself:
 
@@ -313,7 +331,7 @@ contextweaver follows [Semantic Versioning](https://semver.org/):
 - Routing Engine: Catalog, DAG builder, beam-search router, choice cards
 - Protocol adapters: MCP (full content types, structured content, output schemas) and A2A
 - Stores: `EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore` with protocol-based interfaces
-- 500+ passing tests, mypy strict, ruff clean, zero runtime dependencies
+- 600+ passing tests, mypy strict, ruff clean, minimal core dependencies
 
 **v0.2 (🚧 In Progress — Q2 2026)**
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Optional capabilities are gated behind extras so the core install stays small:
 
 | Extra | What it adds |
 |---|---|
-| `contextweaver[cli]` | Rich-formatted CLI (typer + rich) |
+| `contextweaver[cli]` | Rich-formatted CLI rendering (rich) |
 | `contextweaver[retrieval]` | Fuzzy lexical matching backend (rapidfuzz) |
 | `contextweaver[otel]` | OpenTelemetry tracing + metrics export |
 | `contextweaver[ann]` | Approximate-nearest-neighbour backend (reserved) |

--- a/examples/sample_catalog.yaml
+++ b/examples/sample_catalog.yaml
@@ -1,0 +1,63 @@
+- args_schema: {}
+  cost_hint: 0.29
+  description: Export audit log entries
+  id: admin.audit.export
+  kind: tool
+  metadata: {}
+  name: audit_export
+  namespace: admin
+  side_effects: true
+  tags:
+  - admin
+  - audit
+- args_schema: {}
+  cost_hint: 0.27
+  description: Query the audit log
+  id: admin.audit.query
+  kind: tool
+  metadata: {}
+  name: audit_query
+  namespace: admin
+  side_effects: false
+  tags:
+  - admin
+  - audit
+  - search
+- args_schema: {}
+  cost_hint: 0.0
+  description: Configure audit log retention
+  id: admin.audit.retention
+  kind: tool
+  metadata: {}
+  name: audit_retention
+  namespace: admin
+  side_effects: false
+  tags:
+  - admin
+  - audit
+- args_schema: {}
+  cost_hint: 0.25
+  description: Assign a role to a user
+  id: admin.roles.assign
+  kind: tool
+  metadata: {}
+  name: roles_assign
+  namespace: admin
+  side_effects: true
+  tags:
+  - admin
+  - roles
+  - write
+- args_schema: {}
+  cost_hint: 0.01
+  description: Create a custom role
+  id: admin.roles.create
+  kind: tool
+  metadata: {}
+  name: roles_create
+  namespace: admin
+  side_effects: false
+  tags:
+  - admin
+  - create
+  - roles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,15 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Typing :: Typed",
 ]
-dependencies = []
+# Minimal core runtime dependencies. Each entry is broadly used in GenAI stacks
+# (often already pulled in transitively) and unblocks default behaviour the
+# library would otherwise have to approximate. Heavy or runtime-specific
+# packages live under [project.optional-dependencies] below.
+dependencies = [
+    "tiktoken>=0.5",
+    "PyYAML>=6.0",
+    "rank-bm25>=0.2",
+]
 
 [project.urls]
 Homepage = "https://github.com/dgenio/contextweaver"
@@ -30,6 +38,7 @@ Repository = "https://github.com/dgenio/contextweaver"
 Changelog = "https://github.com/dgenio/contextweaver/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
+# Dev / test toolchain.
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
@@ -38,12 +47,15 @@ dev = [
     "mypy>=1.10",
     "pre-commit>=3.7",
 ]
+# FastMCP adapter integration.
 fastmcp = [
     "fastmcp>=2.0",
 ]
+# LangChain integration examples.
 langchain = [
     "langchain-core>=0.3",
 ]
+# Docs site (mkdocs).
 docs = [
     "mkdocs>=1.6",
     "mkdocs-material>=9.5",
@@ -51,6 +63,38 @@ docs = [
     "mkdocs-gen-files>=0.5",
     "mkdocs-literate-nav>=0.6",
     "mkdocs-section-index>=0.3",
+]
+# Enhanced CLI: typer-based commands with rich-formatted output (tree, tables).
+cli = [
+    "typer>=0.9",
+    "rich>=13.0",
+]
+# Fuzzy lexical retrieval backend (rapidfuzz) — supplements the default BM25
+# scorer for typo / abbreviation tolerance.
+retrieval = [
+    "rapidfuzz>=3.0",
+]
+# Approximate-nearest-neighbour backends. Reserved for future embedding-based
+# routing (#8). No functional code references these yet.
+ann = [
+    "hnswlib>=0.8",
+]
+# OpenTelemetry tracing + metrics export.
+otel = [
+    "opentelemetry-api>=1.20",
+    "opentelemetry-sdk>=1.20",
+]
+# NetworkX-backed graph ops. Reserved; no functional code references these yet.
+graph = [
+    "networkx>=3.0",
+]
+# Convenience: install every optional capability at once.
+all = [
+    "contextweaver[cli]",
+    "contextweaver[retrieval]",
+    "contextweaver[ann]",
+    "contextweaver[otel]",
+    "contextweaver[graph]",
 ]
 
 [project.scripts]
@@ -83,6 +127,30 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "fastmcp"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "rank_bm25"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "yaml"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "rapidfuzz.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "opentelemetry.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "rich.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "typer.*"
 ignore_missing_imports = true
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,10 @@ docs = [
     "mkdocs-literate-nav>=0.6",
     "mkdocs-section-index>=0.3",
 ]
-# Enhanced CLI: typer-based commands with rich-formatted output (tree, tables).
+# Enhanced CLI: rich-formatted output (tree, tables) for the existing argparse CLI.
+# A typer-based rewrite of __main__.py is tracked separately under the v0.6 milestone;
+# do not add typer here until that work lands so the extra reflects what users actually get.
 cli = [
-    "typer>=0.9",
     "rich>=13.0",
 ]
 # Fuzzy lexical retrieval backend (rapidfuzz) — supplements the default BM25

--- a/src/contextweaver/__init__.py
+++ b/src/contextweaver/__init__.py
@@ -21,7 +21,7 @@ Quick start::
 from __future__ import annotations
 
 from contextweaver import config, envelope, exceptions, protocols, types
-from contextweaver._utils import TfIdfScorer, jaccard
+from contextweaver._utils import BM25Scorer, FuzzyScorer, TfIdfScorer, jaccard
 from contextweaver.config import (
     ContextBudget,
     ContextPolicy,
@@ -51,6 +51,7 @@ from contextweaver.exceptions import (
     PolicyViolationError,
     RouteError,
 )
+from contextweaver.metrics import MetricsCollector, MetricsHook
 from contextweaver.protocols import (
     EventHook,
     Extractor,
@@ -63,8 +64,10 @@ from contextweaver.routing.cards import make_choice_cards, render_cards_text
 from contextweaver.routing.catalog import (
     Catalog,
     generate_sample_catalog,
+    load_catalog,
     load_catalog_dicts,
     load_catalog_json,
+    load_catalog_yaml,
 )
 from contextweaver.routing.graph import ChoiceGraph
 from contextweaver.routing.graph_node import ChoiceNode
@@ -100,6 +103,8 @@ __all__ = [
     "protocols",
     "types",
     # utilities
+    "BM25Scorer",
+    "FuzzyScorer",
     "TfIdfScorer",
     "jaccard",
     # types / enums
@@ -153,6 +158,9 @@ __all__ = [
     "drilldown_tool_spec",
     "generate_views",
     "register_redaction_hook",
+    # observability
+    "MetricsCollector",
+    "MetricsHook",
     # routing engine
     "Catalog",
     "ChoiceGraph",
@@ -162,8 +170,10 @@ __all__ = [
     "Router",
     "TreeBuilder",
     "generate_sample_catalog",
+    "load_catalog",
     "load_catalog_dicts",
     "load_catalog_json",
+    "load_catalog_yaml",
     "make_choice_cards",
     "render_cards_text",
     # summarize

--- a/src/contextweaver/__main__.py
+++ b/src/contextweaver/__main__.py
@@ -17,6 +17,16 @@ Invocable as ``python -m contextweaver`` or ``contextweaver`` (via
 from __future__ import annotations
 
 import argparse
+
+# `[cli]` extra adds rich-formatted output. Guarded import keeps the CLI
+# fully functional with stdlib-only argparse when the extra is absent.
+try:
+    from rich.console import Console as _RichConsole
+    from rich.tree import Tree as _RichTree
+
+    _HAS_RICH = True
+except ImportError:  # pragma: no cover - exercised only when extra is missing
+    _HAS_RICH = False
 import json
 import sys
 from pathlib import Path
@@ -210,17 +220,51 @@ def _cmd_route(args: argparse.Namespace) -> int:
 
 
 def _cmd_print_tree(args: argparse.Namespace) -> int:
-    """Pretty-print the routing tree for a graph."""
+    """Pretty-print the routing tree for a graph.
+
+    Uses ``rich.tree`` for coloured output when the ``[cli]`` extra is
+    installed; falls back to plain ASCII otherwise.
+    """
     graph_path: str = args.graph
     max_depth: int = args.depth
 
     graph = load_graph(graph_path)
+    items_set = set(graph.items())
 
+    if _HAS_RICH:
+        console = _RichConsole()
+
+        def _build_rich(node_id: str, depth: int) -> _RichTree:
+            node = graph.get_node(node_id)
+            is_item = node_id in items_set
+            label = node.label or node_id
+            if is_item:
+                rendered = f"[bold green]* {label}[/bold green]"
+            else:
+                hint = f"  [dim]({node.routing_hint})[/dim]" if node.routing_hint else ""
+                rendered = f"[bold cyan]> {label}[/bold cyan]{hint}"
+            tree = _RichTree(rendered)
+            if depth < max_depth:
+                for child in graph.successors(node_id):
+                    tree.add(_build_rich(child, depth + 1))
+            return tree
+
+        console.print(f"[bold]Routing tree (depth={max_depth}):[/bold]")
+        console.print(_build_rich(graph.root_id, 0))
+        stats = graph.stats()
+        console.print(
+            f"\n[dim]Stats: {stats['total_nodes']} nodes,"
+            f" {stats['total_items']} items,"
+            f" depth={stats['max_depth']}[/dim]"
+        )
+        return 0
+
+    # Stdlib fallback (existing behaviour, byte-for-byte compatible).
     def _print_node(node_id: str, depth: int, prefix: str = "") -> None:
         if depth > max_depth:
             return
         node = graph.get_node(node_id)
-        is_item = node_id in set(graph.items())
+        is_item = node_id in items_set
         marker = "*" if is_item else ">"
         label = node.label or node_id
         hint = f" - {node.routing_hint}" if node.routing_hint and not is_item else ""

--- a/src/contextweaver/_utils.py
+++ b/src/contextweaver/_utils.py
@@ -8,7 +8,10 @@ Public API:
     - :data:`STOPWORDS` — frozen set of ~100 common English stop-words
     - :func:`tokenize` — normalise + tokenise a string to a ``set[str]``
     - :func:`jaccard` — Jaccard similarity between two token sets
-    - :class:`TfIdfScorer` — lightweight, deterministic TF-IDF scorer
+    - :class:`TfIdfScorer` — pure-Python deterministic TF-IDF scorer
+    - :class:`BM25Scorer` — BM25 scorer backed by ``rank-bm25`` (core dep)
+    - :class:`FuzzyScorer` — fuzzy scorer backed by ``rapidfuzz``
+      (``contextweaver[retrieval]`` extra; ``None`` when missing)
 """
 
 from __future__ import annotations
@@ -285,3 +288,103 @@ class TfIdfScorer:
             A ``list[float]`` of scores, one per document, in corpus order.
         """
         return [self.score(query, i) for i in range(len(self._documents))]
+
+
+# ---------------------------------------------------------------------------
+# BM25 scorer (rank-bm25 is a core dep)
+# ---------------------------------------------------------------------------
+
+
+class BM25Scorer:
+    """BM25 scorer backed by the ``rank-bm25`` library.
+
+    BM25 typically outperforms raw TF-IDF on lexical retrieval because of
+    term-frequency saturation and document-length normalisation. The same
+    interface as :class:`TfIdfScorer` (``fit`` / ``score`` / ``score_all``)
+    so the two are interchangeable in :class:`~contextweaver.routing.router.Router`.
+
+    Determinism: ``rank-bm25`` is deterministic for a fixed corpus + query.
+    Tokens are sorted before indexing to keep the corpus order stable.
+    """
+
+    def __init__(self) -> None:
+        from rank_bm25 import BM25Okapi  # core dep
+
+        self._bm25_cls = BM25Okapi
+        self._bm25: BM25Okapi | None = None
+        self._n_docs: int = 0
+
+    def fit(self, documents: list[str]) -> None:
+        """Index *documents* with BM25.
+
+        Args:
+            documents: Raw text strings; index order is preserved as
+                ``doc_index`` in subsequent calls to :meth:`score`.
+        """
+        corpus = [sorted(tokenize(doc)) for doc in documents]
+        self._n_docs = len(documents)
+        # rank_bm25 raises on empty corpora; guard with a sentinel.
+        self._bm25 = self._bm25_cls(corpus) if corpus else None
+
+    def score(self, query: str, doc_index: int) -> float:
+        """Return the BM25 score of *query* against the document at *doc_index*."""
+        if self._bm25 is None:
+            return 0.0
+        if doc_index < 0 or doc_index >= self._n_docs:
+            raise IndexError(f"doc_index {doc_index} out of range ({self._n_docs} docs)")
+        q_tokens = sorted(tokenize(query))
+        if not q_tokens:
+            return 0.0
+        scores = self._bm25.get_scores(q_tokens)
+        return float(scores[doc_index])
+
+    def score_all(self, query: str) -> list[float]:
+        """Score *query* against every document in the corpus."""
+        if self._bm25 is None:
+            return []
+        q_tokens = sorted(tokenize(query))
+        if not q_tokens:
+            return [0.0] * self._n_docs
+        return [float(s) for s in self._bm25.get_scores(q_tokens)]
+
+
+# ---------------------------------------------------------------------------
+# Fuzzy scorer (rapidfuzz; contextweaver[retrieval] extra)
+# ---------------------------------------------------------------------------
+
+try:
+    from rapidfuzz import fuzz as _rapidfuzz_fuzz
+
+    class FuzzyScorer:
+        """Fuzzy string-similarity scorer backed by ``rapidfuzz``.
+
+        Useful when queries contain typos, abbreviations, or partial matches
+        that token-set similarity would miss (``"emal"`` ↔ ``"email"``).
+        Same interface as :class:`TfIdfScorer`. Score values are normalised
+        to ``[0.0, 1.0]``.
+
+        Available only when ``contextweaver[retrieval]`` extra is installed.
+        ``FuzzyScorer is None`` otherwise.
+        """
+
+        def __init__(self) -> None:
+            self._docs: list[str] = []
+
+        def fit(self, documents: list[str]) -> None:
+            """Store *documents* for later fuzzy scoring."""
+            self._docs = list(documents)
+
+        def score(self, query: str, doc_index: int) -> float:
+            """Return the rapidfuzz token-set ratio in ``[0.0, 1.0]``."""
+            if doc_index < 0 or doc_index >= len(self._docs):
+                raise IndexError(f"doc_index {doc_index} out of range ({len(self._docs)} docs)")
+            if not query:
+                return 0.0
+            return float(_rapidfuzz_fuzz.token_set_ratio(query, self._docs[doc_index])) / 100.0
+
+        def score_all(self, query: str) -> list[float]:
+            """Score *query* against every document."""
+            return [self.score(query, i) for i in range(len(self._docs))]
+
+except ImportError:  # pragma: no cover - exercised only when extra is missing
+    FuzzyScorer = None  # type: ignore[assignment, misc]

--- a/src/contextweaver/_utils.py
+++ b/src/contextweaver/_utils.py
@@ -164,6 +164,31 @@ STOPWORDS: frozenset[str] = frozenset(
 _SPLIT_RE = re.compile(r"\W+")
 
 
+def tokenize_list(text: str) -> list[str]:
+    """Normalise *text* and return a list of meaningful tokens (preserves duplicates).
+
+    Same normalisation pipeline as :func:`tokenize`, but returns the tokens
+    in occurrence order with duplicates intact. Use this when downstream
+    code depends on term frequency (e.g. BM25 scoring). For set-style
+    operations (Jaccard, presence checks), use :func:`tokenize` instead.
+
+    Steps:
+    1. Lower-case the input.
+    2. Split on one or more non-word characters.
+    3. Discard tokens shorter than 2 characters.
+    4. Remove :data:`STOPWORDS`.
+
+    Args:
+        text: Raw input string.
+
+    Returns:
+        A ``list[str]`` of normalised, stop-word-filtered tokens in
+        occurrence order. Duplicate tokens are preserved.
+    """
+    tokens = _SPLIT_RE.split(text.lower())
+    return [t for t in tokens if len(t) >= 2 and t not in STOPWORDS]
+
+
 def tokenize(text: str) -> set[str]:
     """Normalise *text* and return a set of meaningful tokens.
 
@@ -177,10 +202,11 @@ def tokenize(text: str) -> set[str]:
         text: Raw input string.
 
     Returns:
-        A ``set[str]`` of normalised, stop-word-filtered tokens.
+        A ``set[str]`` of normalised, stop-word-filtered tokens. Duplicate
+        tokens are collapsed; use :func:`tokenize_list` when term frequency
+        matters (e.g. BM25 scoring).
     """
-    tokens = _SPLIT_RE.split(text.lower())
-    return {t for t in tokens if len(t) >= 2 and t not in STOPWORDS}
+    return set(tokenize_list(text))
 
 
 # ---------------------------------------------------------------------------
@@ -317,11 +343,15 @@ class BM25Scorer:
     def fit(self, documents: list[str]) -> None:
         """Index *documents* with BM25.
 
+        Uses :func:`tokenize_list` so duplicate terms are preserved — BM25
+        relies on per-document term frequency to compute saturation and
+        length-normalised scores.
+
         Args:
             documents: Raw text strings; index order is preserved as
                 ``doc_index`` in subsequent calls to :meth:`score`.
         """
-        corpus = [sorted(tokenize(doc)) for doc in documents]
+        corpus = [tokenize_list(doc) for doc in documents]
         self._n_docs = len(documents)
         # rank_bm25 raises on empty corpora; guard with a sentinel.
         self._bm25 = self._bm25_cls(corpus) if corpus else None
@@ -332,7 +362,7 @@ class BM25Scorer:
             return 0.0
         if doc_index < 0 or doc_index >= self._n_docs:
             raise IndexError(f"doc_index {doc_index} out of range ({self._n_docs} docs)")
-        q_tokens = sorted(tokenize(query))
+        q_tokens = tokenize_list(query)
         if not q_tokens:
             return 0.0
         scores = self._bm25.get_scores(q_tokens)
@@ -342,7 +372,7 @@ class BM25Scorer:
         """Score *query* against every document in the corpus."""
         if self._bm25 is None:
             return []
-        q_tokens = sorted(tokenize(query))
+        q_tokens = tokenize_list(query)
         if not q_tokens:
             return [0.0] * self._n_docs
         return [float(s) for s in self._bm25.get_scores(q_tokens)]

--- a/src/contextweaver/context/manager.py
+++ b/src/contextweaver/context/manager.py
@@ -28,6 +28,7 @@ from contextweaver.context.selection import select_and_pack
 from contextweaver.context.sensitivity import apply_sensitivity_filter
 from contextweaver.context.views import ViewRegistry
 from contextweaver.envelope import ContextPack, ResultEnvelope
+from contextweaver.metrics import MetricsCollector
 from contextweaver.protocols import (
     ArtifactStore,
     CharDivFourEstimator,
@@ -91,6 +92,7 @@ class ContextManager:
         stores: StoreBundle | None = None,
         summarizer: Summarizer | None = None,
         extractor: Extractor | None = None,
+        metrics: MetricsCollector | None = None,
     ) -> None:
         _stores = stores or StoreBundle()
         self._event_log: EventLog = event_log or _stores.event_log or InMemoryEventLog()
@@ -109,6 +111,7 @@ class ContextManager:
         self._view_registry: ViewRegistry = ViewRegistry()
         self._summarizer: Summarizer | None = summarizer
         self._extractor: Extractor | None = extractor
+        self._metrics: MetricsCollector | None = metrics
 
     # ------------------------------------------------------------------
     # Properties
@@ -138,6 +141,16 @@ class ContextManager:
     def view_registry(self) -> ViewRegistry:
         """The view registry for auto-generating drilldown views."""
         return self._view_registry
+
+    @property
+    def metrics(self) -> MetricsCollector | None:
+        """The optional :class:`~contextweaver.metrics.MetricsCollector`.
+
+        ``None`` unless ``metrics=`` was passed to :meth:`__init__`. When
+        present, route-level metrics are recorded automatically via
+        :meth:`MetricsCollector.record_route` after every routing call.
+        """
+        return self._metrics
 
     # ------------------------------------------------------------------
     # Ingestion helpers
@@ -681,6 +694,8 @@ class ContextManager:
         )
 
         self._hook.on_route_completed(route_result.candidate_ids)
+        if self._metrics is not None:
+            self._metrics.record_route(route_result)
         return pack, cards, route_result
 
     def build_route_prompt_sync(

--- a/src/contextweaver/extras/__init__.py
+++ b/src/contextweaver/extras/__init__.py
@@ -1,0 +1,14 @@
+"""Optional integrations gated behind ``[project.optional-dependencies]`` extras.
+
+Each module in this package imports its third-party dependency at module
+import time and surfaces a friendly ``ImportError`` (with the exact pip
+command to install it) when the extra is missing. Importing
+``contextweaver.extras`` itself does *not* trigger those imports.
+
+Currently shipped:
+
+- :mod:`contextweaver.extras.otel` — OpenTelemetry tracing + metrics
+  (``contextweaver[otel]``).
+"""
+
+from __future__ import annotations

--- a/src/contextweaver/extras/otel.py
+++ b/src/contextweaver/extras/otel.py
@@ -1,0 +1,120 @@
+"""OpenTelemetry integration for contextweaver.
+
+Provides :class:`OTelEventHook` — an :class:`~contextweaver.protocols.EventHook`
+implementation that emits OpenTelemetry spans and metrics for every context
+build, firewall trigger, item exclusion, budget overrun, and routing call.
+
+This module requires the ``[otel]`` optional extra::
+
+    pip install 'contextweaver[otel]'
+
+Without that extra, importing this module raises :class:`ImportError` with
+the exact install hint above. The rest of contextweaver works unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from contextweaver.envelope import ContextPack
+    from contextweaver.types import ContextItem
+
+
+try:
+    from opentelemetry import metrics as _otel_metrics
+    from opentelemetry import trace as _otel_trace
+except ImportError as _otel_import_err:  # pragma: no cover - exercised only when extra is missing
+    raise ImportError(
+        "OpenTelemetry integration requires the [otel] extra. "
+        "Install with: pip install 'contextweaver[otel]'"
+    ) from _otel_import_err
+
+
+class OTelEventHook:
+    """:class:`~contextweaver.protocols.EventHook` that emits OTel spans + metrics.
+
+    Pass an instance to :class:`~contextweaver.context.manager.ContextManager`
+    via ``hook=``; spans are created for build / firewall / route events and
+    metrics are exported to whatever OTel backend you have configured
+    (Jaeger, Honeycomb, Datadog, console exporter, …).
+
+    Span names emitted:
+
+    - ``contextweaver.context.build`` — one span per :meth:`ContextManager.build`
+    - ``contextweaver.context.firewall`` — one span per firewall interception
+    - ``contextweaver.context.exclude`` — one span per item-exclusion event
+    - ``contextweaver.routing.route`` — one span per routing call
+
+    Metrics emitted:
+
+    - ``contextweaver.tokens.used`` (gauge) — prompt tokens for the build
+    - ``contextweaver.firewall.interceptions`` (counter) — total intercepts
+    - ``contextweaver.items.excluded`` (counter) — total items dropped
+    - ``contextweaver.budget.exceeded`` (counter) — over-budget events
+    - ``contextweaver.routing.candidates`` (histogram) — candidates returned
+    """
+
+    def __init__(self, service_name: str = "contextweaver") -> None:
+        """Initialise tracer + meter for the given service name."""
+        self._tracer = _otel_trace.get_tracer(service_name)
+        self._meter = _otel_metrics.get_meter(service_name)
+        self._tokens_gauge: Any = self._meter.create_gauge("contextweaver.tokens.used")
+        self._firewall_counter: Any = self._meter.create_counter(
+            "contextweaver.firewall.interceptions"
+        )
+        self._exclude_counter: Any = self._meter.create_counter("contextweaver.items.excluded")
+        self._budget_counter: Any = self._meter.create_counter("contextweaver.budget.exceeded")
+        self._candidates_hist: Any = self._meter.create_histogram(
+            "contextweaver.routing.candidates"
+        )
+
+    def on_context_built(self, pack: ContextPack) -> None:
+        """Record a span + tokens-used gauge for one build."""
+        stats = pack.stats
+        prompt_tokens = sum(stats.tokens_per_section.values()) + stats.header_footer_tokens
+        attrs: dict[str, Any] = {
+            "phase": pack.phase.value,
+            "tokens": prompt_tokens,
+            "candidates": stats.total_candidates,
+            "included": stats.included_count,
+            "dropped": stats.dropped_count,
+            "dedup_removed": stats.dedup_removed,
+        }
+        with self._tracer.start_as_current_span("contextweaver.context.build", attributes=attrs):
+            pass
+        self._tokens_gauge.set(prompt_tokens, attributes={"phase": pack.phase.value})
+
+    def on_firewall_triggered(self, item: ContextItem, reason: str) -> None:
+        """Record a span + counter increment for one firewall interception."""
+        with self._tracer.start_as_current_span(
+            "contextweaver.context.firewall",
+            attributes={"reason": reason, "item_kind": item.kind.value},
+        ):
+            pass
+        self._firewall_counter.add(1, attributes={"reason": reason})
+
+    def on_items_excluded(self, items: list[ContextItem], reason: str) -> None:
+        """Record a span + counter increment for one exclusion batch."""
+        with self._tracer.start_as_current_span(
+            "contextweaver.context.exclude",
+            attributes={"reason": reason, "count": len(items)},
+        ):
+            pass
+        self._exclude_counter.add(len(items), attributes={"reason": reason})
+
+    def on_budget_exceeded(self, requested: int, budget: int) -> None:
+        """Increment the budget-exceeded counter with the overrun ratio."""
+        self._budget_counter.add(
+            1,
+            attributes={"requested": requested, "budget": budget},
+        )
+
+    def on_route_completed(self, tool_ids: list[str]) -> None:
+        """Record a span + candidates-histogram observation for one route."""
+        with self._tracer.start_as_current_span(
+            "contextweaver.routing.route",
+            attributes={"candidate_count": len(tool_ids)},
+        ):
+            pass
+        self._candidates_hist.record(len(tool_ids))

--- a/src/contextweaver/extras/otel.py
+++ b/src/contextweaver/extras/otel.py
@@ -48,7 +48,7 @@ class OTelEventHook:
 
     Metrics emitted:
 
-    - ``contextweaver.tokens.used`` (gauge) — prompt tokens for the build
+    - ``contextweaver.tokens.used`` (histogram) — prompt tokens per build
     - ``contextweaver.firewall.interceptions`` (counter) — total intercepts
     - ``contextweaver.items.excluded`` (counter) — total items dropped
     - ``contextweaver.budget.exceeded`` (counter) — over-budget events
@@ -56,10 +56,18 @@ class OTelEventHook:
     """
 
     def __init__(self, service_name: str = "contextweaver") -> None:
-        """Initialise tracer + meter for the given service name."""
+        """Initialise tracer + meter for the given service name.
+
+        ``contextweaver.tokens.used`` is recorded as a histogram so it stays
+        portable across all ``opentelemetry-api>=1.20`` releases — the
+        synchronous ``create_gauge`` instrument only landed in 1.27, and an
+        observable gauge would force callers to keep a global "latest
+        value" cache. Histograms record per-build distributions which is
+        usually the more useful surface for dashboards anyway.
+        """
         self._tracer = _otel_trace.get_tracer(service_name)
         self._meter = _otel_metrics.get_meter(service_name)
-        self._tokens_gauge: Any = self._meter.create_gauge("contextweaver.tokens.used")
+        self._tokens_hist: Any = self._meter.create_histogram("contextweaver.tokens.used")
         self._firewall_counter: Any = self._meter.create_counter(
             "contextweaver.firewall.interceptions"
         )
@@ -70,7 +78,7 @@ class OTelEventHook:
         )
 
     def on_context_built(self, pack: ContextPack) -> None:
-        """Record a span + tokens-used gauge for one build."""
+        """Record a span + tokens-used histogram observation for one build."""
         stats = pack.stats
         prompt_tokens = sum(stats.tokens_per_section.values()) + stats.header_footer_tokens
         attrs: dict[str, Any] = {
@@ -83,7 +91,7 @@ class OTelEventHook:
         }
         with self._tracer.start_as_current_span("contextweaver.context.build", attributes=attrs):
             pass
-        self._tokens_gauge.set(prompt_tokens, attributes={"phase": pack.phase.value})
+        self._tokens_hist.record(prompt_tokens, attributes={"phase": pack.phase.value})
 
     def on_firewall_triggered(self, item: ContextItem, reason: str) -> None:
         """Record a span + counter increment for one firewall interception."""

--- a/src/contextweaver/metrics.py
+++ b/src/contextweaver/metrics.py
@@ -41,7 +41,13 @@ logger = logging.getLogger("contextweaver.metrics")
 
 @dataclass
 class _Counters:
-    """Internal mutable counter state for :class:`MetricsCollector`."""
+    """Internal mutable counter state for :class:`MetricsCollector`.
+
+    Per-route statistics are stored as running sums rather than per-call
+    lists so memory stays O(1) in long-running processes. Averages are
+    derived from ``<sum> / total_routes`` at :meth:`summary` time; running
+    maxima are tracked separately for inspection.
+    """
 
     total_builds: int = 0
     total_routes: int = 0
@@ -52,9 +58,13 @@ class _Counters:
     items_excluded: int = 0
     budget_exceeded: int = 0
     drop_reasons: dict[str, int] = field(default_factory=dict)
-    route_candidate_counts: list[int] = field(default_factory=list)
-    route_top_scores: list[float] = field(default_factory=list)
-    route_confidence_gaps: list[float] = field(default_factory=list)
+    # Running sums + maxima for the route stream — O(1) memory.
+    route_candidate_count_sum: int = 0
+    route_candidate_count_max: int = 0
+    route_top_score_sum: float = 0.0
+    route_top_score_max: float = 0.0
+    route_confidence_gap_sum: float = 0.0
+    route_confidence_gap_max: float = 0.0
 
 
 class MetricsCollector:
@@ -119,16 +129,24 @@ class MetricsCollector:
         """Aggregate stats from one route call.
 
         Captures candidate count, top score, and the confidence gap between
-        rank-1 and rank-2 (zero when fewer than two candidates).
+        rank-1 and rank-2 (zero when fewer than two candidates). Stored as
+        running sums + maxima so memory stays O(1) regardless of how many
+        routes are recorded.
         """
         candidate_count = len(result.candidate_ids)
         top_score = result.scores[0] if result.scores else 0.0
         gap = (result.scores[0] - result.scores[1]) if len(result.scores) >= 2 else 0.0
         with self._lock:
             self._c.total_routes += 1
-            self._c.route_candidate_counts.append(candidate_count)
-            self._c.route_top_scores.append(top_score)
-            self._c.route_confidence_gaps.append(gap)
+            self._c.route_candidate_count_sum += candidate_count
+            self._c.route_top_score_sum += top_score
+            self._c.route_confidence_gap_sum += gap
+            if candidate_count > self._c.route_candidate_count_max:
+                self._c.route_candidate_count_max = candidate_count
+            if top_score > self._c.route_top_score_max:
+                self._c.route_top_score_max = top_score
+            if gap > self._c.route_confidence_gap_max:
+                self._c.route_confidence_gap_max = gap
         if self._log_each:
             logger.info(
                 "route: candidates=%d top_score=%.4f gap=%.4f",
@@ -165,18 +183,10 @@ class MetricsCollector:
         with self._lock:
             c = self._c
             avg_prompt_tokens = c.total_prompt_tokens / c.total_builds if c.total_builds else 0.0
-            avg_candidates = (
-                sum(c.route_candidate_counts) / len(c.route_candidate_counts)
-                if c.route_candidate_counts
-                else 0.0
-            )
-            avg_top_score = (
-                sum(c.route_top_scores) / len(c.route_top_scores) if c.route_top_scores else 0.0
-            )
+            avg_candidates = c.route_candidate_count_sum / c.total_routes if c.total_routes else 0.0
+            avg_top_score = c.route_top_score_sum / c.total_routes if c.total_routes else 0.0
             avg_confidence_gap = (
-                sum(c.route_confidence_gaps) / len(c.route_confidence_gaps)
-                if c.route_confidence_gaps
-                else 0.0
+                c.route_confidence_gap_sum / c.total_routes if c.total_routes else 0.0
             )
             return {
                 "avg_candidates_per_route": round(avg_candidates, 4),
@@ -187,6 +197,9 @@ class MetricsCollector:
                 "drop_reasons": dict(sorted(c.drop_reasons.items())),
                 "firewall_interceptions": c.firewall_interceptions,
                 "items_excluded": c.items_excluded,
+                "max_candidates_per_route": c.route_candidate_count_max,
+                "max_confidence_gap": round(c.route_confidence_gap_max, 4),
+                "max_top_score": round(c.route_top_score_max, 4),
                 "total_builds": c.total_builds,
                 "total_dedup_removed": c.total_dedup_removed,
                 "total_dropped": c.total_dropped,

--- a/src/contextweaver/metrics.py
+++ b/src/contextweaver/metrics.py
@@ -1,0 +1,251 @@
+"""Production observability primitives for contextweaver.
+
+This module provides a stdlib-only metrics layer that aggregates statistics
+across many context builds and routing calls — enough to answer questions
+like "how many tokens am I saving per build?", "what's the top-k hit rate?",
+or "how often does the firewall trigger?".
+
+Two pieces:
+
+- :class:`MetricsCollector` — thread-safe accumulator with a JSON-serialisable
+  :meth:`MetricsCollector.summary` snapshot and a :meth:`MetricsCollector.reset`.
+- :class:`MetricsHook` — concrete :class:`~contextweaver.protocols.EventHook`
+  implementation that wires its callbacks into a :class:`MetricsCollector`.
+  Drop-in replacement for :class:`~contextweaver.protocols.NoOpHook`.
+
+For full routing-level metrics (confidence gap, candidate count) wire a
+:class:`MetricsCollector` directly into :class:`~contextweaver.context.manager.ContextManager`
+via the ``metrics=`` parameter — that path receives the full
+:class:`~contextweaver.routing.router.RouteResult`.
+
+For OpenTelemetry export, install the ``[otel]`` extra and use
+:class:`~contextweaver.extras.otel.OTelEventHook` instead of (or alongside)
+:class:`MetricsHook`.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from contextweaver.envelope import ContextPack
+    from contextweaver.routing.router import RouteResult
+    from contextweaver.types import ContextItem
+
+
+logger = logging.getLogger("contextweaver.metrics")
+
+
+@dataclass
+class _Counters:
+    """Internal mutable counter state for :class:`MetricsCollector`."""
+
+    total_builds: int = 0
+    total_routes: int = 0
+    total_prompt_tokens: int = 0
+    total_dropped: int = 0
+    total_dedup_removed: int = 0
+    firewall_interceptions: int = 0
+    items_excluded: int = 0
+    budget_exceeded: int = 0
+    drop_reasons: dict[str, int] = field(default_factory=dict)
+    route_candidate_counts: list[int] = field(default_factory=list)
+    route_top_scores: list[float] = field(default_factory=list)
+    route_confidence_gaps: list[float] = field(default_factory=list)
+
+
+class MetricsCollector:
+    """Thread-safe accumulator for context-build and routing metrics.
+
+    Every counter is updated under a single :class:`threading.Lock` so the
+    collector can be shared across worker threads (e.g. an async pipeline
+    with a thread-pool executor).
+
+    Use :meth:`record_build` for context-build outcomes (typically driven by
+    :meth:`MetricsHook.on_context_built`) and :meth:`record_route` for
+    routing outcomes (driven from :class:`ContextManager` to capture the
+    full :class:`~contextweaver.routing.router.RouteResult`).
+
+    Call :meth:`summary` for a JSON-serialisable snapshot and :meth:`reset`
+    to zero every counter.
+    """
+
+    def __init__(self, *, log_each_build: bool = False) -> None:
+        """Initialise an empty collector.
+
+        Args:
+            log_each_build: When ``True``, emit a single INFO log line on
+                every recorded build/route. Off by default to keep busy
+                pipelines quiet.
+        """
+        self._lock = threading.Lock()
+        self._c = _Counters()
+        self._log_each = log_each_build
+
+    # ------------------------------------------------------------------
+    # Recording
+    # ------------------------------------------------------------------
+
+    def record_build(self, pack: ContextPack) -> None:
+        """Aggregate stats from one context build.
+
+        Args:
+            pack: The :class:`~contextweaver.envelope.ContextPack` produced
+                by :meth:`~contextweaver.context.manager.ContextManager.build`.
+        """
+        stats = pack.stats
+        prompt_tokens = sum(stats.tokens_per_section.values()) + stats.header_footer_tokens
+        with self._lock:
+            self._c.total_builds += 1
+            self._c.total_prompt_tokens += prompt_tokens
+            self._c.total_dropped += stats.dropped_count
+            self._c.total_dedup_removed += stats.dedup_removed
+            for reason, n in stats.dropped_reasons.items():
+                self._c.drop_reasons[reason] = self._c.drop_reasons.get(reason, 0) + n
+        if self._log_each:
+            logger.info(
+                "build: phase=%s tokens=%d candidates=%d included=%d dropped=%d",
+                pack.phase.value,
+                prompt_tokens,
+                stats.total_candidates,
+                stats.included_count,
+                stats.dropped_count,
+            )
+
+    def record_route(self, result: RouteResult) -> None:
+        """Aggregate stats from one route call.
+
+        Captures candidate count, top score, and the confidence gap between
+        rank-1 and rank-2 (zero when fewer than two candidates).
+        """
+        candidate_count = len(result.candidate_ids)
+        top_score = result.scores[0] if result.scores else 0.0
+        gap = (result.scores[0] - result.scores[1]) if len(result.scores) >= 2 else 0.0
+        with self._lock:
+            self._c.total_routes += 1
+            self._c.route_candidate_counts.append(candidate_count)
+            self._c.route_top_scores.append(top_score)
+            self._c.route_confidence_gaps.append(gap)
+        if self._log_each:
+            logger.info(
+                "route: candidates=%d top_score=%.4f gap=%.4f",
+                candidate_count,
+                top_score,
+                gap,
+            )
+
+    def record_firewall(self) -> None:
+        """Increment the firewall-interception counter."""
+        with self._lock:
+            self._c.firewall_interceptions += 1
+
+    def record_items_excluded(self, n: int) -> None:
+        """Increment the items-excluded counter by *n*."""
+        with self._lock:
+            self._c.items_excluded += n
+
+    def record_budget_exceeded(self) -> None:
+        """Increment the budget-exceeded counter."""
+        with self._lock:
+            self._c.budget_exceeded += 1
+
+    # ------------------------------------------------------------------
+    # Inspection
+    # ------------------------------------------------------------------
+
+    def summary(self) -> dict[str, Any]:
+        """Return a JSON-serialisable snapshot of every counter.
+
+        Output keys are deterministic (alphabetical at the top level) so
+        diffs are stable across builds.
+        """
+        with self._lock:
+            c = self._c
+            avg_prompt_tokens = c.total_prompt_tokens / c.total_builds if c.total_builds else 0.0
+            avg_candidates = (
+                sum(c.route_candidate_counts) / len(c.route_candidate_counts)
+                if c.route_candidate_counts
+                else 0.0
+            )
+            avg_top_score = (
+                sum(c.route_top_scores) / len(c.route_top_scores) if c.route_top_scores else 0.0
+            )
+            avg_confidence_gap = (
+                sum(c.route_confidence_gaps) / len(c.route_confidence_gaps)
+                if c.route_confidence_gaps
+                else 0.0
+            )
+            return {
+                "avg_candidates_per_route": round(avg_candidates, 4),
+                "avg_confidence_gap": round(avg_confidence_gap, 4),
+                "avg_prompt_tokens": round(avg_prompt_tokens, 4),
+                "avg_top_score": round(avg_top_score, 4),
+                "budget_exceeded": c.budget_exceeded,
+                "drop_reasons": dict(sorted(c.drop_reasons.items())),
+                "firewall_interceptions": c.firewall_interceptions,
+                "items_excluded": c.items_excluded,
+                "total_builds": c.total_builds,
+                "total_dedup_removed": c.total_dedup_removed,
+                "total_dropped": c.total_dropped,
+                "total_prompt_tokens": c.total_prompt_tokens,
+                "total_routes": c.total_routes,
+            }
+
+    def reset(self) -> None:
+        """Zero every counter atomically."""
+        with self._lock:
+            self._c = _Counters()
+
+
+class MetricsHook:
+    """Concrete :class:`~contextweaver.protocols.EventHook` that feeds a collector.
+
+    Pass this to :class:`~contextweaver.context.manager.ContextManager` as the
+    ``hook=`` argument; build-level metrics flow through the existing
+    :class:`~contextweaver.protocols.EventHook` callbacks.
+
+    For full routing metrics (RouteResult-level), pair this with the same
+    :class:`MetricsCollector` passed via ``metrics=`` to ``ContextManager``.
+    """
+
+    def __init__(self, collector: MetricsCollector | None = None) -> None:
+        """Construct the hook.
+
+        Args:
+            collector: External :class:`MetricsCollector` to share with
+                ``ContextManager``. When ``None``, a fresh collector is
+                created and exposed as :attr:`collector`.
+        """
+        self.collector = collector if collector is not None else MetricsCollector()
+
+    def on_context_built(self, pack: ContextPack) -> None:
+        """Forward to :meth:`MetricsCollector.record_build`."""
+        self.collector.record_build(pack)
+
+    def on_firewall_triggered(self, item: ContextItem, reason: str) -> None:
+        """Forward to :meth:`MetricsCollector.record_firewall`."""
+        _ = item, reason
+        self.collector.record_firewall()
+
+    def on_items_excluded(self, items: list[ContextItem], reason: str) -> None:
+        """Forward to :meth:`MetricsCollector.record_items_excluded`."""
+        _ = reason
+        self.collector.record_items_excluded(len(items))
+
+    def on_budget_exceeded(self, requested: int, budget: int) -> None:
+        """Forward to :meth:`MetricsCollector.record_budget_exceeded`."""
+        _ = requested, budget
+        self.collector.record_budget_exceeded()
+
+    def on_route_completed(self, tool_ids: list[str]) -> None:
+        """No-op at hook level; route metrics arrive via ``ContextManager.metrics``.
+
+        We deliberately ignore the ``tool_ids``-only signature here: the
+        full :class:`~contextweaver.routing.router.RouteResult` carries
+        scores and confidence gaps that this collector wants. Wire those
+        via :class:`ContextManager`'s ``metrics=`` parameter.
+        """
+        _ = tool_ids

--- a/src/contextweaver/protocols.py
+++ b/src/contextweaver/protocols.py
@@ -6,11 +6,17 @@ so that stores, hooks, and summarisers remain swappable.
 
 from __future__ import annotations
 
+import logging as _logging
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+import tiktoken as _tiktoken
 
 if TYPE_CHECKING:
     from contextweaver.envelope import ContextPack
     from contextweaver.types import ArtifactRef, ContextItem, ItemKind, SelectableItem
+
+
+_tiktoken_logger = _logging.getLogger("contextweaver.protocols")
 
 
 # ---------------------------------------------------------------------------
@@ -161,44 +167,53 @@ class CharDivFourEstimator:
         return len(text) // 4
 
 
-try:
-    import tiktoken as _tiktoken
+class TiktokenEstimator:
+    """Token estimator backed by OpenAI's ``tiktoken`` library.
 
-    class TiktokenEstimator:
-        """Token estimator backed by OpenAI's ``tiktoken`` library.
+    *model* may be a model name (e.g. ``"gpt-4"``) or a raw encoding name
+    (e.g. ``"cl100k_base"``). Model names are resolved via
+    ``tiktoken.encoding_for_model``; if that fails the value is treated as
+    an encoding name.
 
-        Falls back to :class:`CharDivFourEstimator` if ``tiktoken`` is not
-        installed.  *model* may be a model name (e.g. ``"gpt-4"``) or a raw
-        encoding name (e.g. ``"cl100k_base"``).  Model names are resolved via
-        ``tiktoken.encoding_for_model``; if that fails the value is treated as
-        an encoding name.
-        """
+    ``tiktoken`` is a core runtime dependency, so the import always succeeds.
+    However, tiktoken downloads BPE encoding files on first use; in offline /
+    air-gapped environments this download fails. When that happens the
+    estimator transparently falls back to :class:`CharDivFourEstimator` and
+    logs a warning so the operator can pre-cache encodings (set
+    ``TIKTOKEN_CACHE_DIR``) or use the heuristic estimator directly.
+    """
 
-        def __init__(self, model: str = "cl100k_base") -> None:
+    def __init__(self, model: str = "cl100k_base") -> None:
+        self._fallback: CharDivFourEstimator | None = None
+        try:
+            self._enc = _tiktoken.encoding_for_model(model)
+        except KeyError:
             try:
-                self._enc = _tiktoken.encoding_for_model(model)
-            except KeyError:
                 self._enc = _tiktoken.get_encoding(model)
-
-        def estimate(self, text: str) -> int:
-            """Return the exact token count using tiktoken."""
-            return len(self._enc.encode(text))
-
-except ImportError:  # pragma: no cover
-
-    class TiktokenEstimator:  # type: ignore[no-redef]
-        """Stub when ``tiktoken`` is not installed — delegates to :class:`CharDivFourEstimator`.
-
-        *model* is accepted for API compatibility but ignored.
-        """
-
-        def __init__(self, model: str = "cl100k_base") -> None:
-            _ = model
+            except Exception as exc:  # pragma: no cover - exercised in offline tests
+                self._fallback = CharDivFourEstimator()
+                _tiktoken_logger.warning(
+                    "tiktoken encoding %r unavailable (%s); falling back to "
+                    "CharDivFourEstimator. Pre-cache encodings via TIKTOKEN_CACHE_DIR "
+                    "for exact token counts.",
+                    model,
+                    exc,
+                )
+        except Exception as exc:  # pragma: no cover - exercised in offline tests
             self._fallback = CharDivFourEstimator()
+            _tiktoken_logger.warning(
+                "tiktoken encoding %r unavailable (%s); falling back to "
+                "CharDivFourEstimator. Pre-cache encodings via TIKTOKEN_CACHE_DIR "
+                "for exact token counts.",
+                model,
+                exc,
+            )
 
-        def estimate(self, text: str) -> int:
-            """Return ``len(text) // 4`` (tiktoken not available)."""
+    def estimate(self, text: str) -> int:
+        """Return the exact token count using tiktoken (or fallback estimate)."""
+        if self._fallback is not None:
             return self._fallback.estimate(text)
+        return len(self._enc.encode(text))
 
 
 # ---------------------------------------------------------------------------

--- a/src/contextweaver/routing/catalog.py
+++ b/src/contextweaver/routing/catalog.py
@@ -172,6 +172,57 @@ def load_catalog_json(path: str | Path) -> list[SelectableItem]:
     return load_catalog_dicts(data)
 
 
+def load_catalog_yaml(path: str | Path) -> list[SelectableItem]:
+    """Load :class:`SelectableItem` objects from a YAML file.
+
+    The file must contain a YAML sequence of item mappings, each with at
+    least ``id``, ``kind``, ``name``, and ``description`` keys. Equivalent
+    to :func:`load_catalog_json` but using YAML syntax for human-friendly
+    catalog authoring.
+
+    Args:
+        path: Filesystem path to a YAML file.
+
+    Returns:
+        A list of :class:`SelectableItem` objects.
+
+    Raises:
+        CatalogError: If the file cannot be read or parsed, or if any item
+            mapping is missing required fields.
+    """
+    import yaml  # core dep — see pyproject.toml
+
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CatalogError(f"Cannot read catalog file: {exc}") from exc
+    try:
+        data = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise CatalogError(f"Invalid YAML in catalog file: {exc}") from exc
+    if not isinstance(data, list):
+        raise CatalogError("Catalog YAML must be a sequence of item mappings.")
+    return load_catalog_dicts(data)
+
+
+def load_catalog(path: str | Path) -> list[SelectableItem]:
+    """Load a catalog file, auto-detecting format from the file extension.
+
+    ``.yaml`` / ``.yml`` extensions dispatch to :func:`load_catalog_yaml`;
+    everything else is treated as JSON via :func:`load_catalog_json`.
+
+    Args:
+        path: Filesystem path to a catalog file.
+
+    Returns:
+        A list of :class:`SelectableItem` objects.
+    """
+    suffix = Path(path).suffix.lower()
+    if suffix in (".yaml", ".yml"):
+        return load_catalog_yaml(path)
+    return load_catalog_json(path)
+
+
 def load_catalog_dicts(data: list[dict[str, Any]]) -> list[SelectableItem]:
     """Convert a list of raw dicts into :class:`SelectableItem` objects.
 

--- a/src/contextweaver/routing/graph_io.py
+++ b/src/contextweaver/routing/graph_io.py
@@ -2,6 +2,9 @@
 
 Provides standalone :func:`save_graph` and :func:`load_graph` functions
 so that the main ``graph`` module stays focused on the DAG data structure.
+
+Supports both JSON and YAML formats; the format is auto-detected from the
+file extension (``.yaml`` / ``.yml`` → YAML, everything else → JSON).
 """
 
 from __future__ import annotations
@@ -16,27 +19,40 @@ if TYPE_CHECKING:
     from contextweaver.routing.graph import ChoiceGraph
 
 
+def _is_yaml_path(path: str | Path) -> bool:
+    return Path(path).suffix.lower() in (".yaml", ".yml")
+
+
 def save_graph(graph: ChoiceGraph, path: str | Path) -> None:
-    """Write *graph* to a JSON file with deterministic formatting.
+    """Write *graph* to a JSON or YAML file with deterministic formatting.
+
+    The format is selected by the file extension: ``.yaml`` / ``.yml`` for
+    YAML, anything else for JSON. Output is always sorted by key to
+    preserve deterministic-by-default behaviour.
 
     Args:
         graph: The :class:`ChoiceGraph` to persist.
         path: Filesystem path for the output file.
     """
-    Path(path).write_text(
-        json.dumps(graph.to_dict(), indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    data = graph.to_dict()
+    if _is_yaml_path(path):
+        import yaml  # core dep — see pyproject.toml
+
+        text = yaml.safe_dump(data, sort_keys=True, default_flow_style=False)
+    else:
+        text = json.dumps(data, indent=2, sort_keys=True) + "\n"
+    Path(path).write_text(text, encoding="utf-8")
 
 
 def load_graph(path: str | Path) -> ChoiceGraph:
-    """Load a graph from a JSON file and validate it.
+    """Load a graph from a JSON or YAML file and validate it.
 
-    Validates: root_id exists, all child refs resolve, no cycles (DFS),
-    all items reachable from root.
+    The format is selected by the file extension. Validates: root_id
+    exists, all child refs resolve, no cycles (DFS), all items reachable
+    from root.
 
     Args:
-        path: Filesystem path to a JSON file.
+        path: Filesystem path to a JSON or YAML file.
 
     Returns:
         A validated :class:`ChoiceGraph`.
@@ -51,10 +67,19 @@ def load_graph(path: str | Path) -> ChoiceGraph:
         text = Path(path).read_text(encoding="utf-8")
     except OSError as exc:
         raise GraphBuildError(f"Cannot read graph file: {exc}") from exc
-    try:
-        data = json.loads(text)
-    except json.JSONDecodeError as exc:
-        raise GraphBuildError(f"Invalid JSON in graph file: {exc}") from exc
+
+    if _is_yaml_path(path):
+        import yaml  # core dep — see pyproject.toml
+
+        try:
+            data = yaml.safe_load(text)
+        except yaml.YAMLError as exc:
+            raise GraphBuildError(f"Invalid YAML in graph file: {exc}") from exc
+    else:
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise GraphBuildError(f"Invalid JSON in graph file: {exc}") from exc
 
     graph = ChoiceGraph.from_dict(data)
     graph._validate()  # noqa: SLF001

--- a/src/contextweaver/routing/router.py
+++ b/src/contextweaver/routing/router.py
@@ -10,13 +10,43 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
-from contextweaver._utils import TfIdfScorer, jaccard, tokenize
+from contextweaver._utils import BM25Scorer, FuzzyScorer, TfIdfScorer, jaccard, tokenize
 from contextweaver.config import RoutingConfig
-from contextweaver.exceptions import RouteError
+from contextweaver.exceptions import ConfigError, RouteError
 from contextweaver.routing.graph import ChoiceGraph
 from contextweaver.types import SelectableItem
 
 logger = logging.getLogger("contextweaver.routing")
+
+# Union of all scorer types Router accepts. ``FuzzyScorer`` is ``None`` when
+# the ``contextweaver[retrieval]`` extra is not installed; we widen with
+# ``Any`` rather than naming the runtime ``None`` sentinel here.
+_ScorerLike = TfIdfScorer | BM25Scorer | Any
+
+# Registry of named backends. ``Router(scorer_backend="bm25")`` constructs
+# the corresponding scorer when no explicit instance is provided.
+_SCORER_BACKENDS: dict[str, str] = {
+    "tfidf": "TfIdfScorer",
+    "bm25": "BM25Scorer",
+    "fuzzy": "FuzzyScorer",
+}
+
+
+def _build_scorer(backend: str) -> _ScorerLike:
+    """Construct a scorer instance from a backend name."""
+    if backend == "tfidf":
+        return TfIdfScorer()
+    if backend == "bm25":
+        return BM25Scorer()
+    if backend == "fuzzy":
+        if FuzzyScorer is None:
+            raise ConfigError(
+                "scorer_backend='fuzzy' requires the [retrieval] extra: "
+                "pip install 'contextweaver[retrieval]'"
+            )
+        return FuzzyScorer()
+    raise ConfigError(f"Unknown scorer_backend {backend!r}")
+
 
 # ---------------------------------------------------------------------------
 # RouteResult
@@ -80,12 +110,13 @@ class Router:
         self,
         graph: ChoiceGraph,
         items: list[SelectableItem] | None = None,
-        scorer: TfIdfScorer | None = None,
+        scorer: _ScorerLike | None = None,
         beam_width: int = 2,
         max_depth: int = 8,
         top_k: int = 10,
         confidence_gap: float = 0.15,
         *,
+        scorer_backend: str = "tfidf",
         routing_config: RoutingConfig | None = None,
     ) -> None:
         if routing_config is not None:
@@ -95,19 +126,25 @@ class Router:
             confidence_gap = routing_config.confidence_gap
         if not 0.0 <= confidence_gap <= 1.0:
             raise ValueError(f"confidence_gap must be in [0.0, 1.0], got {confidence_gap}")
+        if scorer_backend not in _SCORER_BACKENDS:
+            raise ConfigError(
+                f"Unknown scorer_backend {scorer_backend!r}; "
+                f"valid options: {sorted(_SCORER_BACKENDS)}"
+            )
         self._graph = graph
         self._beam_width = beam_width
         self._max_depth = max_depth
         self._top_k = top_k
         self._confidence_gap = confidence_gap
+        self._scorer_backend = scorer_backend
         self._items: dict[str, SelectableItem] = {}
-        self._scorer = scorer
+        self._scorer: _ScorerLike | None = scorer
         self._indexed = False
         if items is not None:
             self.set_items(items)
 
     def set_items(self, items: list[SelectableItem]) -> None:
-        """Register the catalog items for TF-IDF indexing and result lookup.
+        """Register the catalog items for indexing and result lookup.
 
         Args:
             items: All items in the catalog.
@@ -116,11 +153,11 @@ class Router:
         self._indexed = False
 
     def _ensure_index(self) -> None:
-        """Lazily fit the TF-IDF scorer on item + node texts."""
+        """Lazily fit the configured scorer on item + node texts."""
         if self._indexed and self._scorer is not None:
             return
         if self._scorer is None:
-            self._scorer = TfIdfScorer()
+            self._scorer = _build_scorer(self._scorer_backend)
 
         # Build document corpus: items first (by sorted id), then non-leaf nodes
         docs: list[str] = []

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -13,8 +13,10 @@ from contextweaver.exceptions import CatalogError, ItemNotFoundError
 from contextweaver.routing.catalog import (
     Catalog,
     generate_sample_catalog,
+    load_catalog,
     load_catalog_dicts,
     load_catalog_json,
+    load_catalog_yaml,
 )
 from contextweaver.types import SelectableItem
 
@@ -120,6 +122,68 @@ def test_load_catalog_json_invalid_json() -> None:
     try:
         with pytest.raises(CatalogError, match="Invalid JSON"):
             load_catalog_json(path)
+    finally:
+        Path(path).unlink()
+
+
+def test_load_catalog_yaml() -> None:
+    yaml_text = (
+        "- id: t1\n  kind: tool\n  name: t1\n  description: desc\n"
+        "- id: t2\n  kind: tool\n  name: t2\n  description: desc\n"
+    )
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8") as f:
+        f.write(yaml_text)
+        path = f.name
+    try:
+        items = load_catalog_yaml(path)
+        assert len(items) == 2
+        assert items[0].id == "t1"
+        assert items[1].id == "t2"
+    finally:
+        Path(path).unlink()
+
+
+def test_load_catalog_yaml_invalid() -> None:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8") as f:
+        f.write("- id: t1\n  : invalid\n  bad indent\n")
+        path = f.name
+    try:
+        with pytest.raises(CatalogError, match="Invalid YAML"):
+            load_catalog_yaml(path)
+    finally:
+        Path(path).unlink()
+
+
+def test_load_catalog_yaml_not_sequence() -> None:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8") as f:
+        f.write("items: []\n")
+        path = f.name
+    try:
+        with pytest.raises(CatalogError, match="must be a sequence"):
+            load_catalog_yaml(path)
+    finally:
+        Path(path).unlink()
+
+
+def test_load_catalog_auto_detects_yaml() -> None:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False, encoding="utf-8") as f:
+        f.write("- id: t1\n  kind: tool\n  name: t1\n  description: desc\n")
+        path = f.name
+    try:
+        items = load_catalog(path)
+        assert len(items) == 1
+        assert items[0].id == "t1"
+    finally:
+        Path(path).unlink()
+
+
+def test_load_catalog_auto_detects_json() -> None:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False, encoding="utf-8") as f:
+        json.dump([{"id": "t1", "kind": "tool", "name": "t1", "description": "desc"}], f)
+        path = f.name
+    try:
+        items = load_catalog(path)
+        assert items[0].id == "t1"
     finally:
         Path(path).unlink()
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -261,6 +261,38 @@ def test_save_and_load() -> None:
         Path(path).unlink()
 
 
+def test_save_and_load_yaml() -> None:
+    g = ChoiceGraph()
+    g.add_item("tool-a")
+    g.add_node("root")
+    g.add_edge("root", "tool-a")
+    g.root_id = "root"
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8") as f:
+        path = f.name
+    try:
+        save_graph(g, path)
+        loaded = load_graph(path)
+        assert "tool-a" in loaded.items()
+        assert loaded.root_id == "root"
+        # File should not contain JSON brackets — confirms YAML format selected by extension
+        text = Path(path).read_text(encoding="utf-8")
+        assert not text.lstrip().startswith("{")
+    finally:
+        Path(path).unlink()
+
+
+def test_load_bad_yaml_raises() -> None:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8") as f:
+        f.write("- id: t1\n  : bad mapping\n  bad indent\n")
+        path = f.name
+    try:
+        with pytest.raises(GraphBuildError, match="Invalid YAML"):
+            load_graph(path)
+    finally:
+        Path(path).unlink()
+
+
 def test_load_bad_file_raises() -> None:
     with pytest.raises(GraphBuildError, match="Cannot read"):
         load_graph("/nonexistent/graph.json")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -101,6 +101,35 @@ def test_record_route_single_candidate_zero_gap() -> None:
     assert c.summary()["avg_confidence_gap"] == 0.0
 
 
+def test_record_route_uses_running_sums_and_maxima() -> None:
+    """Per-route stats track running sums + maxima, not unbounded lists.
+
+    Regression for PR #188 review — the earlier implementation stored
+    every route's candidate count, top score, and confidence gap in
+    `list[...]` fields, leaking memory in long-running processes. The
+    collector now keeps O(1) state per route; this test confirms that
+    averages still match and that the new max_* fields surface correctly.
+    """
+    c = MetricsCollector()
+    c.record_route(RouteResult(candidate_ids=["a", "b", "c"], scores=[0.9, 0.5, 0.3]))
+    c.record_route(RouteResult(candidate_ids=["a", "b"], scores=[0.7, 0.65]))
+    c.record_route(
+        RouteResult(
+            candidate_ids=["a", "b", "c", "d", "e"],
+            scores=[0.95, 0.4, 0.3, 0.2, 0.1],
+        )
+    )
+    s = c.summary()
+    # Running maxima (new fields)
+    assert s["max_candidates_per_route"] == 5
+    assert s["max_top_score"] == 0.95
+    # Confidence gaps per call: 0.4, 0.05, 0.55 → max = 0.55
+    assert s["max_confidence_gap"] == 0.55
+    # Averages still computed from running sums
+    assert s["avg_candidates_per_route"] == round((3 + 2 + 5) / 3, 4)
+    assert s["total_routes"] == 3
+
+
 def test_firewall_and_excluded_counters() -> None:
     c = MetricsCollector()
     c.record_firewall()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,205 @@
+"""Tests for contextweaver.metrics — MetricsCollector + MetricsHook."""
+
+from __future__ import annotations
+
+from contextweaver.envelope import BuildStats, ContextPack
+from contextweaver.metrics import MetricsCollector, MetricsHook
+from contextweaver.protocols import EventHook
+from contextweaver.routing.router import RouteResult
+from contextweaver.types import ContextItem, ItemKind, Phase
+
+
+def _pack(
+    *,
+    tokens: int = 100,
+    dropped: int = 0,
+    dedup: int = 0,
+    drop_reasons: dict[str, int] | None = None,
+) -> ContextPack:
+    """Build a ContextPack with the given diagnostic stats."""
+    stats = BuildStats(
+        tokens_per_section={"body": tokens},
+        total_candidates=10,
+        included_count=10 - dropped,
+        dropped_count=dropped,
+        dropped_reasons=drop_reasons or {},
+        dedup_removed=dedup,
+        header_footer_tokens=20,
+    )
+    return ContextPack(prompt="", stats=stats, phase=Phase.answer)
+
+
+def _item(iid: str = "u1") -> ContextItem:
+    return ContextItem(id=iid, kind=ItemKind.user_turn, text="hello")
+
+
+# ---------------------------------------------------------------------------
+# MetricsCollector — direct accumulation
+# ---------------------------------------------------------------------------
+
+
+def test_collector_starts_empty() -> None:
+    c = MetricsCollector()
+    s = c.summary()
+    assert s["total_builds"] == 0
+    assert s["total_routes"] == 0
+    assert s["total_prompt_tokens"] == 0
+    assert s["drop_reasons"] == {}
+
+
+def test_record_build_accumulates_tokens_and_drops() -> None:
+    c = MetricsCollector()
+    c.record_build(_pack(tokens=100, dropped=2, dedup=1, drop_reasons={"budget": 2}))
+    c.record_build(_pack(tokens=200, dropped=3, dedup=0, drop_reasons={"budget": 3}))
+    s = c.summary()
+    assert s["total_builds"] == 2
+    # 100+20 + 200+20 (header_footer adds 20 each)
+    assert s["total_prompt_tokens"] == 340
+    assert s["total_dropped"] == 5
+    assert s["total_dedup_removed"] == 1
+    assert s["drop_reasons"] == {"budget": 5}
+    assert s["avg_prompt_tokens"] == 170.0
+
+
+def test_record_build_merges_drop_reasons() -> None:
+    c = MetricsCollector()
+    c.record_build(_pack(drop_reasons={"budget": 2}))
+    c.record_build(_pack(drop_reasons={"sensitivity": 1}))
+    s = c.summary()
+    assert s["drop_reasons"] == {"budget": 2, "sensitivity": 1}
+
+
+def test_record_route_captures_top_score_and_gap() -> None:
+    c = MetricsCollector()
+    r = RouteResult(
+        candidate_items=[],
+        candidate_ids=["a", "b", "c"],
+        scores=[0.9, 0.5, 0.3],
+        paths=[],
+    )
+    c.record_route(r)
+    s = c.summary()
+    assert s["total_routes"] == 1
+    assert s["avg_candidates_per_route"] == 3.0
+    assert s["avg_top_score"] == 0.9
+    assert s["avg_confidence_gap"] == 0.4
+
+
+def test_record_route_empty_result_safe() -> None:
+    c = MetricsCollector()
+    c.record_route(RouteResult())
+    s = c.summary()
+    assert s["total_routes"] == 1
+    assert s["avg_candidates_per_route"] == 0.0
+    assert s["avg_top_score"] == 0.0
+    assert s["avg_confidence_gap"] == 0.0
+
+
+def test_record_route_single_candidate_zero_gap() -> None:
+    c = MetricsCollector()
+    c.record_route(RouteResult(candidate_ids=["only"], scores=[0.7]))
+    assert c.summary()["avg_confidence_gap"] == 0.0
+
+
+def test_firewall_and_excluded_counters() -> None:
+    c = MetricsCollector()
+    c.record_firewall()
+    c.record_firewall()
+    c.record_items_excluded(3)
+    c.record_budget_exceeded()
+    s = c.summary()
+    assert s["firewall_interceptions"] == 2
+    assert s["items_excluded"] == 3
+    assert s["budget_exceeded"] == 1
+
+
+def test_summary_keys_are_sorted_alphabetically() -> None:
+    c = MetricsCollector()
+    keys = list(c.summary().keys())
+    assert keys == sorted(keys)
+
+
+def test_reset_zeroes_all_counters() -> None:
+    c = MetricsCollector()
+    c.record_build(_pack(tokens=50, dropped=1, drop_reasons={"budget": 1}))
+    c.record_route(RouteResult(candidate_ids=["a"], scores=[0.5]))
+    c.record_firewall()
+    c.reset()
+    s = c.summary()
+    assert s["total_builds"] == 0
+    assert s["total_routes"] == 0
+    assert s["firewall_interceptions"] == 0
+    assert s["drop_reasons"] == {}
+
+
+# ---------------------------------------------------------------------------
+# MetricsHook — EventHook integration
+# ---------------------------------------------------------------------------
+
+
+def test_metrics_hook_satisfies_event_hook_protocol() -> None:
+    hook = MetricsHook()
+    assert isinstance(hook, EventHook)
+
+
+def test_metrics_hook_owns_a_collector_by_default() -> None:
+    hook = MetricsHook()
+    assert isinstance(hook.collector, MetricsCollector)
+
+
+def test_metrics_hook_shares_external_collector() -> None:
+    shared = MetricsCollector()
+    hook = MetricsHook(collector=shared)
+    assert hook.collector is shared
+
+
+def test_metrics_hook_on_context_built_records_to_collector() -> None:
+    hook = MetricsHook()
+    hook.on_context_built(_pack(tokens=80))
+    s = hook.collector.summary()
+    assert s["total_builds"] == 1
+    assert s["total_prompt_tokens"] == 100  # 80 + 20 header_footer
+
+
+def test_metrics_hook_firewall_callback() -> None:
+    hook = MetricsHook()
+    hook.on_firewall_triggered(_item(), reason="size_limit")
+    assert hook.collector.summary()["firewall_interceptions"] == 1
+
+
+def test_metrics_hook_items_excluded_counts_length() -> None:
+    hook = MetricsHook()
+    hook.on_items_excluded([_item("a"), _item("b"), _item("c")], reason="budget")
+    assert hook.collector.summary()["items_excluded"] == 3
+
+
+def test_metrics_hook_budget_exceeded_counter() -> None:
+    hook = MetricsHook()
+    hook.on_budget_exceeded(requested=2000, budget=1000)
+    assert hook.collector.summary()["budget_exceeded"] == 1
+
+
+def test_metrics_hook_route_completed_is_intentionally_no_op() -> None:
+    """Route metrics arrive via ContextManager.metrics, not the hook."""
+    hook = MetricsHook()
+    hook.on_route_completed(["a", "b"])
+    # No route counted from the hook path.
+    assert hook.collector.summary()["total_routes"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Cross-build aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_collector_aggregates_across_many_builds() -> None:
+    c = MetricsCollector()
+    for i in range(10):
+        c.record_build(_pack(tokens=100 + i, dropped=i % 3))
+        c.record_route(
+            RouteResult(candidate_ids=[f"x{j}" for j in range(i + 1)], scores=[0.9 - 0.05 * i])
+        )
+    s = c.summary()
+    assert s["total_builds"] == 10
+    assert s["total_routes"] == 10
+    assert s["avg_candidates_per_route"] > 0.0

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -1,0 +1,89 @@
+"""Tests for contextweaver.extras.otel — OpenTelemetry integration.
+
+The whole module is skipped when the ``[otel]`` extra is not installed, with
+one exception: a single test that imports the module and asserts the friendly
+ImportError surfaces. This guarantees both code paths are covered without
+requiring opentelemetry in the default CI install.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _otel_available() -> bool:
+    try:
+        importlib.import_module("opentelemetry.trace")
+        importlib.import_module("opentelemetry.metrics")
+    except ImportError:
+        return False
+    return True
+
+
+HAS_OTEL = _otel_available()
+
+
+# ---------------------------------------------------------------------------
+# Import-error path (always runs — covers the no-extra case)
+# ---------------------------------------------------------------------------
+
+
+def test_import_error_message_when_extra_missing() -> None:
+    """If opentelemetry is missing, importing extras.otel must guide the user."""
+    if HAS_OTEL:
+        # Cannot meaningfully test the ImportError path when the extra IS installed.
+        pytest.skip("opentelemetry is installed; ImportError path not exercised here")
+    with pytest.raises(ImportError, match=r"\[otel\]"):
+        importlib.import_module("contextweaver.extras.otel")
+
+
+# ---------------------------------------------------------------------------
+# Functional path (runs only when [otel] is installed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed ([otel] extra)")
+def test_otel_event_hook_constructs() -> None:
+    from contextweaver.extras.otel import OTelEventHook
+
+    hook = OTelEventHook(service_name="cw-test")
+    # Tracer and meter handles are created at construction time.
+    assert hook._tracer is not None
+    assert hook._meter is not None
+
+
+@pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed ([otel] extra)")
+def test_otel_event_hook_satisfies_event_hook_protocol() -> None:
+    from contextweaver.extras.otel import OTelEventHook
+    from contextweaver.protocols import EventHook
+
+    assert isinstance(OTelEventHook(), EventHook)
+
+
+@pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed ([otel] extra)")
+def test_otel_event_hook_records_build() -> None:
+    from contextweaver.envelope import BuildStats, ContextPack
+    from contextweaver.extras.otel import OTelEventHook
+    from contextweaver.types import Phase
+
+    pack = ContextPack(
+        prompt="",
+        stats=BuildStats(
+            tokens_per_section={"body": 100},
+            total_candidates=5,
+            included_count=4,
+            dropped_count=1,
+            header_footer_tokens=20,
+        ),
+        phase=Phase.answer,
+    )
+    OTelEventHook().on_context_built(pack)  # must not raise
+
+
+@pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed ([otel] extra)")
+def test_otel_event_hook_route_completed() -> None:
+    from contextweaver.extras.otel import OTelEventHook
+
+    OTelEventHook().on_route_completed(["a", "b", "c"])  # must not raise

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from contextweaver.envelope import ContextPack
 from contextweaver.protocols import (
     ArtifactStore,
@@ -42,13 +44,12 @@ def test_char_div_four_satisfies_protocol() -> None:
 
 
 # ---------------------------------------------------------------------------
-# TiktokenEstimator (stub fallback)
+# TiktokenEstimator (tiktoken is a core dep)
 # ---------------------------------------------------------------------------
 
 
-def test_tiktoken_estimator_fallback() -> None:
+def test_tiktoken_estimator_basic() -> None:
     est = TiktokenEstimator()
-    # Should work regardless of whether tiktoken is installed
     result = est.estimate("hello world")
     assert isinstance(result, int)
     assert result > 0
@@ -62,11 +63,48 @@ def test_tiktoken_estimator_custom_model() -> None:
 
 def test_tiktoken_estimator_accepts_model_name() -> None:
     """model param should accept a model name like 'gpt-4', not just encoding names."""
-    # Whether tiktoken is installed or not, this must not raise.
     est = TiktokenEstimator(model="gpt-4")
     result = est.estimate("hello")
     assert isinstance(result, int)
     assert result > 0
+
+
+def test_tiktoken_more_accurate_than_chardiv() -> None:
+    """tiktoken should produce different counts than the char/4 heuristic on real text.
+
+    Only meaningful when tiktoken's BPE encoding is actually available
+    (i.e., not falling back to the heuristic due to offline / cache miss).
+    Skipped in offline environments where tiktoken cannot download encodings.
+    """
+    est = TiktokenEstimator()
+    if est._fallback is not None:
+        pytest.skip("tiktoken encoding not available offline; fallback active")
+    text = "The quick brown fox jumps over the lazy dog." * 10
+    tt = est.estimate(text)
+    cd = CharDivFourEstimator().estimate(text)
+    assert tt > 0
+    assert cd > 0
+    # Real tokenization differs from chars // 4 for non-trivial text.
+    assert tt != cd
+
+
+def test_tiktoken_fallback_when_encoding_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When tiktoken can't load an encoding, estimator falls back transparently."""
+    import contextweaver.protocols as protocols_mod
+
+    def _raise(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("simulated download failure")
+
+    monkeypatch.setattr(protocols_mod._tiktoken, "encoding_for_model", _raise)
+    monkeypatch.setattr(protocols_mod._tiktoken, "get_encoding", _raise)
+
+    est = TiktokenEstimator()
+    assert est._fallback is not None
+    # Falls back to char/4 estimate without raising.
+    text = "abcd" * 10  # 40 chars -> 10 tokens via char/4
+    assert est.estimate(text) == 10
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -152,6 +152,38 @@ def test_confidence_gap_above_one_raises() -> None:
 
 
 # ------------------------------------------------------------------
+# Pluggable scorer backends
+# ------------------------------------------------------------------
+
+
+def test_router_bm25_backend_routes() -> None:
+    items = _build_catalog_items()
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items, scorer_backend="bm25", top_k=3)
+    result = router.route("send email to user")
+    assert len(result.candidate_ids) > 0
+    assert "send_email" in result.candidate_ids
+
+
+def test_router_tfidf_backend_default() -> None:
+    items = _build_catalog_items()
+    graph = TreeBuilder().build(items)
+    # Default backend should still be tfidf for backward compatibility.
+    router = Router(graph, items=items, top_k=3)
+    result = router.route("read database")
+    assert len(result.candidate_ids) > 0
+
+
+def test_router_unknown_backend_raises() -> None:
+    items = _build_catalog_items()
+    graph = TreeBuilder().build(items)
+    from contextweaver.exceptions import ConfigError
+
+    with pytest.raises(ConfigError, match="scorer_backend"):
+        Router(graph, items=items, scorer_backend="not-a-backend")
+
+
+# ------------------------------------------------------------------
 # Error handling
 # ------------------------------------------------------------------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -135,6 +135,41 @@ def test_bm25_deterministic() -> None:
     assert s1.score_all("alpha delta") == s2.score_all("alpha delta")
 
 
+def test_bm25_preserves_term_frequency() -> None:
+    """BM25 must count term frequency.
+
+    Regression for PR #188 review — `BM25Scorer.fit()` previously fed
+    `sorted(tokenize(doc))` to `BM25Okapi`, but `tokenize()` returned a
+    ``set[str]`` which discarded duplicates. With TF lost the scorer
+    degraded to binary matching: a doc mentioning the query term once
+    scored the same as one mentioning it many times.
+
+    With `tokenize_list()` in place, a doc that repeats the query term
+    multiple times must score strictly higher than one that mentions it
+    only once.
+    """
+    scorer = BM25Scorer()
+    # Doc 0 mentions "database" three times; doc 1 mentions it once.
+    # Three distractor docs that don't mention the query term keep the
+    # `database` IDF positive (otherwise a query term present in every
+    # doc would have a non-positive IDF and TF would lose its boost).
+    scorer.fit(
+        [
+            "database database database lookup tool",
+            "database lookup tool",
+            "unrelated alpha beta gamma",
+            "another bravo charlie delta",
+            "echo foxtrot golf hotel",
+        ]
+    )
+    scores = scorer.score_all("database")
+    assert scores[0] > scores[1], (
+        f"BM25 must reward higher term frequency; "
+        f"got scores[0]={scores[0]!r} <= scores[1]={scores[1]!r} — "
+        f"indicates tokenize_list() is not being used in BM25Scorer.fit()."
+    )
+
+
 # ---------------------------------------------------------------------------
 # FuzzyScorer (rapidfuzz; contextweaver[retrieval] extra)
 # ---------------------------------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,14 @@ from __future__ import annotations
 
 import pytest
 
-from contextweaver._utils import STOPWORDS, TfIdfScorer, jaccard, tokenize
+from contextweaver._utils import (
+    STOPWORDS,
+    BM25Scorer,
+    FuzzyScorer,
+    TfIdfScorer,
+    jaccard,
+    tokenize,
+)
 
 
 def test_stopwords_nonempty() -> None:
@@ -83,3 +90,81 @@ def test_tfidf_deterministic() -> None:
     s2 = TfIdfScorer()
     s2.fit(docs)
     assert s1.score_all("alpha delta") == s2.score_all("alpha delta")
+
+
+# ---------------------------------------------------------------------------
+# BM25Scorer (rank-bm25 is a core dep)
+# ---------------------------------------------------------------------------
+
+
+def test_bm25_fit_and_score() -> None:
+    scorer = BM25Scorer()
+    docs = ["search database quickly", "fast database access", "unrelated content here"]
+    scorer.fit(docs)
+    scores = scorer.score_all("fast database")
+    assert len(scores) == 3
+    # Second doc should score highest for "fast database" (matches both terms)
+    assert scores[1] >= scores[2]
+
+
+def test_bm25_empty_corpus() -> None:
+    scorer = BM25Scorer()
+    scorer.fit([])
+    assert scorer.score_all("hello") == []
+
+
+def test_bm25_score_out_of_range() -> None:
+    scorer = BM25Scorer()
+    scorer.fit(["hello world"])
+    with pytest.raises(IndexError):
+        scorer.score("hello", 5)
+
+
+def test_bm25_empty_query_returns_zeros() -> None:
+    scorer = BM25Scorer()
+    scorer.fit(["hello world", "another doc"])
+    assert scorer.score_all("") == [0.0, 0.0]
+
+
+def test_bm25_deterministic() -> None:
+    docs = ["alpha beta gamma", "delta epsilon", "alpha delta"]
+    s1 = BM25Scorer()
+    s1.fit(docs)
+    s2 = BM25Scorer()
+    s2.fit(docs)
+    assert s1.score_all("alpha delta") == s2.score_all("alpha delta")
+
+
+# ---------------------------------------------------------------------------
+# FuzzyScorer (rapidfuzz; contextweaver[retrieval] extra)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(FuzzyScorer is None, reason="rapidfuzz not installed ([retrieval] extra)")
+def test_fuzzy_basic_match() -> None:
+    scorer = FuzzyScorer()  # type: ignore[misc]
+    docs = ["send email to user", "create database", "search documentation"]
+    scorer.fit(docs)
+    scores = scorer.score_all("emal")  # typo of "email"
+    assert scores[0] > scores[1]  # email match wins despite typo
+
+
+@pytest.mark.skipif(FuzzyScorer is None, reason="rapidfuzz not installed ([retrieval] extra)")
+def test_fuzzy_empty_query() -> None:
+    scorer = FuzzyScorer()  # type: ignore[misc]
+    scorer.fit(["hello world"])
+    assert scorer.score("", 0) == 0.0
+
+
+@pytest.mark.skipif(FuzzyScorer is None, reason="rapidfuzz not installed ([retrieval] extra)")
+def test_fuzzy_score_out_of_range() -> None:
+    scorer = FuzzyScorer()  # type: ignore[misc]
+    scorer.fit(["hello"])
+    with pytest.raises(IndexError):
+        scorer.score("hi", 5)
+
+
+def test_fuzzy_scorer_is_none_when_extra_missing() -> None:
+    """Document the public contract: FuzzyScorer is None unless [retrieval] extra installed."""
+    # Either the extra is installed (FuzzyScorer is a class) or it isn't (None).
+    assert FuzzyScorer is None or callable(FuzzyScorer)


### PR DESCRIPTION
## Summary

Hybrid dependency model (small core + optional extras) plus eight triage-prioritised features delivered in one cohesive PR. Promotes `tiktoken`, `PyYAML`, and `rank-bm25` to core, adds five new optional extras, ships BM25 and fuzzy retrieval backends, a thread-safe metrics layer, an OpenTelemetry hook, YAML catalog/graph support, a rich-formatted CLI, and an offline-friendly `TiktokenEstimator`.

Closes #10
Closes #49
Closes #50
Closes #52
Closes #53
Closes #54
Closes #55
Closes #57

## Changes

**Dependency model (`pyproject.toml`)**
- Promote `tiktoken>=0.5`, `PyYAML>=6.0`, `rank-bm25>=0.2` to core runtime dependencies (#10, #49, #54, #55)
- New optional extras: `[cli]` (rich), `[retrieval]` (rapidfuzz), `[ann]` (hnswlib, reserved), `[otel]` (opentelemetry-api/sdk), `[graph]` (networkx, reserved), `[all]` (union convenience)
- mypy `ignore_missing_imports` overrides for every new optional package

**Token estimation (`src/contextweaver/protocols.py`)** — #49
- `TiktokenEstimator` handles offline / air-gapped environments: encoding download failures transparently fall back to `CharDivFourEstimator` with a structured warning naming `TIKTOKEN_CACHE_DIR` as the workaround
- The try-except stub is gone — `tiktoken` is now a core dep, so the import always succeeds

**Retrieval backends (`src/contextweaver/_utils.py`, `src/contextweaver/routing/router.py`)** — #52, #55
- `BM25Scorer` (core dep, `rank-bm25`) with the same `fit()` / `score()` / `score_all()` interface as `TfIdfScorer`. Backed by a new `tokenize_list()` helper in `_utils` that preserves term frequency for BM25 TF-saturation; `tokenize()` still returns `set[str]` for Jaccard / TF-IDF callers.
- `FuzzyScorer` (guarded import, `[retrieval]` extra) with the same API; `FuzzyScorer is None` when the extra is absent
- `Router(scorer_backend="bm25" | "tfidf" | "fuzzy")` keyword-only parameter; unknown values raise `ConfigError`. Cooperates with the `EngineRegistry` / `retriever` plumbing from #47 — passing an explicit `retriever=` or `scorer=` still wins over the named backend.

**Metrics & observability (`src/contextweaver/metrics.py`, `src/contextweaver/context/manager.py`)** — #55
- New `MetricsCollector`: thread-safe accumulator that records build- and route-level statistics through `record_build()` / `record_route()` / `record_firewall()` / `record_items_excluded()` / `record_budget_exceeded()`. Per-route stats (candidate count, top score, confidence gap) are tracked as running sums + running maxima so memory stays O(1) regardless of how many routes are recorded.
- `summary()` returns a JSON-serialisable, alphabetically-sorted snapshot; keys include the existing `avg_*` averages plus `max_candidates_per_route`, `max_top_score`, and `max_confidence_gap`. `reset()` zeroes every counter atomically.
- New `MetricsHook`: concrete `EventHook` implementation that forwards build-level callbacks to a shared `MetricsCollector`.
- `ContextManager` gains a keyword-only `metrics: MetricsCollector | None = None` parameter; full `RouteResult` is recorded automatically after every routing call.

**OpenTelemetry integration (`src/contextweaver/extras/otel.py`)** — #57
- New `OTelEventHook` emits spans (`contextweaver.context.build`, `contextweaver.context.firewall`, `contextweaver.context.exclude`, `contextweaver.routing.route`) and metrics (`contextweaver.tokens.used` histogram, `contextweaver.firewall.interceptions` counter, `contextweaver.items.excluded` counter, `contextweaver.budget.exceeded` counter, `contextweaver.routing.candidates` histogram)
- The tokens metric is a histogram so the hook is portable across the full supported `opentelemetry-api>=1.20` range (the synchronous `create_gauge` instrument only landed in 1.27, and observable gauges would force callers to maintain a global latest-value cache)
- Import guard raises an informative `ImportError` carrying `pip install 'contextweaver[otel]'` when the extra is absent

**YAML catalog + graph I/O (`src/contextweaver/routing/catalog.py`, `src/contextweaver/routing/graph_io.py`)** — #54
- `load_catalog_yaml(path)` reads a catalog from a YAML file via `yaml.safe_load`
- `load_catalog(path)` auto-detects `.yaml` / `.yml` vs `.json` by file extension
- `save_graph()` / `load_graph()` auto-detect the same way; YAML output uses `sort_keys=True` for determinism
- `examples/sample_catalog.yaml` ships alongside the JSON sample

**CLI rich rendering (`src/contextweaver/__main__.py`)** — #50
- The `print-tree` subcommand uses `rich.tree` for coloured output when the `[cli]` extra is installed; stdlib argparse + plain ASCII output remains byte-identical when `rich` is absent. The `_HAS_RICH` guard at module level keeps the import strictly optional.

**Docs (`README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `.github/copilot-instructions.md`)** — #53
- "zero runtime dependencies" → "minimal core dependencies" everywhere; the extras model is documented in a dedicated README table
- New core-dep policy in `AGENTS.md`: zero core runtime deps, additions require broad ecosystem use + small wheel + unblocked default behaviour

**Public API (`src/contextweaver/__init__.py`)**
- New top-level exports: `BM25Scorer`, `FuzzyScorer`, `MetricsCollector`, `MetricsHook`, `load_catalog`, `load_catalog_yaml`

**Tests**
- `tests/test_metrics.py` — collector accumulation, summary key determinism, reset, running-sum + running-maxima behaviour, `MetricsHook` protocol conformance
- `tests/test_otel.py` — conditional tests: the `ImportError` path always runs; functional tests skip when `[otel]` is absent
- `tests/test_protocols.py` — `TiktokenEstimator` offline-fallback simulation via monkeypatch
- `tests/test_utils.py` — `BM25Scorer` tests including a term-frequency regression test that asserts a doc with TF=3 outscores one with TF=1; `FuzzyScorer` tests (skipif rapidfuzz absent)
- `tests/test_router.py` — BM25 backend routing, tfidf default, unknown-backend `ConfigError`
- `tests/test_catalog.py` — YAML load, error handling, auto-detect
- `tests/test_graph.py` — YAML round-trip, bad-YAML error

**`CHANGELOG.md`** — `[Unreleased]` section updated with every change above

## Checklist

- [x] Tests added or updated for every new/changed public function
- [x] `make ci` passes locally (fmt + lint + type + test + example + demo)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docstrings added for all new public APIs (Google-style)
- [x] Modules over 300 lines have a decomposition issue linked (see Notes)
- [x] Related issues linked in the summary above
- [x] Agent-facing docs updated where pipeline, API, or conventions changed

## Notes for reviewers

**Backward compatibility:** All changes are additive. `Router.__init__` gains a `scorer_backend` keyword-only default (`"tfidf"`), so existing call sites are unaffected. `ContextManager` gains optional keyword-only `metrics=` and `profile=` arguments defaulting to `None`. The `EventHook.on_route_completed(list[str])` signature is unchanged; full `RouteResult` metrics flow through the separate `metrics=` channel.

**Line-count soft violations:** `_utils.py` (420 lines), `catalog.py` (~410 lines), and `router.py` (~620 lines) exceed the 300-line guideline; the new additions are self-contained and appropriate to each module. `manager.py` (850 lines), `graph.py` (~397), `tree.py` (~380), `adapters/mcp.py` (~352), and `protocols.py` (~302) are pre-existing. Decomposition is tracked under #56 (routing decomposition epic) and #73 / #69 for `manager.py`, and is out of scope for this PR.

**`FuzzyScorer` when `rapidfuzz` is absent:** `contextweaver.FuzzyScorer` is `None` at runtime when the `[retrieval]` extra is not installed. Passing `scorer_backend="fuzzy"` to `Router` without the extra raises `ConfigError` with the exact install hint.

**OTel hook location:** `OTelEventHook` lives in `contextweaver.extras.otel` (not the top-level namespace) so importing `contextweaver` never pulls in `opentelemetry`. Opt in explicitly: `from contextweaver.extras.otel import OTelEventHook`.
