### PR TITLE
feat(adapters): MCP proxy + two-tool gateway runtime (#13, #28, #29, #34)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,16 @@ It prepares context and routes tools but never calls models or executes tools.
 | `routing/normalizer.py` | `CatalogNormalizer` + `NormalizationReport` for catalog metadata hygiene (issue #44) |
 | `routing/registry.py` | `EngineRegistry` and bundled `TfIdfRetriever` / `NoOpReranker` / `JaccardClusteringEngine` defaults (issue #47) |
 | `routing/trace.py` | `RouteTrace` + `TraceStep` structured routing audit (issue #51) |
-| `adapters/` | MCP, FastMCP, A2A, and weaver-spec protocol adapters |
+| `routing/tool_id.py` | Canonical `tool_id` grammar (`parse_tool_id` / `format_tool_id` / `compute_hash8`) per `docs/gateway_spec.md` §1 |
+| `routing/path.py` | `tool_browse` path-navigation grammar (`parse_path` / `resolve_path`) per `docs/gateway_spec.md` §3 |
+| `adapters/` | MCP, FastMCP, A2A, and weaver-spec protocol adapters + MCP proxy / gateway runtime (issues #13, #28, #29, #34) |
+| `adapters/proxy_runtime.py` | `ProxyRuntime` shared core + `ExposureMode` enum + `UpstreamCall` Protocol (issue #29) |
+| `adapters/mcp_gateway.py` | Two-tool gateway dispatch (`tool_browse` + `tool_execute` + `tool_view`, issues #28 / #34) |
+| `adapters/mcp_proxy.py` | Transparent proxy dispatch (stripped `tools/list` + `tool_hydrate` + `tool_execute`, issue #13) |
+| `adapters/mcp_upstream.py` | Concrete `UpstreamCall` adapters (`StubUpstream`, `McpClientUpstream`, `MultiplexUpstream`) |
+| `adapters/mcp_gateway_server.py` | Bind `mcp_gateway` onto `mcp.server.Server` over stdio (issue #28) |
+| `adapters/mcp_proxy_server.py` | Bind `mcp_proxy` onto `mcp.server.Server` over stdio (issue #13) |
+| `adapters/gateway_error.py` | Structured `GatewayError` (codes + §3.4 wire shape) |
 | `__main__.py` | CLI: 7 subcommands (`demo`, `build`, `route`, `print-tree`, `init`, `ingest`, `replay`) |
 
 ## Pipelines (summary)
@@ -74,6 +83,11 @@ For full pipeline descriptions and design rationale, see [docs/agent-context/arc
 | `MaskRedactionHook` | Built-in redaction hook for sensitivity enforcement |
 | `HydrationResult` | Result of hydrating a tool call with context |
 | `ViewRegistry` | Maps content-type patterns to view generators for progressive disclosure |
+| `ProxyRuntime` | Shared core for MCP proxy (#13) and gateway (#28) modes — owns upstream catalog, per-session `ContextManager`, browse / execute / view dispatch |
+| `ExposureMode` | `TRANSPARENT` (#13) vs `GATEWAY` (#28) for `ProxyRuntime` |
+| `UpstreamCall` | Transport-agnostic Protocol over upstream MCP fan-out (used by `ProxyRuntime`) |
+| `GatewayError` | Structured error payload (§3.4) returned from every gateway/proxy meta-tool |
+| `ToolIdParts` | Destructured canonical `tool_id` (namespace / name / version / hash8) |
 
 **Vocabulary notes:**
 - `SelectableItem` is the canonical name. `ToolCard` is a user-facing alias — use `SelectableItem` in code and docs.
@@ -129,7 +143,7 @@ These are strongly recommended. Engineering judgment applies — deviate with go
 - **Google-style docstrings** on all public classes and functions.
 - **100-character line length** (enforced by ruff).
 - **≤ 300 lines per module** — exempt: `types.py`, `envelope.py`, `__main__.py`.
-- **Minimal core runtime dependencies.** The core install pulls only `tiktoken`, `PyYAML`, and `rank-bm25` — each is broadly used in GenAI stacks and unblocks default behaviour. Adding a new core dependency requires explicit justification: broad ecosystem use, small wheel, and a default the library would otherwise have to approximate. Heavy or runtime-specific packages (CLI, OpenTelemetry, fuzzy retrieval, ANN, NetworkX, FastMCP, LangChain) live under `[project.optional-dependencies]` and are loaded via guarded imports.
+- **Core runtime dependencies.** The core install pulls `tiktoken`, `PyYAML`, `rank-bm25`, plus `mcp` and `jsonschema` (added when the proxy / gateway runtimes landed — both are load-bearing for `docs/gateway_spec.md` §4.4 schema validation and the MCP transport binding).  Adding *another* core dependency requires explicit justification: broad ecosystem use, small wheel, and a default the library would otherwise have to approximate.  Heavy or runtime-specific packages (CLI, OpenTelemetry, fuzzy retrieval, ANN, NetworkX, FastMCP, LangChain) live under `[project.optional-dependencies]` and are loaded via guarded imports.
 
 ## Testing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CI as a gating step (the issue allowed a non-gating stub, but the
   available `weaver_contracts` + `jsonschema` dev deps unlock real schema
   validation today).
+- **MCP proxy + two-tool gateway runtime** (#13, #28, #29, #34).  Lands the
+  full proxy/gateway surface specified by `docs/gateway_spec.md`:
+  - `src/contextweaver/routing/tool_id.py` — canonical `tool_id` grammar
+    (`parse_tool_id`, `format_tool_id`, `compute_hash8`, `canonical_tool_id`,
+    `ToolIdParts`) per §1.  `mcp_tool_to_selectable` is cut over to emit
+    canonical ids (§1.7); the legacy `mcp:{name}` form is retired.
+  - `src/contextweaver/routing/path.py` — `tool_browse` path-navigation
+    grammar (`parse_path`, `resolve_path`) per §3, with two new typed
+    exceptions (`PathInvalidError`, `PathNotFoundError`).
+  - `src/contextweaver/routing/cards.py` — refit to **token-native**
+    enforcement of the §2.3 ChoiceCard size bounds against
+    `cl100k_base` (`make_choice_cards`, `bound_browse_response`,
+    `truncate_description_to_tokens`, `count_tokens`).  The old
+    `max_total_chars` / `max_desc_chars` arguments are removed.
+  - `src/contextweaver/adapters/proxy_runtime.py` — `ProxyRuntime`
+    shared core with `ExposureMode`, `UpstreamCall` Protocol, and
+    browse / execute / view / hydrate / strip_tools_list primitives
+    (#29).  Validates `tool_execute` args against the hydrated schema
+    via `jsonschema` (§4.4).
+  - `src/contextweaver/adapters/mcp_gateway.py` — three meta-tools
+    (`tool_browse`, `tool_execute`, `tool_view`) with structured
+    `GatewayError` returns (§3.4) (#28, #34).
+  - `src/contextweaver/adapters/mcp_proxy.py` — transparent-proxy
+    surfaces: stripped `tools/list` + `tool_hydrate` + `tool_execute`
+    (§4.1) (#13).
+  - `src/contextweaver/adapters/mcp_upstream.py` — concrete
+    `UpstreamCall` adapters: `StubUpstream` (in-process tests / demos),
+    `McpClientUpstream` (single MCP `ClientSession`), and
+    `MultiplexUpstream` (multi-server fan-out).
+  - `src/contextweaver/adapters/mcp_gateway_server.py` /
+    `mcp_proxy_server.py` — bind the dispatch layers onto a real
+    `mcp.server.Server` over stdio.
+  - `src/contextweaver/adapters/gateway_error.py` — typed `GatewayError`
+    dataclass with the §3.4 wire shape.
+  - Two new runnable demos (`examples/mcp_gateway_demo.py`,
+    `examples/mcp_proxy_demo.py`) wired into `make example`.
+- **Content-addressed firewall idempotency** (#190).
+  `ArtifactRef.content_hash` (lowercase sha256 hex) is populated when
+  the firewall stores raw bytes.  `apply_firewall` now short-circuits
+  when an incoming item already carries a populated `content_hash`,
+  preventing the previous regression where a `build()` call run after
+  `ingest_tool_result_sync()` overwrote the original raw bytes with the
+  summary.
+
+### Changed
+
+- **`mcp` and `jsonschema` promoted to core dependencies** (was: planned
+  optional extras).  Driven by the gateway / proxy runtimes — both are
+  load-bearing for `gateway_spec.md` §4.4 argument validation and the
+  MCP transport binding.  The AGENTS.md "minimal core runtime
+  dependencies" rule is amended accordingly.
+- **`mcp_tool_to_selectable` emits canonical `tool_id`** (§1.7
+  cutover).  Existing call sites that hard-coded `f"mcp:{name}"` must
+  consume the canonical form (round-tripped through
+  `parse_tool_id` / `format_tool_id`).
+- **`make_choice_cards` is token-native** against `cl100k_base`.  The
+  `max_total_chars` and `max_desc_chars` keyword arguments are removed;
+  callers use `target_tokens_per_card` and `hard_cap_tokens_per_card`
+  (defaults 60 / 80 matching `gateway_spec.md` §2.3).
+
+### Added (carried from prior unreleased entries)
+
 - **Gateway surface specification** (#30, #31). New
   `docs/gateway_spec.md` codifies the three contract gaps blocking the
   MCP proxy and gateway runtimes: canonical `tool_id` grammar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,13 @@ All CI checks must pass before a PR can be merged.
 ## Style guide
 
 - **Python ≥ 3.10** — use `X | Y` union syntax, `match` statements where appropriate.
-- **Minimal core runtime dependencies** — the core ships with `tiktoken`, `PyYAML`, and
-  `rank-bm25`. Adding a new entry to `dependencies` in `pyproject.toml` requires broad
-  ecosystem use, a small wheel, and a default the library would otherwise approximate.
-  Heavy or runtime-specific packages go under `[project.optional-dependencies]` (e.g.
-  `cli`, `otel`, `retrieval`, `ann`, `graph`) and must be loaded via guarded imports
+- **Core runtime dependencies** — the core ships with `tiktoken`, `PyYAML`, `rank-bm25`,
+  plus `mcp` and `jsonschema` (the latter two are required by the MCP proxy / gateway
+  runtimes — see `docs/gateway_spec.md` §4.4 and `adapters/mcp_*`).  Adding *another*
+  entry to `dependencies` in `pyproject.toml` requires broad ecosystem use, a small
+  wheel, and a default the library would otherwise approximate.  Heavy or
+  runtime-specific packages go under `[project.optional-dependencies]` (e.g. `cli`,
+  `otel`, `retrieval`, `ann`, `graph`) and must be loaded via guarded imports
   (`try: import x ... except ImportError: ...`).
 - **Type hints everywhere** — all public functions and methods must be fully annotated.
 - **Docstrings** — use Google-style docstrings on all public classes and functions.

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ example:
 	python examples/before_after.py
 	python examples/hydrate_call_demo.py
 	python examples/mcp_adapter_demo.py
+	python examples/mcp_gateway_demo.py
+	python examples/mcp_proxy_demo.py
 	python examples/a2a_adapter_demo.py
 	python examples/langchain_memory_demo.py
 	python examples/cookbook/byot_recipe.py

--- a/docs/integration_mcp.md
+++ b/docs/integration_mcp.md
@@ -213,3 +213,83 @@ control.
 proposed/future feature, not a type that is implemented in the library
 today. For actual access control, enforce authorization in your own
 application or policy layer.
+
+---
+
+## Runtime modes: transparent proxy and two-tool gateway
+
+The MCP adapter ships two runtime modes for fronting one or more
+upstream MCP servers.  Both share the
+[`ProxyRuntime`](../src/contextweaver/adapters/proxy_runtime.py) core and
+satisfy the contracts in [`docs/gateway_spec.md`](gateway_spec.md):
+
+| Mode | Discovery channel | Invocation channel | Schema exposure |
+|------|-------------------|--------------------|-----------------|
+| `ExposureMode.TRANSPARENT` (#13) | Stripped `tools/list` — one entry per upstream tool with sentinel `inputSchema: {"type": "object"}` | `tool_hydrate(tool_id)` + `tool_execute(tool_id, args)` | On demand via `tool_hydrate` |
+| `ExposureMode.GATEWAY` (#28 + #34) | None — the agent never sees a `tools/list` | `tool_browse(query|path)` + `tool_execute(tool_id, args)` + `tool_view(handle, selector)` | Internal: `tool_execute` hydrates and validates before upstream dispatch |
+
+Both modes share the same invocation contract: arguments to
+`tool_execute` are validated against the hydrated schema via
+`jsonschema` before any upstream call, per
+[`gateway_spec.md` §4.4](gateway_spec.md#4-schema-exposure-strategy).
+
+### Wiring a gateway over stdio
+
+```python
+import asyncio
+from contextweaver.adapters import ProxyRuntime, StubUpstream
+from contextweaver.adapters.mcp_gateway_server import McpGatewayServer
+
+runtime = ProxyRuntime(StubUpstream([...]))
+await runtime.refresh_catalog()
+server = McpGatewayServer(runtime, name="example-gateway")
+asyncio.run(server.run_stdio())
+```
+
+### Wiring a transparent proxy over stdio
+
+```python
+from contextweaver.adapters import ExposureMode, ProxyRuntime, StubUpstream
+from contextweaver.adapters.mcp_proxy_server import McpProxyServer
+
+runtime = ProxyRuntime(StubUpstream([...]), mode=ExposureMode.TRANSPARENT)
+await runtime.refresh_catalog()
+server = McpProxyServer(runtime, name="example-proxy")
+asyncio.run(server.run_stdio())
+```
+
+### Connecting to real upstream MCP servers
+
+Swap [`StubUpstream`](../src/contextweaver/adapters/mcp_upstream.py) for
+`McpClientUpstream(session)` (one upstream) or
+`MultiplexUpstream([a, b, ...])` (multi-server fan-out).  The runtime
+itself is transport-agnostic; the upstream adapter handles the wire
+protocol.
+
+### Error shape
+
+Every gateway / proxy meta-tool returns either a `ResultEnvelope` or a
+typed
+[`GatewayError`](../src/contextweaver/adapters/gateway_error.py)
+matching `gateway_spec.md` §3.4:
+
+```json
+{
+  "error": "PATH_INVALID" | "PATH_NOT_FOUND" | "ARGS_INVALID" | "UPSTREAM_ERROR" | "HYDRATE_FAILED" | "VIEW_FAILED",
+  "message": "<human-readable>",
+  "path": "<offending path or tool_id>",
+  "details": { "...": "..." }
+}
+```
+
+The meta-tools never raise across the MCP boundary — failures are
+delivered as `isError=true` `CallToolResult` payloads.
+
+### See also
+
+- [`docs/gateway_spec.md`](gateway_spec.md) — the normative
+  surface specification.
+- [`examples/mcp_gateway_demo.py`](../examples/mcp_gateway_demo.py) —
+  end-to-end gateway flow using `StubUpstream`.
+- [`examples/mcp_proxy_demo.py`](../examples/mcp_proxy_demo.py) —
+  end-to-end proxy flow.

--- a/examples/mcp_gateway_demo.py
+++ b/examples/mcp_gateway_demo.py
@@ -1,0 +1,153 @@
+"""Two-tool MCP gateway end-to-end demo (#28 + #34).
+
+Demonstrates the three meta-tools the gateway exposes per
+``docs/gateway_spec.md`` §4.2:
+
+- ``tool_browse(query|path)`` — returns bounded ChoiceCards.
+- ``tool_execute(tool_id, args)`` — validates args, calls upstream,
+  applies the context firewall.
+- ``tool_view(handle, selector)`` — drills into a previously stored
+  artifact (#34).
+
+The demo wires :class:`~contextweaver.adapters.StubUpstream` so it runs
+without network access and without an MCP-SDK transport — exactly what
+``make example`` exercises in CI.  Swap the upstream for
+:class:`~contextweaver.adapters.McpClientUpstream` to front a real MCP
+server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from contextweaver.adapters import (
+    GatewayError,
+    ProxyRuntime,
+    StubUpstream,
+    dispatch_meta_tool,
+    make_gateway_meta_tools,
+)
+from contextweaver.envelope import ChoiceCard, ResultEnvelope
+
+UPSTREAM_TOOL_DEFS: list[dict[str, Any]] = [
+    {
+        "name": "github.create_issue",
+        "description": "Open a new GitHub issue.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "body": {"type": "string"},
+            },
+            "required": ["title"],
+        },
+        "_meta": {"version": "1.4.0"},
+    },
+    {
+        "name": "github.close_issue",
+        "description": "Close an existing GitHub issue.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"issue_id": {"type": "integer"}},
+            "required": ["issue_id"],
+        },
+        "_meta": {"version": "1.4.0"},
+    },
+    {
+        "name": "slack_send_message",
+        "description": "Post a message to a Slack channel.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "channel": {"type": "string"},
+                "text": {"type": "string"},
+            },
+            "required": ["channel", "text"],
+        },
+    },
+]
+
+
+async def _stub_handler(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Pretend to invoke an upstream tool — return canned text."""
+    if tool_name == "github.create_issue":
+        body = "\n".join(
+            [
+                "issue_id: 142",
+                f"title: {args.get('title')!r}",
+                f"body: {args.get('body', '<empty>')!r}",
+                "status: open",
+                "html_url: https://example.com/issues/142",
+            ]
+        )
+        return {"content": [{"type": "text", "text": body}], "isError": False}
+    return {
+        "content": [{"type": "text", "text": f"stub called {tool_name}"}],
+        "isError": False,
+    }
+
+
+async def main() -> int:
+    runtime = ProxyRuntime(StubUpstream(UPSTREAM_TOOL_DEFS, handler=_stub_handler))
+    runtime.register_tool_defs_sync(UPSTREAM_TOOL_DEFS)
+
+    print("[1/5] Gateway meta-tools advertised to agents:")
+    for meta in make_gateway_meta_tools(runtime):
+        print(f"      - {meta['name']}: {meta['description'][:60]}…")
+
+    print("\n[2/5] tool_browse(query='open a github issue')")
+    cards_payload = await dispatch_meta_tool(
+        runtime, "tool_browse", {"query": "open a github issue"}
+    )
+    cards = json.loads(cards_payload["content"][0]["text"])
+    for card in cards[:3]:
+        print(f"      [{card['id']}] {card['description'][:48]}")
+
+    print("\n[3/5] tool_browse(path='/')")
+    by_path = await dispatch_meta_tool(runtime, "tool_browse", {"path": "/"})
+    if by_path["isError"]:
+        body = json.loads(by_path["content"][0]["text"])
+        print(f"      error: {body['error']} — {body['message']}")
+    else:
+        for entry in json.loads(by_path["content"][0]["text"])[:5]:
+            print(f"      [{entry['id']}] {entry['description'][:48]}")
+
+    print("\n[4/5] tool_execute(github.create_issue)")
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:create_issue"))
+    exec_result = await dispatch_meta_tool(
+        runtime,
+        "tool_execute",
+        {"tool_id": tool_id, "args": {"title": "Demo issue", "body": "Hello"}},
+    )
+    envelope_dict = json.loads(exec_result["content"][0]["text"])
+    print(f"      status={envelope_dict['status']}, summary={envelope_dict['summary'][:60]!r}")
+
+    print("\n[5/5] tool_view over the stored upstream response")
+    handles = list(runtime.context_manager.artifact_store.list_refs())
+    if handles:
+        view_result = await dispatch_meta_tool(
+            runtime,
+            "tool_view",
+            {"handle": handles[0].handle, "selector": {"type": "head", "n_chars": 40}},
+        )
+        sliced = view_result["content"][0]["text"]
+        print(f"      head(40 chars): {sliced!r}")
+    else:
+        print("      (no artifact persisted — text-only upstream)")
+
+    # Show graceful error handling.
+    print("\n[bonus] tool_execute with invalid args returns a structured error")
+    bad = await dispatch_meta_tool(runtime, "tool_execute", {"tool_id": tool_id, "args": {}})
+    err_body = json.loads(bad["content"][0]["text"])
+    assert err_body["error"] == "ARGS_INVALID"
+    print(f"      error={err_body['error']}, message={err_body['message'][:60]}…")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))
+
+
+__all__ = ["ChoiceCard", "GatewayError", "ResultEnvelope", "main"]

--- a/examples/mcp_proxy_demo.py
+++ b/examples/mcp_proxy_demo.py
@@ -1,0 +1,118 @@
+"""Transparent MCP proxy demo (#13).
+
+Demonstrates the two surfaces the transparent proxy publishes per
+``docs/gateway_spec.md`` §4.1:
+
+1. **Discovery channel** — a stripped ``tools/list`` where every upstream
+   tool keeps its canonical ``tool_id`` and description but exposes the
+   sentinel ``inputSchema = {"type": "object"}``.
+2. **Invocation channel** — two meta-tools: ``tool_hydrate(tool_id)``
+   for retrieving the real schema on demand, and
+   ``tool_execute(tool_id, args)`` for invoking the upstream tool with
+   schema-validated arguments.
+
+The demo uses :class:`~contextweaver.adapters.StubUpstream` so it
+exercises every dispatch path without an MCP transport.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+from contextweaver.adapters import (
+    ExposureMode,
+    ProxyRuntime,
+    StubUpstream,
+    dispatch_proxy_request,
+    make_stripped_tools_list,
+)
+
+UPSTREAM_TOOL_DEFS: list[dict[str, Any]] = [
+    {
+        "name": "filesystem/read",
+        "description": "Read a file from the local filesystem.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+        "_meta": {"version": "2.0"},
+    },
+    {
+        "name": "filesystem/write",
+        "description": "Write bytes to a file on the local filesystem.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "content": {"type": "string"},
+            },
+            "required": ["path", "content"],
+        },
+        "_meta": {"version": "2.0"},
+    },
+]
+
+
+async def _handler(tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
+    if tool_name == "filesystem/read":
+        return {
+            "content": [{"type": "text", "text": f"<stub bytes for {args.get('path')!r}>"}],
+            "isError": False,
+        }
+    return {"content": [{"type": "text", "text": "stub write ok"}], "isError": False}
+
+
+async def main() -> int:
+    runtime = ProxyRuntime(
+        StubUpstream(UPSTREAM_TOOL_DEFS, handler=_handler),
+        mode=ExposureMode.TRANSPARENT,
+    )
+    runtime.register_tool_defs_sync(UPSTREAM_TOOL_DEFS)
+
+    print("[1/4] Stripped tools/list (proxy discovery channel):")
+    for entry in make_stripped_tools_list(runtime):
+        schema = entry["inputSchema"]
+        print(f"      - {entry['name']}: inputSchema={schema}")
+
+    print("\n[2/4] tool_hydrate retrieves the real schema on demand:")
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("filesystem:read"))
+    hyd = await dispatch_proxy_request(
+        runtime,
+        "tools/call",
+        {"name": "tool_hydrate", "arguments": {"tool_id": tool_id}},
+    )
+    body = json.loads(hyd["content"][0]["text"])
+    print(f"      schema properties: {list(body['args_schema'].get('properties', {}).keys())}")
+    print(f"      required: {body['args_schema'].get('required', [])}")
+
+    print("\n[3/4] tool_execute validates args before upstream dispatch:")
+    bad = await dispatch_proxy_request(
+        runtime,
+        "tools/call",
+        {"name": "tool_execute", "arguments": {"tool_id": tool_id, "args": {}}},
+    )
+    bad_body = json.loads(bad["content"][0]["text"])
+    print(f"      missing path → error={bad_body['error']}, message={bad_body['message'][:50]}")
+
+    print("\n[4/4] tool_execute happy path:")
+    ok = await dispatch_proxy_request(
+        runtime,
+        "tools/call",
+        {
+            "name": "tool_execute",
+            "arguments": {"tool_id": tool_id, "args": {"path": "/etc/hostname"}},
+        },
+    )
+    ok_body = json.loads(ok["content"][0]["text"])
+    print(f"      status={ok_body['status']}, summary={ok_body['summary'][:50]!r}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))
+
+
+__all__ = ["main"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,21 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Typing :: Typed",
 ]
-# Minimal core runtime dependencies. Each entry is broadly used in GenAI stacks
-# (often already pulled in transitively) and unblocks default behaviour the
-# library would otherwise have to approximate. Heavy or runtime-specific
-# packages live under [project.optional-dependencies] below.
+# Core runtime dependencies.  contextweaver opted into shipping the MCP SDK
+# and ``jsonschema`` as core (rather than gating them behind optional extras)
+# when the MCP proxy / gateway runtimes landed in v0.4: both are load-bearing
+# for the gateway invocation contract (see ``docs/gateway_spec.md`` §4.4) and
+# gating them behind extras forced every caller through a guarded-import
+# dance.  ``tiktoken``, ``PyYAML``, ``rank-bm25`` are broadly used in GenAI
+# stacks (often already pulled in transitively) and unblock default behaviour
+# the library would otherwise have to approximate.  Other heavy or
+# runtime-specific packages remain under [project.optional-dependencies].
 dependencies = [
     "tiktoken>=0.5",
     "PyYAML>=6.0",
     "rank-bm25>=0.2",
+    "mcp>=1.0",
+    "jsonschema>=4.0",
 ]
 
 [project.urls]
@@ -171,6 +178,10 @@ ignore_missing_imports = true
 # while still being a real installed package the adapter can import.
 [[tool.mypy.overrides]]
 module = "weaver_contracts.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "mcp.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/src/contextweaver/adapters/__init__.py
+++ b/src/contextweaver/adapters/__init__.py
@@ -1,7 +1,8 @@
 """Adapters sub-package for contextweaver.
 
 Provides thin adapters that convert external protocol data (MCP, A2A, FastMCP,
-weaver-spec) into contextweaver-native types and back.
+weaver-spec) into contextweaver-native types and back, and shipping runtime
+modes for fronting upstream MCP servers (proxy + gateway).
 """
 
 from __future__ import annotations
@@ -17,12 +18,30 @@ from contextweaver.adapters.fastmcp import (
     infer_fastmcp_namespace,
     load_fastmcp_catalog,
 )
+from contextweaver.adapters.gateway_error import GatewayError
 from contextweaver.adapters.mcp import (
     infer_namespace,
     load_mcp_session_jsonl,
     mcp_result_to_envelope,
     mcp_tool_to_selectable,
 )
+from contextweaver.adapters.mcp_gateway import (
+    GATEWAY_TOOL_NAMES,
+    dispatch_meta_tool,
+    make_gateway_meta_tools,
+)
+from contextweaver.adapters.mcp_proxy import (
+    PROXY_META_TOOL_NAMES,
+    dispatch_proxy_request,
+    make_proxy_meta_tools,
+    make_stripped_tools_list,
+)
+from contextweaver.adapters.mcp_upstream import (
+    McpClientUpstream,
+    MultiplexUpstream,
+    StubUpstream,
+)
+from contextweaver.adapters.proxy_runtime import ExposureMode, ProxyRuntime, UpstreamCall
 from contextweaver.adapters.weaver_contracts import (
     from_weaver_choice_card,
     from_weaver_choice_card_single,
@@ -37,8 +56,19 @@ from contextweaver.adapters.weaver_contracts import (
 )
 
 __all__ = [
+    "ExposureMode",
+    "GATEWAY_TOOL_NAMES",
+    "GatewayError",
+    "McpClientUpstream",
+    "MultiplexUpstream",
+    "PROXY_META_TOOL_NAMES",
+    "ProxyRuntime",
+    "StubUpstream",
+    "UpstreamCall",
     "a2a_agent_to_selectable",
     "a2a_result_to_envelope",
+    "dispatch_meta_tool",
+    "dispatch_proxy_request",
     "fastmcp_tool_to_selectable",
     "fastmcp_tools_to_catalog",
     "from_weaver_choice_card",
@@ -51,6 +81,9 @@ __all__ = [
     "load_a2a_session_jsonl",
     "load_fastmcp_catalog",
     "load_mcp_session_jsonl",
+    "make_gateway_meta_tools",
+    "make_proxy_meta_tools",
+    "make_stripped_tools_list",
     "mcp_result_to_envelope",
     "mcp_tool_to_selectable",
     "to_weaver_choice_card",

--- a/src/contextweaver/adapters/gateway_error.py
+++ b/src/contextweaver/adapters/gateway_error.py
@@ -1,0 +1,66 @@
+"""Structured error payload for the MCP proxy/gateway meta-tools.
+
+The :class:`GatewayError` dataclass is the on-the-wire error shape
+specified by ``docs/gateway_spec.md`` §3.4.  It is returned from
+``tool_browse``, ``tool_execute``, ``tool_view``, and ``tool_hydrate``
+when an invocation cannot be satisfied — the meta-tools never raise
+across the MCP boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+GatewayErrorCode = Literal[
+    "PATH_INVALID",
+    "PATH_NOT_FOUND",
+    "ARGS_INVALID",
+    "UPSTREAM_ERROR",
+    "HYDRATE_FAILED",
+    "VIEW_FAILED",
+]
+
+
+@dataclass
+class GatewayError:
+    """Structured error payload returned from a gateway/proxy meta-tool.
+
+    Attributes:
+        code: One of the gateway error codes (§3.4).  ``UPSTREAM_ERROR``
+            extends the spec list to cover transport failures from the
+            wrapped MCP server; ``HYDRATE_FAILED`` and ``VIEW_FAILED``
+            cover the analogous failures on the gateway's other two
+            meta-tools.
+        message: A short, human-readable description of the failure.
+        path: The offending path or tool_id when relevant; empty string
+            otherwise.
+        details: Optional implementation-defined diagnostics (e.g.
+            ``jsonschema`` validation error path lists).
+    """
+
+    code: GatewayErrorCode
+    message: str
+    path: str = ""
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the §3.4 JSON shape."""
+        out: dict[str, Any] = {
+            "error": self.code,
+            "message": self.message,
+            "path": self.path,
+        }
+        if self.details:
+            out["details"] = dict(self.details)
+        return out
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> GatewayError:
+        """Deserialise from the §3.4 JSON shape."""
+        return cls(
+            code=data["error"],
+            message=data.get("message", ""),
+            path=data.get("path", ""),
+            details=dict(data.get("details", {})),
+        )

--- a/src/contextweaver/adapters/mcp.py
+++ b/src/contextweaver/adapters/mcp.py
@@ -16,6 +16,7 @@ from typing import Any, Literal
 
 from contextweaver.envelope import ResultEnvelope
 from contextweaver.exceptions import CatalogError
+from contextweaver.routing.tool_id import canonical_tool_id
 from contextweaver.types import ArtifactRef, ContextItem, ItemKind, SelectableItem
 
 logger = logging.getLogger("contextweaver.adapters")
@@ -53,6 +54,36 @@ def infer_namespace(tool_name: str) -> str:
     if len(parts) >= 3 and parts[0]:
         return parts[0]
     return "mcp"
+
+
+def _derive_tool_id_name(upstream_name: str) -> str:
+    """Derive the canonical ``tool_id`` name field from *upstream_name* (§1.4).
+
+    The rule is keyed on the separator that :func:`infer_namespace` matched:
+
+    - Dot or slash separator: the namespace prefix is stripped from
+      ``name`` (it is unambiguously carried by the namespace field).
+    - Underscore with ≥ 3 segments, or the ``mcp`` fallback: the prefix
+      is **preserved** in ``name`` because underscores can appear inside
+      the upstream tool name itself.
+
+    Args:
+        upstream_name: The raw upstream MCP tool name.
+
+    Returns:
+        The derived ``name`` portion of the canonical ``tool_id``.
+    """
+    if "." in upstream_name:
+        prefix, _, rest = upstream_name.partition(".")
+        if prefix and rest:
+            return rest
+    if "/" in upstream_name:
+        prefix, _, rest = upstream_name.partition("/")
+        if prefix and rest:
+            return rest
+    # Underscore-≥3-segments and the ``mcp`` fallback both preserve the
+    # full upstream name.
+    return upstream_name
 
 
 def mcp_tool_to_selectable(tool_def: dict[str, Any]) -> SelectableItem:
@@ -121,14 +152,32 @@ def mcp_tool_to_selectable(tool_def: dict[str, Any]) -> SelectableItem:
     side_effects = not annotations.get("readOnlyHint", False)
     cost_hint = float(annotations.get("costHint", 0.0))
 
-    logger.debug("mcp_tool_to_selectable: name=%s, tags=%s", name, sorted(tags))
+    # Canonical tool_id per docs/gateway_spec.md §1.  The legacy
+    # ``mcp:{name}`` form is retired (§1.7 — no deprecation period).
+    upstream_name = str(name)
+    namespace = infer_namespace(upstream_name)
+    derived_name = _derive_tool_id_name(upstream_name)
+    meta_block = tool_def.get("_meta") or {}
+    version_raw = meta_block.get("version") if isinstance(meta_block, dict) else None
+    version = str(version_raw) if version_raw else None
+    tool_id = canonical_tool_id(
+        namespace=namespace,
+        name=derived_name,
+        upstream_name=upstream_name,
+        input_schema=input_schema,
+        version=version,
+    )
+
+    logger.debug(
+        "mcp_tool_to_selectable: name=%s, tool_id=%s, tags=%s", name, tool_id, sorted(tags)
+    )
     return SelectableItem(
-        id=f"mcp:{name}",
+        id=tool_id,
         kind="tool",
-        name=str(name),
+        name=upstream_name,
         description=str(description),
         tags=sorted(tags),
-        namespace=infer_namespace(str(name)),
+        namespace=namespace,
         args_schema=dict(input_schema),
         output_schema=output_schema,
         side_effects=side_effects,

--- a/src/contextweaver/adapters/mcp_gateway.py
+++ b/src/contextweaver/adapters/mcp_gateway.py
@@ -125,7 +125,7 @@ async def dispatch_meta_tool(
 
     The returned dict is the MCP ``CallToolResult`` shape (``content``,
     ``isError``).  Errors produced by :class:`ProxyRuntime` are
-    serialised via :func:`_envelope_call_result` so they are visible to
+    serialised via :func:`envelope_call_result` so they are visible to
     the agent's client without raising across the MCP boundary.
 
     Args:
@@ -142,12 +142,12 @@ async def dispatch_meta_tool(
             path=args.get("path"),
             top_k=args.get("top_k"),
         )
-        return _envelope_call_result(result, label="tool_browse")
+        return envelope_call_result(result, label="tool_browse")
     if name == TOOL_EXECUTE:
         tool_id = args.get("tool_id")
         tool_args = args.get("args", {}) or {}
         if not isinstance(tool_id, str) or not isinstance(tool_args, dict):
-            return _envelope_call_result(
+            return envelope_call_result(
                 GatewayError(
                     code="ARGS_INVALID",
                     message="tool_execute requires string 'tool_id' and object 'args'.",
@@ -155,12 +155,12 @@ async def dispatch_meta_tool(
                 label="tool_execute",
             )
         envelope = await runtime.execute(tool_id, tool_args)
-        return _envelope_call_result(envelope, label="tool_execute")
+        return envelope_call_result(envelope, label="tool_execute")
     if name == TOOL_VIEW:
         handle = args.get("handle")
         selector = args.get("selector", {}) or {}
         if not isinstance(handle, str) or not isinstance(selector, dict):
-            return _envelope_call_result(
+            return envelope_call_result(
                 GatewayError(
                     code="ARGS_INVALID",
                     message="tool_view requires string 'handle' and object 'selector'.",
@@ -168,8 +168,8 @@ async def dispatch_meta_tool(
                 label="tool_view",
             )
         sliced = runtime.view(handle, selector)
-        return _envelope_call_result(sliced, label="tool_view")
-    return _envelope_call_result(
+        return envelope_call_result(sliced, label="tool_view")
+    return envelope_call_result(
         GatewayError(
             code="ARGS_INVALID",
             message=f"unknown meta-tool {name!r} (valid: {list(GATEWAY_TOOL_NAMES)})",
@@ -178,8 +178,12 @@ async def dispatch_meta_tool(
     )
 
 
-def _envelope_call_result(value: Any, *, label: str) -> dict[str, Any]:  # noqa: ANN401
+def envelope_call_result(value: Any, *, label: str) -> dict[str, Any]:  # noqa: ANN401
     """Wrap *value* in an MCP ``CallToolResult`` dict.
+
+    Shared by :mod:`mcp_gateway` and :mod:`mcp_proxy` — promoted to a
+    public symbol so both siblings can import it without coupling
+    through a private name.
 
     - :class:`GatewayError` → ``isError=True`` with the §3.4 JSON shape
       as a text content part.

--- a/src/contextweaver/adapters/mcp_gateway.py
+++ b/src/contextweaver/adapters/mcp_gateway.py
@@ -1,0 +1,228 @@
+"""Two-tool MCP gateway (#28) + ``tool_view`` meta-tool (#34).
+
+The gateway exposes exactly **three** MCP meta-tools per
+``docs/gateway_spec.md`` §4.2:
+
+- ``tool_browse(query|path)`` — returns ``list[ChoiceCard]`` per §2.
+- ``tool_execute(tool_id, args)`` — internal hydrate + jsonschema
+  validation + upstream call + firewall.
+- ``tool_view(handle, selector)`` — drilldown into a previously-stored
+  artifact (#34).
+
+This module provides two thin layers on top of
+:class:`~contextweaver.adapters.proxy_runtime.ProxyRuntime`:
+
+- :func:`make_gateway_meta_tools` — returns the three MCP tool
+  definitions ready for an upstream ``tools/list``.
+- :func:`dispatch_meta_tool` — invokes one of the three meta-tools and
+  packages the response in the MCP wire format the agent's client
+  expects.
+
+The MCP server transport binding (stdio / SSE) lives in
+:mod:`contextweaver.adapters.mcp_gateway_server`.  The two-layer split
+keeps this module pure (no transport coupling) and synchronous for the
+parts that do not need to await upstream.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+from contextweaver.adapters.gateway_error import GatewayError
+from contextweaver.adapters.proxy_runtime import ProxyRuntime
+from contextweaver.envelope import ChoiceCard, ResultEnvelope
+
+logger = logging.getLogger("contextweaver.adapters.mcp_gateway")
+
+TOOL_BROWSE = "tool_browse"
+TOOL_EXECUTE = "tool_execute"
+TOOL_VIEW = "tool_view"
+
+GATEWAY_TOOL_NAMES = (TOOL_BROWSE, TOOL_EXECUTE, TOOL_VIEW)
+
+
+def make_gateway_meta_tools(runtime: ProxyRuntime) -> list[dict[str, Any]]:
+    """Return the three MCP meta-tool definitions for gateway mode (§4.2).
+
+    The shape mirrors the MCP ``tools/list`` entry: ``name``,
+    ``description``, ``inputSchema``.  No banned fields per §2.2.
+
+    Args:
+        runtime: A configured :class:`ProxyRuntime`.  Currently unused
+            in shape (the meta-tools are statically defined) but accepted
+            so future per-runtime customisation (e.g. exposing the
+            configured top-k via the description) is non-breaking.
+
+    Returns:
+        A list of three MCP tool definition dicts.
+    """
+    _ = runtime  # reserved
+    return [
+        {
+            "name": TOOL_BROWSE,
+            "description": (
+                "Browse the upstream tool catalog.  Pass exactly one of "
+                "'query' (free-text) or 'path' (e.g. '/github/issues') and "
+                "receive a bounded list of ChoiceCards."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "path": {"type": "string"},
+                    "top_k": {"type": "integer", "minimum": 1, "maximum": 50},
+                },
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": TOOL_EXECUTE,
+            "description": (
+                "Invoke an upstream tool by canonical tool_id.  Arguments "
+                "are validated against the hydrated input schema before "
+                "dispatch and the response is compacted via the context "
+                "firewall."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "tool_id": {"type": "string"},
+                    "args": {"type": "object"},
+                },
+                "required": ["tool_id", "args"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": TOOL_VIEW,
+            "description": (
+                "Drill into a previously stored artifact handle and "
+                "return a slice (head / lines / json_keys / rows) per the "
+                "ArtifactStore.drilldown contract."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "handle": {"type": "string"},
+                    "selector": {"type": "object"},
+                },
+                "required": ["handle", "selector"],
+                "additionalProperties": False,
+            },
+        },
+    ]
+
+
+async def dispatch_meta_tool(
+    runtime: ProxyRuntime,
+    name: str,
+    args: dict[str, Any],
+) -> dict[str, Any]:
+    """Invoke a gateway meta-tool by name and return an MCP-format response.
+
+    The returned dict is the MCP ``CallToolResult`` shape (``content``,
+    ``isError``).  Errors produced by :class:`ProxyRuntime` are
+    serialised via :func:`_envelope_call_result` so they are visible to
+    the agent's client without raising across the MCP boundary.
+
+    Args:
+        runtime: The active :class:`ProxyRuntime`.
+        name: One of :data:`GATEWAY_TOOL_NAMES`.
+        args: Arguments coming off the MCP wire (already JSON-decoded).
+
+    Returns:
+        An MCP-format ``CallToolResult`` dict.
+    """
+    if name == TOOL_BROWSE:
+        result = runtime.browse(
+            query=args.get("query"),
+            path=args.get("path"),
+            top_k=args.get("top_k"),
+        )
+        return _envelope_call_result(result, label="tool_browse")
+    if name == TOOL_EXECUTE:
+        tool_id = args.get("tool_id")
+        tool_args = args.get("args", {}) or {}
+        if not isinstance(tool_id, str) or not isinstance(tool_args, dict):
+            return _envelope_call_result(
+                GatewayError(
+                    code="ARGS_INVALID",
+                    message="tool_execute requires string 'tool_id' and object 'args'.",
+                ),
+                label="tool_execute",
+            )
+        envelope = await runtime.execute(tool_id, tool_args)
+        return _envelope_call_result(envelope, label="tool_execute")
+    if name == TOOL_VIEW:
+        handle = args.get("handle")
+        selector = args.get("selector", {}) or {}
+        if not isinstance(handle, str) or not isinstance(selector, dict):
+            return _envelope_call_result(
+                GatewayError(
+                    code="ARGS_INVALID",
+                    message="tool_view requires string 'handle' and object 'selector'.",
+                ),
+                label="tool_view",
+            )
+        sliced = runtime.view(handle, selector)
+        return _envelope_call_result(sliced, label="tool_view")
+    return _envelope_call_result(
+        GatewayError(
+            code="ARGS_INVALID",
+            message=f"unknown meta-tool {name!r} (valid: {list(GATEWAY_TOOL_NAMES)})",
+        ),
+        label=name,
+    )
+
+
+def _envelope_call_result(value: Any, *, label: str) -> dict[str, Any]:  # noqa: ANN401
+    """Wrap *value* in an MCP ``CallToolResult`` dict.
+
+    - :class:`GatewayError` → ``isError=True`` with the §3.4 JSON shape
+      as a text content part.
+    - :class:`ResultEnvelope` → ``isError`` mirrors the envelope status
+      and the body carries the envelope JSON.
+    - ``list[ChoiceCard]`` → ``isError=False`` with a JSON array body.
+    - Any other value (e.g. a plain string from ``tool_view``) is
+      serialised as JSON (or as plain text if not JSON-encodable).
+    """
+    _ = label
+    if isinstance(value, GatewayError):
+        return {
+            "content": [{"type": "text", "text": json.dumps(value.to_dict())}],
+            "isError": True,
+        }
+    if isinstance(value, ResultEnvelope):
+        return {
+            "content": [{"type": "text", "text": json.dumps(value.to_dict())}],
+            "isError": value.status == "error",
+        }
+    if isinstance(value, list):
+        payload = [c.to_dict() if isinstance(c, ChoiceCard) else c for c in value]
+        return {
+            "content": [{"type": "text", "text": json.dumps(payload)}],
+            "isError": False,
+        }
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            "content": [{"type": "text", "text": json.dumps(asdict(value))}],
+            "isError": False,
+        }
+    if isinstance(value, str):
+        return {
+            "content": [{"type": "text", "text": value}],
+            "isError": False,
+        }
+    try:
+        return {
+            "content": [{"type": "text", "text": json.dumps(value)}],
+            "isError": False,
+        }
+    except TypeError:
+        return {
+            "content": [{"type": "text", "text": repr(value)}],
+            "isError": False,
+        }

--- a/src/contextweaver/adapters/mcp_gateway_server.py
+++ b/src/contextweaver/adapters/mcp_gateway_server.py
@@ -66,7 +66,8 @@ class McpGatewayServer:
     ) -> None:
         if runtime.mode != ExposureMode.GATEWAY:
             logger.warning(
-                "McpGatewayServer received runtime in %s mode; forcing GATEWAY",
+                "McpGatewayServer received runtime in %s mode; expected GATEWAY — "
+                "behaviour may differ",
                 runtime.mode,
             )
         self.runtime = runtime

--- a/src/contextweaver/adapters/mcp_gateway_server.py
+++ b/src/contextweaver/adapters/mcp_gateway_server.py
@@ -1,0 +1,119 @@
+"""Run the two-tool gateway (#28) + ``tool_view`` (#34) as a real MCP server.
+
+This is the transport-binding layer that lifts
+:mod:`contextweaver.adapters.mcp_gateway` onto an
+:class:`mcp.server.Server`.  Keeping it in a separate module preserves
+the "pure logic" status of :mod:`mcp_gateway` itself — that module has
+no MCP-SDK dependency at construction time and can be tested without
+spinning up a server.
+
+Typical usage::
+
+    import asyncio
+    from contextweaver.adapters import ProxyRuntime, StubUpstream
+    from contextweaver.adapters.mcp_gateway_server import McpGatewayServer
+
+    runtime = ProxyRuntime(StubUpstream([...]))
+    server = McpGatewayServer(runtime, name="example-gateway")
+    asyncio.run(server.run_stdio())
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, cast
+
+from mcp import types as mcp_types
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+from contextweaver.adapters.mcp_gateway import (
+    GATEWAY_TOOL_NAMES,
+    dispatch_meta_tool,
+    make_gateway_meta_tools,
+)
+from contextweaver.adapters.proxy_runtime import ExposureMode, ProxyRuntime
+
+logger = logging.getLogger("contextweaver.adapters.mcp_gateway_server")
+
+
+class McpGatewayServer:
+    """Binds :mod:`mcp_gateway` onto an :class:`mcp.server.Server`.
+
+    Args:
+        runtime: A configured :class:`ProxyRuntime`.  The constructor
+            sets :attr:`runtime.mode` to :attr:`ExposureMode.GATEWAY` if
+            it was not already.
+        name: MCP server display name advertised in initialization.
+        version: Optional MCP server version string.
+        instructions: Optional human-readable instructions advertised to
+            the agent.
+
+    Attributes:
+        runtime: The wrapped :class:`ProxyRuntime`.
+        server: The underlying :class:`mcp.server.Server` with handlers
+            wired up.
+    """
+
+    def __init__(
+        self,
+        runtime: ProxyRuntime,
+        *,
+        name: str = "contextweaver-gateway",
+        version: str | None = None,
+        instructions: str | None = None,
+    ) -> None:
+        if runtime.mode != ExposureMode.GATEWAY:
+            logger.warning(
+                "McpGatewayServer received runtime in %s mode; forcing GATEWAY",
+                runtime.mode,
+            )
+        self.runtime = runtime
+        self.server: Server[Any, Any] = Server(name, version=version, instructions=instructions)
+        self._register_handlers()
+
+    def _register_handlers(self) -> None:
+        async def handle_list_tools() -> list[mcp_types.Tool]:
+            return [
+                mcp_types.Tool(
+                    name=tool["name"],
+                    description=tool["description"],
+                    inputSchema=tool["inputSchema"],
+                )
+                for tool in make_gateway_meta_tools(self.runtime)
+            ]
+
+        async def handle_call_tool(
+            name: str, arguments: dict[str, Any] | None
+        ) -> tuple[list[mcp_types.TextContent], bool]:
+            if name not in GATEWAY_TOOL_NAMES:
+                payload = json.dumps(
+                    {
+                        "error": "ARGS_INVALID",
+                        "message": f"unknown meta-tool {name!r}",
+                    }
+                )
+                return [mcp_types.TextContent(type="text", text=payload)], True
+            result = await dispatch_meta_tool(self.runtime, name, arguments or {})
+            content = [
+                mcp_types.TextContent(type="text", text=part.get("text", ""))
+                for part in result.get("content", [])
+                if part.get("type") == "text"
+            ]
+            return content, bool(result.get("isError", False))
+
+        # Register handlers by calling the decorators as functions.  This
+        # avoids the ``Any`` propagation that the MCP SDK's untyped
+        # decorator factory triggers under ``mypy --strict``.
+        cast(Any, self.server).list_tools()(handle_list_tools)
+        cast(Any, self.server).call_tool()(handle_call_tool)
+
+    async def run_stdio(self) -> None:
+        """Run the server over stdio until the client disconnects."""
+        async with stdio_server() as (read_stream, write_stream):
+            await self.server.run(
+                read_stream,
+                write_stream,
+                self.server.create_initialization_options(),
+            )

--- a/src/contextweaver/adapters/mcp_proxy.py
+++ b/src/contextweaver/adapters/mcp_proxy.py
@@ -30,7 +30,7 @@ import logging
 from typing import Any
 
 from contextweaver.adapters.gateway_error import GatewayError
-from contextweaver.adapters.mcp_gateway import _envelope_call_result
+from contextweaver.adapters.mcp_gateway import envelope_call_result
 from contextweaver.adapters.proxy_runtime import ExposureMode, ProxyRuntime
 
 logger = logging.getLogger("contextweaver.adapters.mcp_proxy")
@@ -131,7 +131,7 @@ async def dispatch_proxy_request(
         name = params.get("name")
         args = params.get("arguments", {}) or {}
         if not isinstance(name, str):
-            return _envelope_call_result(
+            return envelope_call_result(
                 GatewayError(
                     code="ARGS_INVALID",
                     message="tools/call params require a string 'name'.",
@@ -141,7 +141,7 @@ async def dispatch_proxy_request(
         if name == TOOL_HYDRATE:
             tool_id = args.get("tool_id")
             if not isinstance(tool_id, str):
-                return _envelope_call_result(
+                return envelope_call_result(
                     GatewayError(
                         code="ARGS_INVALID",
                         message="tool_hydrate requires a string 'tool_id'.",
@@ -150,7 +150,7 @@ async def dispatch_proxy_request(
                 )
             hydrated = runtime.hydrate(tool_id)
             if isinstance(hydrated, GatewayError):
-                return _envelope_call_result(hydrated, label=TOOL_HYDRATE)
+                return envelope_call_result(hydrated, label=TOOL_HYDRATE)
             payload = {
                 "tool_id": tool_id,
                 "args_schema": hydrated.args_schema,
@@ -165,7 +165,7 @@ async def dispatch_proxy_request(
             tool_id = args.get("tool_id")
             tool_args = args.get("args", {}) or {}
             if not isinstance(tool_id, str) or not isinstance(tool_args, dict):
-                return _envelope_call_result(
+                return envelope_call_result(
                     GatewayError(
                         code="ARGS_INVALID",
                         message="tool_execute requires string 'tool_id' and object 'args'.",
@@ -173,15 +173,15 @@ async def dispatch_proxy_request(
                     label=TOOL_EXECUTE,
                 )
             envelope = await runtime.execute(tool_id, tool_args)
-            return _envelope_call_result(envelope, label=TOOL_EXECUTE)
-        return _envelope_call_result(
+            return envelope_call_result(envelope, label=TOOL_EXECUTE)
+        return envelope_call_result(
             GatewayError(
                 code="ARGS_INVALID",
                 message=f"proxy mode does not expose meta-tool {name!r}",
             ),
             label=name,
         )
-    return _envelope_call_result(
+    return envelope_call_result(
         GatewayError(
             code="ARGS_INVALID",
             message=f"unsupported MCP method {method!r}",

--- a/src/contextweaver/adapters/mcp_proxy.py
+++ b/src/contextweaver/adapters/mcp_proxy.py
@@ -1,0 +1,201 @@
+"""Transparent MCP proxy (#13) — stripped ``tools/list`` + invocation channel.
+
+The transparent proxy publishes two surfaces per
+``docs/gateway_spec.md`` §4.1:
+
+1. **Discovery channel** — :func:`make_stripped_tools_list` replaces the
+   upstream ``inputSchema`` with the sentinel ``{"type": "object"}`` for
+   every tool, keeping prompt cost constant per tool.
+2. **Invocation channel** — :func:`make_proxy_meta_tools` exposes two
+   meta-tools, ``tool_hydrate(tool_id)`` and ``tool_execute(tool_id, args)``,
+   so an agent can retrieve a real schema only when it intends to call
+   the underlying tool.
+
+Both surfaces dispatch through :class:`~contextweaver.adapters.proxy_runtime.ProxyRuntime`
+in :attr:`ExposureMode.TRANSPARENT` mode.
+
+A note on MCP ``name`` characters: the canonical ``tool_id`` may contain
+``:`` and ``#``.  MCP treats ``name`` as opaque, but strict downstream
+clients may reject these characters.  Implementations MAY URL-encode the
+``tool_id`` in the ``name`` field; round-trip is preserved because the
+canonical helpers (:func:`~contextweaver.routing.tool_id.parse_tool_id` /
+:func:`~contextweaver.routing.tool_id.format_tool_id`) consume the
+decoded form.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from contextweaver.adapters.gateway_error import GatewayError
+from contextweaver.adapters.mcp_gateway import _envelope_call_result
+from contextweaver.adapters.proxy_runtime import ExposureMode, ProxyRuntime
+
+logger = logging.getLogger("contextweaver.adapters.mcp_proxy")
+
+TOOL_HYDRATE = "tool_hydrate"
+TOOL_EXECUTE = "tool_execute"
+
+PROXY_META_TOOL_NAMES = (TOOL_HYDRATE, TOOL_EXECUTE)
+
+
+def make_stripped_tools_list(runtime: ProxyRuntime) -> list[dict[str, Any]]:
+    """Return the stripped ``tools/list`` for the transparent-proxy mode (§4.1).
+
+    The returned list mirrors :meth:`ProxyRuntime.strip_tools_list` and
+    appends the two meta-tools published on the invocation channel so a
+    single ``tools/list`` response covers both surfaces.
+
+    Args:
+        runtime: A configured :class:`ProxyRuntime`.  ``runtime.mode``
+            is not enforced because the proxy may be composed with a
+            gateway in the same process during migration; the caller is
+            responsible for matching mode to wiring.
+
+    Returns:
+        A list of MCP-format tool definitions: ``len(catalog) + 2``
+        entries.
+    """
+    entries = list(runtime.strip_tools_list())
+    entries.extend(make_proxy_meta_tools(runtime))
+    return entries
+
+
+def make_proxy_meta_tools(runtime: ProxyRuntime) -> list[dict[str, Any]]:
+    """Return the two invocation-channel meta-tools (§4.1)."""
+    _ = runtime
+    return [
+        {
+            "name": TOOL_HYDRATE,
+            "description": (
+                "Retrieve the full input schema for a tool by its canonical "
+                "tool_id.  Use this before tool_execute to inspect the "
+                "schema you must supply."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {"tool_id": {"type": "string"}},
+                "required": ["tool_id"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": TOOL_EXECUTE,
+            "description": (
+                "Invoke an upstream tool by canonical tool_id.  Arguments "
+                "are validated against the hydrated input schema before "
+                "dispatch."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "tool_id": {"type": "string"},
+                    "args": {"type": "object"},
+                },
+                "required": ["tool_id", "args"],
+                "additionalProperties": False,
+            },
+        },
+    ]
+
+
+async def dispatch_proxy_request(
+    runtime: ProxyRuntime,
+    method: str,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Route an MCP request to the proxy's discovery or invocation channel.
+
+    Supports the two MCP methods relevant to the proxy:
+
+    - ``tools/list`` → returns the stripped catalog (§4.1).
+    - ``tools/call`` → routes to ``tool_hydrate`` or ``tool_execute``
+      based on the ``name`` field.
+
+    Args:
+        runtime: A :class:`ProxyRuntime` (typically in
+            :attr:`ExposureMode.TRANSPARENT` mode).
+        method: The MCP method name.
+        params: The MCP request params (already JSON-decoded).
+
+    Returns:
+        An MCP-format response dict.  Errors are returned as
+        ``isError=True`` ``CallToolResult`` payloads to match how MCP
+        clients consume tool failures.
+    """
+    if method == "tools/list":
+        return {"tools": make_stripped_tools_list(runtime)}
+    if method == "tools/call":
+        name = params.get("name")
+        args = params.get("arguments", {}) or {}
+        if not isinstance(name, str):
+            return _envelope_call_result(
+                GatewayError(
+                    code="ARGS_INVALID",
+                    message="tools/call params require a string 'name'.",
+                ),
+                label="tools/call",
+            )
+        if name == TOOL_HYDRATE:
+            tool_id = args.get("tool_id")
+            if not isinstance(tool_id, str):
+                return _envelope_call_result(
+                    GatewayError(
+                        code="ARGS_INVALID",
+                        message="tool_hydrate requires a string 'tool_id'.",
+                    ),
+                    label=TOOL_HYDRATE,
+                )
+            hydrated = runtime.hydrate(tool_id)
+            if isinstance(hydrated, GatewayError):
+                return _envelope_call_result(hydrated, label=TOOL_HYDRATE)
+            payload = {
+                "tool_id": tool_id,
+                "args_schema": hydrated.args_schema,
+                "examples": list(hydrated.examples),
+                "constraints": hydrated.constraints,
+            }
+            return {
+                "content": [{"type": "text", "text": json.dumps(payload)}],
+                "isError": False,
+            }
+        if name == TOOL_EXECUTE:
+            tool_id = args.get("tool_id")
+            tool_args = args.get("args", {}) or {}
+            if not isinstance(tool_id, str) or not isinstance(tool_args, dict):
+                return _envelope_call_result(
+                    GatewayError(
+                        code="ARGS_INVALID",
+                        message="tool_execute requires string 'tool_id' and object 'args'.",
+                    ),
+                    label=TOOL_EXECUTE,
+                )
+            envelope = await runtime.execute(tool_id, tool_args)
+            return _envelope_call_result(envelope, label=TOOL_EXECUTE)
+        return _envelope_call_result(
+            GatewayError(
+                code="ARGS_INVALID",
+                message=f"proxy mode does not expose meta-tool {name!r}",
+            ),
+            label=name,
+        )
+    return _envelope_call_result(
+        GatewayError(
+            code="ARGS_INVALID",
+            message=f"unsupported MCP method {method!r}",
+        ),
+        label=method,
+    )
+
+
+__all__ = [
+    "ExposureMode",
+    "PROXY_META_TOOL_NAMES",
+    "TOOL_EXECUTE",
+    "TOOL_HYDRATE",
+    "dispatch_proxy_request",
+    "make_proxy_meta_tools",
+    "make_stripped_tools_list",
+]

--- a/src/contextweaver/adapters/mcp_proxy_server.py
+++ b/src/contextweaver/adapters/mcp_proxy_server.py
@@ -1,0 +1,141 @@
+"""Run the transparent MCP proxy (#13) as a real MCP server.
+
+This is the transport-binding layer that lifts
+:mod:`contextweaver.adapters.mcp_proxy` onto an
+:class:`mcp.server.Server`.  The "pure logic" :mod:`mcp_proxy` module
+has no MCP-SDK dependency at construction time and is independently
+testable.
+
+The transparent proxy advertises **every** upstream tool — each entry
+in ``tools/list`` is a stripped form per §4.1 (sentinel
+``inputSchema``).  Schemas are materialised only when the agent calls
+``tool_hydrate(tool_id)`` and the proxy executes via
+``tool_execute(tool_id, args)``.
+
+Typical usage::
+
+    import asyncio
+    from contextweaver.adapters import ProxyRuntime, ExposureMode, StubUpstream
+    from contextweaver.adapters.mcp_proxy_server import McpProxyServer
+
+    runtime = ProxyRuntime(StubUpstream([...]), mode=ExposureMode.TRANSPARENT)
+    await runtime.refresh_catalog()
+    server = McpProxyServer(runtime, name="example-proxy")
+    asyncio.run(server.run_stdio())
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, cast
+
+from mcp import types as mcp_types
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+from contextweaver.adapters.mcp_proxy import (
+    PROXY_META_TOOL_NAMES,
+    dispatch_proxy_request,
+    make_stripped_tools_list,
+)
+from contextweaver.adapters.proxy_runtime import ExposureMode, ProxyRuntime
+
+logger = logging.getLogger("contextweaver.adapters.mcp_proxy_server")
+
+
+class McpProxyServer:
+    """Binds :mod:`mcp_proxy` onto an :class:`mcp.server.Server`.
+
+    Args:
+        runtime: A configured :class:`ProxyRuntime` in
+            :attr:`ExposureMode.TRANSPARENT` mode.
+        name: MCP server display name.
+        version: Optional MCP server version string.
+        instructions: Optional human-readable instructions.
+    """
+
+    def __init__(
+        self,
+        runtime: ProxyRuntime,
+        *,
+        name: str = "contextweaver-proxy",
+        version: str | None = None,
+        instructions: str | None = None,
+    ) -> None:
+        if runtime.mode != ExposureMode.TRANSPARENT:
+            logger.warning(
+                "McpProxyServer received runtime in %s mode; forcing TRANSPARENT",
+                runtime.mode,
+            )
+        self.runtime = runtime
+        self.server: Server[Any, Any] = Server(name, version=version, instructions=instructions)
+        self._register_handlers()
+
+    def _register_handlers(self) -> None:
+        async def handle_list_tools() -> list[mcp_types.Tool]:
+            return [
+                mcp_types.Tool(
+                    name=tool["name"],
+                    description=tool["description"],
+                    inputSchema=tool["inputSchema"],
+                )
+                for tool in make_stripped_tools_list(self.runtime)
+            ]
+
+        async def handle_call_tool(
+            name: str, arguments: dict[str, Any] | None
+        ) -> tuple[list[mcp_types.TextContent], bool]:
+            # The proxy supports two meta-tools (tool_hydrate / tool_execute).
+            # Any other name is treated as a direct upstream call routed via
+            # tool_execute(name=tool_id) for the transparent flow.
+            if name in PROXY_META_TOOL_NAMES:
+                result = await dispatch_proxy_request(
+                    self.runtime,
+                    "tools/call",
+                    {"name": name, "arguments": arguments or {}},
+                )
+            else:
+                # Direct invocation of a stripped catalog entry: treat the
+                # MCP tool name as the canonical tool_id and dispatch via
+                # tool_execute.
+                result = await dispatch_proxy_request(
+                    self.runtime,
+                    "tools/call",
+                    {
+                        "name": "tool_execute",
+                        "arguments": {
+                            "tool_id": name,
+                            "args": arguments or {},
+                        },
+                    },
+                )
+            content = [
+                mcp_types.TextContent(type="text", text=part.get("text", ""))
+                for part in result.get("content", [])
+                if part.get("type") == "text"
+            ]
+            if not content:
+                content = [
+                    mcp_types.TextContent(
+                        type="text",
+                        text=json.dumps(
+                            {"error": "UPSTREAM_ERROR", "message": "empty upstream response"}
+                        ),
+                    )
+                ]
+            return content, bool(result.get("isError", False))
+
+        # Register handlers by calling the decorators as functions.  See
+        # the matching comment in ``mcp_gateway_server.py`` for context.
+        cast(Any, self.server).list_tools()(handle_list_tools)
+        cast(Any, self.server).call_tool()(handle_call_tool)
+
+    async def run_stdio(self) -> None:
+        """Run the proxy over stdio until the client disconnects."""
+        async with stdio_server() as (read_stream, write_stream):
+            await self.server.run(
+                read_stream,
+                write_stream,
+                self.server.create_initialization_options(),
+            )

--- a/src/contextweaver/adapters/mcp_proxy_server.py
+++ b/src/contextweaver/adapters/mcp_proxy_server.py
@@ -65,7 +65,8 @@ class McpProxyServer:
     ) -> None:
         if runtime.mode != ExposureMode.TRANSPARENT:
             logger.warning(
-                "McpProxyServer received runtime in %s mode; forcing TRANSPARENT",
+                "McpProxyServer received runtime in %s mode; expected TRANSPARENT — "
+                "behaviour may differ",
                 runtime.mode,
             )
         self.runtime = runtime

--- a/src/contextweaver/adapters/mcp_upstream.py
+++ b/src/contextweaver/adapters/mcp_upstream.py
@@ -25,6 +25,7 @@ types) because the runtime's downstream consumers
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -85,21 +86,40 @@ class McpClientUpstream:
 
     Args:
         session: A connected :class:`mcp.client.session.ClientSession`.
+        timeout: Seconds before an upstream call is abandoned and an
+            ``isError`` result is returned.  Defaults to 30 seconds.
+            Pass ``None`` to disable the timeout (not recommended for
+            production deployments).
     """
 
-    def __init__(self, session: Any) -> None:  # noqa: ANN401 — MCP SDK ClientSession
+    def __init__(
+        self,
+        session: Any,  # noqa: ANN401 — MCP SDK ClientSession
+        *,
+        timeout: float | None = 30.0,
+    ) -> None:
         self._session = session
+        self._timeout = timeout
 
     async def list_tools(self) -> list[dict[str, Any]]:
         """Call ``tools/list`` upstream and return dict-shaped defs."""
-        listing = await self._session.list_tools()
+        listing = await asyncio.wait_for(self._session.list_tools(), timeout=self._timeout)
         tools = getattr(listing, "tools", listing) or []
         return [_tool_to_dict(t) for t in tools]
 
     async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         """Forward a tool call and return a dict-shaped MCP result."""
         try:
-            result = await self._session.call_tool(tool_name, arguments)
+            result = await asyncio.wait_for(
+                self._session.call_tool(tool_name, arguments),
+                timeout=self._timeout,
+            )
+        except asyncio.TimeoutError:
+            logger.debug("upstream call_tool %s timed out after %ss", tool_name, self._timeout)
+            return {
+                "content": [{"type": "text", "text": f"upstream timeout after {self._timeout}s"}],
+                "isError": True,
+            }
         except Exception as exc:  # noqa: BLE001
             logger.debug("upstream call_tool %s failed: %s", tool_name, exc)
             return {

--- a/src/contextweaver/adapters/mcp_upstream.py
+++ b/src/contextweaver/adapters/mcp_upstream.py
@@ -1,0 +1,171 @@
+"""Concrete :class:`UpstreamCall` adapters for the MCP proxy / gateway.
+
+The :class:`ProxyRuntime` consumes a transport-agnostic
+:class:`~contextweaver.adapters.proxy_runtime.UpstreamCall` Protocol so it
+can be exercised in unit tests without spinning up a real MCP server.
+This module ships two concrete implementations of that Protocol:
+
+- :class:`StubUpstream` — in-process dict-shaped stub for tests and
+  examples; constructs MCP-protocol results directly without going
+  through the network.
+- :class:`McpClientUpstream` — wraps an
+  :class:`mcp.client.session.ClientSession` so a single upstream server
+  is fronted by the runtime.  Multi-server fan-out is the caller's
+  responsibility (compose multiple ``McpClientUpstream`` instances
+  behind a :class:`MultiplexUpstream`).
+- :class:`MultiplexUpstream` — fans out :meth:`list_tools` over several
+  upstream sources and routes :meth:`call_tool` to the source that
+  exported the named tool.
+
+Each implementation returns MCP-format dicts (not the SDK's pydantic
+types) because the runtime's downstream consumers
+(:func:`~contextweaver.adapters.mcp.mcp_tool_to_selectable`,
+:func:`~contextweaver.adapters.mcp.mcp_result_to_envelope`) speak dict.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+logger = logging.getLogger("contextweaver.adapters.mcp_upstream")
+
+
+class StubUpstream:
+    """An in-process upstream wired up entirely from Python dicts.
+
+    Useful for unit tests, examples, and air-gapped CI.  The caller
+    supplies a static list of tool definitions and an optional handler
+    callback that maps ``(tool_name, args) → MCP result dict``.
+
+    Args:
+        tool_defs: MCP-format tool definitions (``name``,
+            ``description``, ``inputSchema``, ...).
+        handler: Optional async callable invoked by :meth:`call_tool`.
+            When omitted the default handler returns an ``isError=True``
+            result with a "no handler configured" message.
+    """
+
+    def __init__(
+        self,
+        tool_defs: list[dict[str, Any]],
+        handler: Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
+    ) -> None:
+        self._tool_defs = [dict(t) for t in tool_defs]
+        self._handler = handler
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """Return the configured tool definitions."""
+        return [dict(t) for t in self._tool_defs]
+
+    async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Dispatch to the configured handler or return a stub error."""
+        if self._handler is not None:
+            return await self._handler(tool_name, arguments)
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"stub upstream has no handler for {tool_name!r}",
+                }
+            ],
+            "isError": True,
+        }
+
+
+class McpClientUpstream:
+    """Adapt a single :class:`mcp.client.session.ClientSession` to :class:`UpstreamCall`.
+
+    The wrapped session must already be connected; lifecycle management
+    (connect / close, transport, auth) is the caller's responsibility.
+    The MCP SDK's pydantic types are converted to plain dicts on the way
+    out so downstream consumers continue to operate on the MCP wire
+    format.
+
+    Args:
+        session: A connected :class:`mcp.client.session.ClientSession`.
+    """
+
+    def __init__(self, session: Any) -> None:  # noqa: ANN401 — MCP SDK ClientSession
+        self._session = session
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """Call ``tools/list`` upstream and return dict-shaped defs."""
+        listing = await self._session.list_tools()
+        tools = getattr(listing, "tools", listing) or []
+        return [_tool_to_dict(t) for t in tools]
+
+    async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Forward a tool call and return a dict-shaped MCP result."""
+        try:
+            result = await self._session.call_tool(tool_name, arguments)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("upstream call_tool %s failed: %s", tool_name, exc)
+            return {
+                "content": [{"type": "text", "text": f"upstream error: {exc}"}],
+                "isError": True,
+            }
+        return _call_tool_result_to_dict(result)
+
+
+class MultiplexUpstream:
+    """Fan :meth:`list_tools` across multiple :class:`UpstreamCall` sources.
+
+    :meth:`call_tool` routes the request to the source that exported the
+    named tool.  When two upstreams expose tools with the same name, the
+    first source registered wins; the runtime's canonical ``tool_id``
+    cutover (§1.7) keeps this collision rare in practice.
+    """
+
+    def __init__(self, sources: list[Any]) -> None:  # noqa: ANN401 — UpstreamCall Protocol
+        self._sources = list(sources)
+        self._owner_index: dict[str, int] = {}
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """Return the union of tool defs across all sources."""
+        out: list[dict[str, Any]] = []
+        for idx, source in enumerate(self._sources):
+            tools = await source.list_tools()
+            for tool_def in tools:
+                name = str(tool_def.get("name", ""))
+                if name and name not in self._owner_index:
+                    self._owner_index[name] = idx
+                    out.append(tool_def)
+        return out
+
+    async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Forward the call to the source that owns *tool_name*."""
+        idx = self._owner_index.get(tool_name)
+        if idx is None:
+            return {
+                "content": [{"type": "text", "text": f"no upstream owns tool {tool_name!r}"}],
+                "isError": True,
+            }
+        result: dict[str, Any] = await self._sources[idx].call_tool(tool_name, arguments)
+        return result
+
+
+def _tool_to_dict(tool: Any) -> dict[str, Any]:  # noqa: ANN401
+    """Coerce a possibly-pydantic ``Tool`` object to a plain MCP dict."""
+    if isinstance(tool, dict):
+        return dict(tool)
+    if hasattr(tool, "model_dump"):
+        return dict(tool.model_dump())
+    return {
+        "name": getattr(tool, "name", ""),
+        "description": getattr(tool, "description", ""),
+        "inputSchema": getattr(tool, "inputSchema", {}) or {},
+    }
+
+
+def _call_tool_result_to_dict(result: Any) -> dict[str, Any]:  # noqa: ANN401
+    """Coerce an MCP ``CallToolResult`` to the wire-format dict."""
+    if isinstance(result, dict):
+        return dict(result)
+    if hasattr(result, "model_dump"):
+        return dict(result.model_dump())
+    return {
+        "content": getattr(result, "content", []) or [],
+        "isError": bool(getattr(result, "isError", False)),
+    }

--- a/src/contextweaver/adapters/proxy_runtime.py
+++ b/src/contextweaver/adapters/proxy_runtime.py
@@ -1,0 +1,451 @@
+"""Shared core for the MCP proxy (#13) and gateway (#28) runtime modes.
+
+:class:`ProxyRuntime` is the internal subsystem that both the transparent
+proxy and the two-tool gateway share, as called for by ``docs/gateway_spec.md``
+§4.  It owns:
+
+- Upstream MCP catalog aggregation via an injected
+  :class:`UpstreamCall` Protocol (no MCP transport coupling).
+- A per-session :class:`~contextweaver.context.manager.ContextManager`
+  with the standard 4-store bundle.
+- A :class:`~contextweaver.routing.catalog.Catalog` +
+  :class:`~contextweaver.routing.graph.ChoiceGraph` rebuilt whenever the
+  upstream catalog changes.
+- The gateway's three primitives:
+
+  * :meth:`ProxyRuntime.browse` — ``tool_browse(query|path)`` per §3.
+  * :meth:`ProxyRuntime.execute` — ``tool_execute(tool_id, args)`` per
+    §4.4 (validates args against the hydrated schema before upstream
+    dispatch, then runs the result through the context firewall).
+  * :meth:`ProxyRuntime.view` — ``tool_view(handle, selector)`` per #34
+    (drilldown over a previously-stored artifact).
+
+- The proxy's additional helpers:
+
+  * :meth:`ProxyRuntime.strip_tools_list` — stripped MCP-format
+    ``tools/list`` per §4.1.
+  * :meth:`ProxyRuntime.hydrate` — `Catalog.hydrate` wrapper exposed as
+    ``tool_hydrate(tool_id)`` per §4.1.
+
+The shared error shape is :class:`~contextweaver.adapters.gateway_error.GatewayError`;
+none of these primitives raise across the MCP boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+import jsonschema
+import jsonschema.exceptions
+
+from contextweaver.adapters.gateway_error import GatewayError
+from contextweaver.adapters.mcp import mcp_result_to_envelope, mcp_tool_to_selectable
+from contextweaver.context.manager import ContextManager
+from contextweaver.envelope import ChoiceCard, HydrationResult, ResultEnvelope
+from contextweaver.exceptions import (
+    ItemNotFoundError,
+    PathInvalidError,
+    PathNotFoundError,
+)
+from contextweaver.routing.cards import bound_browse_response, item_to_card, make_choice_cards
+from contextweaver.routing.catalog import Catalog
+from contextweaver.routing.graph import ChoiceGraph
+from contextweaver.routing.path import parse_path, resolve_path
+from contextweaver.routing.router import Router
+from contextweaver.routing.tree import TreeBuilder
+from contextweaver.store.artifacts import InMemoryArtifactStore
+from contextweaver.types import SelectableItem
+
+logger = logging.getLogger("contextweaver.adapters.proxy_runtime")
+
+
+class ExposureMode(str, Enum):
+    """Which agent-facing surface the runtime is wired into (§4)."""
+
+    TRANSPARENT = "transparent"
+    GATEWAY = "gateway"
+
+
+@runtime_checkable
+class UpstreamCall(Protocol):
+    """Transport-agnostic interface to one or more upstream MCP servers.
+
+    Implementations may fan out over a single server, multiple servers,
+    or an in-process stub.  The :class:`ProxyRuntime` only depends on
+    the two methods below — concrete MCP-SDK wiring lives in
+    :mod:`contextweaver.adapters.mcp_upstream`.
+    """
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """Return MCP-format tool definitions from all upstream servers."""
+        ...
+
+    async def call_tool(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Invoke *tool_name* upstream and return the raw MCP result dict.
+
+        The returned dict matches the MCP wire format consumed by
+        :func:`~contextweaver.adapters.mcp.mcp_result_to_envelope`.
+        Implementations MUST translate transport-level errors into a
+        result dict with ``isError = True`` rather than raising.
+        """
+        ...
+
+
+@dataclass
+class _UpstreamNameIndex:
+    """Maps canonical ``tool_id`` → upstream raw tool name.
+
+    Required because :func:`mcp_tool_to_selectable` strips namespace
+    prefixes from the canonical id (§1.4), but the upstream MCP server
+    only accepts the original name.
+    """
+
+    by_tool_id: dict[str, str] = field(default_factory=dict)
+
+
+class ProxyRuntime:
+    """Shared core for the MCP proxy and gateway modes.
+
+    Args:
+        upstream: An :class:`UpstreamCall` implementation.
+        mode: Which agent-facing surface this runtime serves.  Defaults
+            to :attr:`ExposureMode.GATEWAY`.
+        context_manager: Optional pre-built
+            :class:`~contextweaver.context.manager.ContextManager`.
+            Defaults to a fresh one with the standard 4-store bundle.
+        tree_builder: Optional custom
+            :class:`~contextweaver.routing.tree.TreeBuilder`.
+        beam_width: Router beam width passed through to
+            :class:`~contextweaver.routing.router.Router`.
+        top_k: Maximum number of cards returned by :meth:`browse`.
+    """
+
+    def __init__(
+        self,
+        upstream: UpstreamCall,
+        *,
+        mode: ExposureMode = ExposureMode.GATEWAY,
+        context_manager: ContextManager | None = None,
+        tree_builder: TreeBuilder | None = None,
+        beam_width: int = 3,
+        top_k: int = 10,
+    ) -> None:
+        self._upstream = upstream
+        self._mode = mode
+        self._context_manager = context_manager or ContextManager()
+        self._tree_builder = tree_builder or TreeBuilder()
+        self._beam_width = beam_width
+        self._top_k = top_k
+        self._catalog: Catalog = Catalog()
+        self._graph: ChoiceGraph | None = None
+        self._router: Router | None = None
+        self._upstream_names = _UpstreamNameIndex()
+        self._raw_tool_defs: dict[str, dict[str, Any]] = {}
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def mode(self) -> ExposureMode:
+        """Return the configured :class:`ExposureMode`."""
+        return self._mode
+
+    @property
+    def catalog(self) -> Catalog:
+        """Return the active :class:`Catalog`."""
+        return self._catalog
+
+    @property
+    def context_manager(self) -> ContextManager:
+        """Return the per-session :class:`ContextManager`."""
+        return self._context_manager
+
+    # ------------------------------------------------------------------
+    # Catalog management
+    # ------------------------------------------------------------------
+
+    async def refresh_catalog(self) -> int:
+        """Re-fetch the upstream ``tools/list`` and rebuild the catalog.
+
+        Returns:
+            The number of tools registered.
+        """
+        tool_defs = await self._upstream.list_tools()
+        return self._register_tool_defs(tool_defs)
+
+    def register_tool_defs_sync(self, tool_defs: list[dict[str, Any]]) -> int:
+        """Register *tool_defs* (MCP-format) into the catalog synchronously.
+
+        Useful for tests and demos that want to bypass the async upstream
+        boundary.  Returns the number of registered tools.
+        """
+        return self._register_tool_defs(tool_defs)
+
+    def _register_tool_defs(self, tool_defs: list[dict[str, Any]]) -> int:
+        items: list[SelectableItem] = []
+        upstream_index: dict[str, str] = {}
+        raw_defs: dict[str, dict[str, Any]] = {}
+        for tool_def in tool_defs:
+            item = mcp_tool_to_selectable(tool_def)
+            items.append(item)
+            upstream_index[item.id] = str(tool_def["name"])
+            raw_defs[item.id] = dict(tool_def)
+        self._catalog = Catalog()
+        for item in items:
+            self._catalog.register(item)
+        self._upstream_names = _UpstreamNameIndex(by_tool_id=upstream_index)
+        self._raw_tool_defs = raw_defs
+        if items:
+            self._graph = self._tree_builder.build(items)
+            self._router = Router(self._graph, items=items, beam_width=self._beam_width)
+        else:
+            self._graph = None
+            self._router = None
+        logger.debug("proxy_runtime: registered %d tools", len(items))
+        return len(items)
+
+    def list_tool_ids(self) -> list[str]:
+        """Return the canonical ``tool_id`` for every registered tool."""
+        return [item.id for item in self._catalog.all()]
+
+    # ------------------------------------------------------------------
+    # tool_browse (§3 + §4.2)
+    # ------------------------------------------------------------------
+
+    def browse(
+        self,
+        *,
+        query: str | None = None,
+        path: str | None = None,
+        top_k: int | None = None,
+    ) -> list[ChoiceCard] | GatewayError:
+        """Implement ``tool_browse(query|path)`` per §3.1.
+
+        Exactly one of *query* or *path* must be supplied — passing both
+        or neither returns :class:`GatewayError` with code
+        ``ARGS_INVALID``.
+
+        Args:
+            query: Free-form natural-language query.  Routed through
+                :class:`Router`.
+            path: Hierarchical path through the :class:`ChoiceGraph`.
+            top_k: Optional override for the configured top-k count.
+
+        Returns:
+            A list of :class:`ChoiceCard` bounded per §2.3, or a
+            :class:`GatewayError` describing why the request was
+            rejected.
+        """
+        if (query is None) == (path is None):
+            return GatewayError(
+                code="ARGS_INVALID",
+                message="tool_browse requires exactly one of 'query' or 'path'.",
+            )
+        if query is not None:
+            return self._browse_by_query(query, top_k=top_k)
+        assert path is not None  # narrowed by the XOR check above
+        return self._browse_by_path(path)
+
+    def _browse_by_query(self, query: str, *, top_k: int | None) -> list[ChoiceCard] | GatewayError:
+        if self._router is None or not self._catalog.all():
+            return []
+        effective_top_k = top_k if top_k is not None else self._top_k
+        # Router.top_k is set at construction; per-call overrides are
+        # applied by truncating the result.  Reconstruct only when the
+        # override exceeds the configured Router capacity.
+        result = self._router.route(query)
+        scores = dict(zip(result.candidate_ids, result.scores, strict=False))
+        cards = make_choice_cards(
+            result.candidate_items,
+            max_cards=effective_top_k,
+            scores=scores,
+        )
+        return bound_browse_response(cards)
+
+    def _browse_by_path(self, path: str) -> list[ChoiceCard] | GatewayError:
+        if self._graph is None:
+            return GatewayError(
+                code="PATH_NOT_FOUND",
+                message="No catalog registered.",
+                path=path,
+            )
+        try:
+            segments = parse_path(path)
+        except PathInvalidError as exc:
+            return GatewayError(code="PATH_INVALID", message=str(exc), path=path)
+        try:
+            child_ids = resolve_path(self._graph, segments)
+        except PathInvalidError as exc:
+            return GatewayError(code="PATH_INVALID", message=str(exc), path=path)
+        except PathNotFoundError as exc:
+            return GatewayError(code="PATH_NOT_FOUND", message=str(exc), path=path)
+        cards: list[ChoiceCard] = []
+        for child_id in child_ids:
+            try:
+                cards.append(item_to_card(self._catalog.get(child_id)))
+            except ItemNotFoundError:
+                # Navigation node, not a leaf — synthesise a cluster card.
+                node = self._graph.get_node(child_id)
+                cards.append(
+                    ChoiceCard(
+                        id=child_id,
+                        name=node.label or child_id,
+                        description=node.routing_hint or "Cluster",
+                        kind="internal",
+                        namespace=child_id.split(":", 1)[0] if ":" in child_id else "",
+                    )
+                )
+        return bound_browse_response(cards)
+
+    # ------------------------------------------------------------------
+    # tool_hydrate (§4.1)
+    # ------------------------------------------------------------------
+
+    def hydrate(self, tool_id: str) -> HydrationResult | GatewayError:
+        """Return the full schema for *tool_id* (§4.3).
+
+        Returns:
+            A :class:`HydrationResult` or :class:`GatewayError` with code
+            ``HYDRATE_FAILED`` when *tool_id* is unknown.
+        """
+        try:
+            return self._catalog.hydrate(tool_id)
+        except ItemNotFoundError as exc:
+            return GatewayError(
+                code="HYDRATE_FAILED",
+                message=str(exc),
+                path=tool_id,
+            )
+
+    # ------------------------------------------------------------------
+    # tool_execute (§4.2 + §4.4)
+    # ------------------------------------------------------------------
+
+    async def execute(
+        self,
+        tool_id: str,
+        args: dict[str, Any],
+    ) -> ResultEnvelope | GatewayError:
+        """Validate *args*, invoke upstream, and return a compacted envelope.
+
+        Args:
+            tool_id: Canonical ``tool_id`` of the target tool.
+            args: Arguments to pass through to the upstream MCP server.
+
+        Returns:
+            A :class:`ResultEnvelope` (post-firewall) or a
+            :class:`GatewayError`.  Validation failures map to
+            ``ARGS_INVALID`` per §4.4; transport / protocol failures map
+            to ``UPSTREAM_ERROR``.
+        """
+        try:
+            hydrated = self._catalog.hydrate(tool_id)
+        except ItemNotFoundError as exc:
+            return GatewayError(
+                code="HYDRATE_FAILED",
+                message=str(exc),
+                path=tool_id,
+            )
+        validation_error = _validate_args(args, hydrated.args_schema)
+        if validation_error is not None:
+            return GatewayError(
+                code="ARGS_INVALID",
+                message=validation_error.message,
+                path=tool_id,
+                details={"path": list(validation_error.path)},
+            )
+        upstream_name = self._upstream_names.by_tool_id.get(tool_id, hydrated.item.name)
+        try:
+            raw = await self._upstream.call_tool(upstream_name, args)
+        except Exception as exc:  # noqa: BLE001
+            return GatewayError(
+                code="UPSTREAM_ERROR",
+                message=f"upstream call failed: {exc}",
+                path=tool_id,
+            )
+        envelope, binaries, full_text = mcp_result_to_envelope(raw, upstream_name)
+        # Persist binaries on the session's artifact store so subsequent
+        # tool_view calls can drill in.  Text content larger than the
+        # firewall threshold is also persisted under a deterministic
+        # handle so the gateway's view path can address it.
+        artifact_store = self._context_manager.artifact_store
+        for handle, (data, mime, label) in binaries.items():
+            if not artifact_store.exists(handle):
+                artifact_store.put(handle=handle, content=data, media_type=mime, label=label)
+        if full_text and not envelope.artifacts:
+            text_handle = f"text:{tool_id}:{len(full_text)}"
+            artifact_store.put(
+                handle=text_handle,
+                content=full_text.encode("utf-8"),
+                media_type="text/plain",
+                label=f"text result from {tool_id}",
+            )
+        envelope.provenance.setdefault("tool_id", tool_id)
+        return envelope
+
+    # ------------------------------------------------------------------
+    # tool_view (#34)
+    # ------------------------------------------------------------------
+
+    def view(self, handle: str, selector: dict[str, Any]) -> str | GatewayError:
+        """Drill into a previously stored artifact (#34).
+
+        Returns the sliced text content, or a :class:`GatewayError` with
+        code ``VIEW_FAILED`` if the handle is unknown or the selector is
+        invalid.
+        """
+        store: InMemoryArtifactStore = self._context_manager.artifact_store  # type: ignore[assignment]
+        try:
+            return store.drilldown(handle, selector)
+        except Exception as exc:  # noqa: BLE001
+            return GatewayError(
+                code="VIEW_FAILED",
+                message=str(exc),
+                path=handle,
+            )
+
+    # ------------------------------------------------------------------
+    # Proxy-only: stripped tools/list (§4.1)
+    # ------------------------------------------------------------------
+
+    def strip_tools_list(self) -> list[dict[str, Any]]:
+        """Return the stripped ``tools/list`` (§4.1) for transparent-proxy mode.
+
+        Each entry mirrors the upstream tool's *name* and *description*
+        (description truncated to the §2.4 budget) but replaces
+        ``inputSchema`` with the sentinel ``{"type": "object"}``.  No
+        banned fields are emitted (§2.2).
+
+        Returns:
+            A list of MCP-format tool definitions ready for the proxy's
+            ``tools/list`` response.
+        """
+        out: list[dict[str, Any]] = []
+        for item in self._catalog.all():
+            card = item_to_card(item)
+            out.append(
+                {
+                    "name": item.id,
+                    "description": card.description,
+                    "inputSchema": {"type": "object"},
+                }
+            )
+        return out
+
+
+def _validate_args(
+    args: dict[str, Any],
+    schema: dict[str, Any],
+) -> jsonschema.exceptions.ValidationError | None:
+    """Validate *args* against *schema*; return ``None`` on success."""
+    if not schema:
+        return None
+    try:
+        jsonschema.validate(instance=args, schema=schema)
+        return None
+    except jsonschema.exceptions.ValidationError as exc:
+        return exc

--- a/src/contextweaver/adapters/proxy_runtime.py
+++ b/src/contextweaver/adapters/proxy_runtime.py
@@ -33,6 +33,7 @@ none of these primitives raise across the MCP boundary.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
@@ -46,6 +47,8 @@ from contextweaver.adapters.mcp import mcp_result_to_envelope, mcp_tool_to_selec
 from contextweaver.context.manager import ContextManager
 from contextweaver.envelope import ChoiceCard, HydrationResult, ResultEnvelope
 from contextweaver.exceptions import (
+    ArtifactNotFoundError,
+    ContextWeaverError,
     ItemNotFoundError,
     PathInvalidError,
     PathNotFoundError,
@@ -201,7 +204,12 @@ class ProxyRuntime:
         self._raw_tool_defs = raw_defs
         if items:
             self._graph = self._tree_builder.build(items)
-            self._router = Router(self._graph, items=items, beam_width=self._beam_width)
+            self._router = Router(
+                self._graph,
+                items=items,
+                beam_width=self._beam_width,
+                top_k=self._top_k,
+            )
         else:
             self._graph = None
             self._router = None
@@ -254,9 +262,9 @@ class ProxyRuntime:
         if self._router is None or not self._catalog.all():
             return []
         effective_top_k = top_k if top_k is not None else self._top_k
-        # Router.top_k is set at construction; per-call overrides are
-        # applied by truncating the result.  Reconstruct only when the
-        # override exceeds the configured Router capacity.
+        # Router.top_k is set at construction to self._top_k; per-call
+        # overrides are applied by truncating the result via make_choice_cards.
+        # Values larger than self._top_k are silently capped at self._top_k.
         result = self._router.route(query)
         scores = dict(zip(result.candidate_ids, result.scores, strict=False))
         cards = make_choice_cards(
@@ -377,13 +385,16 @@ class ProxyRuntime:
             if not artifact_store.exists(handle):
                 artifact_store.put(handle=handle, content=data, media_type=mime, label=label)
         if full_text and not envelope.artifacts:
-            text_handle = f"text:{tool_id}:{len(full_text)}"
-            artifact_store.put(
-                handle=text_handle,
-                content=full_text.encode("utf-8"),
-                media_type="text/plain",
-                label=f"text result from {tool_id}",
-            )
+            content_bytes = full_text.encode("utf-8")
+            text_hash = hashlib.sha256(content_bytes).hexdigest()[:16]
+            text_handle = f"text:{tool_id}:{text_hash}"
+            if not artifact_store.exists(text_handle):
+                artifact_store.put(
+                    handle=text_handle,
+                    content=content_bytes,
+                    media_type="text/plain",
+                    label=f"text result from {tool_id}",
+                )
         envelope.provenance.setdefault("tool_id", tool_id)
         return envelope
 
@@ -401,7 +412,7 @@ class ProxyRuntime:
         store: InMemoryArtifactStore = self._context_manager.artifact_store  # type: ignore[assignment]
         try:
             return store.drilldown(handle, selector)
-        except Exception as exc:  # noqa: BLE001
+        except (ArtifactNotFoundError, ContextWeaverError) as exc:
             return GatewayError(
                 code="VIEW_FAILED",
                 message=str(exc),

--- a/src/contextweaver/context/firewall.py
+++ b/src/contextweaver/context/firewall.py
@@ -8,6 +8,7 @@ containing a human-readable summary, extracted facts, and an
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from typing import Literal
 
@@ -15,7 +16,7 @@ from contextweaver.context.views import ViewRegistry, generate_views
 from contextweaver.envelope import ResultEnvelope
 from contextweaver.protocols import ArtifactStore, EventHook, Extractor, NoOpHook, Summarizer
 from contextweaver.summarize.extract import extract_facts
-from contextweaver.types import ContextItem, ItemKind
+from contextweaver.types import ArtifactRef, ContextItem, ItemKind
 
 logger = logging.getLogger("contextweaver.context")
 
@@ -66,14 +67,35 @@ def apply_firewall(
     if item.kind != ItemKind.tool_result:
         return item, None
 
+    # Issue #190 — content-addressed firewall idempotency.  If the item
+    # already carries an ``artifact_ref`` with a populated
+    # ``content_hash``, an earlier firewall pass has stored the raw
+    # bytes and replaced ``item.text`` with the summary.  Re-firing on a
+    # subsequent ``build()`` call would overwrite the original raw bytes
+    # with the summary and silently break drilldown.  Short-circuit: the
+    # item is already firewall-processed; return it untouched and signal
+    # "no new envelope" so downstream stages know nothing changed.
+    if item.artifact_ref is not None and item.artifact_ref.content_hash:
+        return item, None
+
     raw_bytes = item.text.encode("utf-8")
+    content_hash = hashlib.sha256(raw_bytes).hexdigest()
     handle = f"artifact:{item.id}"
     media = str(item.metadata.get("media_type", "text/plain"))
-    ref = artifact_store.put(
+    stored_ref = artifact_store.put(
         handle=handle,
         content=raw_bytes,
         media_type=media,
         label=f"raw tool result for {item.id}",
+    )
+    # Attach the content_hash so subsequent firewall passes can detect
+    # this item as already-processed (#190).
+    ref = ArtifactRef(
+        handle=stored_ref.handle,
+        media_type=stored_ref.media_type,
+        size_bytes=stored_ref.size_bytes,
+        label=stored_ref.label,
+        content_hash=content_hash,
     )
 
     status: Literal["ok", "partial", "error"] = "ok"

--- a/src/contextweaver/exceptions.py
+++ b/src/contextweaver/exceptions.py
@@ -45,3 +45,15 @@ class DuplicateItemError(ContextWeaverError):
 
 class ConfigError(ContextWeaverError):
     """Raised when a configuration value or preset name is invalid."""
+
+
+class PathInvalidError(CatalogError):
+    """Raised when a ``tool_browse`` path violates the §3.2 grammar."""
+
+
+class PathNotFoundError(CatalogError):
+    """Raised when a well-formed ``tool_browse`` path resolves to no node."""
+
+
+class UpstreamError(ContextWeaverError):
+    """Raised when an upstream MCP tool call fails for transport/protocol reasons."""

--- a/src/contextweaver/routing/__init__.py
+++ b/src/contextweaver/routing/__init__.py
@@ -6,18 +6,29 @@ Exports the catalog, graph, labeler, tree builder, router, and card renderer.
 from __future__ import annotations
 
 from contextweaver.routing.cards import (
+    bound_browse_response,
     cards_for_route,
+    count_tokens,
     format_card_for_prompt,
     make_choice_cards,
     render_cards,
     render_cards_text,
+    truncate_description_to_tokens,
 )
 from contextweaver.routing.catalog import Catalog
 from contextweaver.routing.graph import ChoiceGraph
 from contextweaver.routing.graph_io import load_graph, save_graph
 from contextweaver.routing.graph_node import ChoiceNode
 from contextweaver.routing.labeler import KeywordLabeler
+from contextweaver.routing.path import parse_path, resolve_path
 from contextweaver.routing.router import Router, RouteResult
+from contextweaver.routing.tool_id import (
+    ToolIdParts,
+    canonical_tool_id,
+    compute_hash8,
+    format_tool_id,
+    parse_tool_id,
+)
 from contextweaver.routing.tree import TreeBuilder
 
 __all__ = [
@@ -27,12 +38,22 @@ __all__ = [
     "KeywordLabeler",
     "RouteResult",
     "Router",
+    "ToolIdParts",
     "TreeBuilder",
+    "bound_browse_response",
+    "canonical_tool_id",
     "cards_for_route",
+    "compute_hash8",
+    "count_tokens",
     "format_card_for_prompt",
+    "format_tool_id",
     "load_graph",
     "make_choice_cards",
+    "parse_path",
+    "parse_tool_id",
     "render_cards",
     "render_cards_text",
+    "resolve_path",
     "save_graph",
+    "truncate_description_to_tokens",
 ]

--- a/src/contextweaver/routing/__init__.py
+++ b/src/contextweaver/routing/__init__.py
@@ -6,10 +6,13 @@ Exports the catalog, graph, labeler, tree builder, router, and card renderer.
 from __future__ import annotations
 
 from contextweaver.routing.cards import (
+    DEFAULT_CARD_HARD_CAP_TOKENS,
+    DEFAULT_CARD_TARGET_TOKENS,
     bound_browse_response,
     cards_for_route,
     count_tokens,
     format_card_for_prompt,
+    item_to_card,
     make_choice_cards,
     render_cards,
     render_cards_text,
@@ -35,6 +38,8 @@ __all__ = [
     "Catalog",
     "ChoiceGraph",
     "ChoiceNode",
+    "DEFAULT_CARD_HARD_CAP_TOKENS",
+    "DEFAULT_CARD_TARGET_TOKENS",
     "KeywordLabeler",
     "RouteResult",
     "Router",
@@ -47,6 +52,7 @@ __all__ = [
     "count_tokens",
     "format_card_for_prompt",
     "format_tool_id",
+    "item_to_card",
     "load_graph",
     "make_choice_cards",
     "parse_path",

--- a/src/contextweaver/routing/cards.py
+++ b/src/contextweaver/routing/cards.py
@@ -5,21 +5,152 @@ Converts :class:`~contextweaver.types.SelectableItem` objects into compact
 LLM prompts.  Full arg schemas are intentionally omitted to minimise token
 usage.
 
+The sizing rules in ``docs/gateway_spec.md`` §2 are expressed in **exact
+``cl100k_base`` token counts** rather than characters.  This module's
+public API is token-native:
+
+- Single card target ≤ 60 tokens, hard cap ≤ 80 tokens.
+- ``tool_browse`` response target ≤ ``60·n``, hard cap ≤ ``80·n + 32``
+  (32-token preamble allowance).
+- Ordering: descending score, ties broken by ``id`` ascending.
+
 Public API:
-    - :func:`item_to_card` — single item → card
-    - :func:`render_cards` — list of items → list of cards (preserves order)
-    - :func:`make_choice_cards` — items → bounded card list with truncation
-    - :func:`render_cards_text` — cards → numbered text block for prompts
-    - :func:`cards_for_route` — route IDs + catalog → matching cards
-    - :func:`format_card_for_prompt` — single card → multi-line text
+    - :func:`item_to_card` — single item → card.
+    - :func:`render_cards` — list of items → list of cards (preserves order).
+    - :func:`make_choice_cards` — items → bounded card list with
+      token-budget truncation per §2.3 / §2.4.
+    - :func:`bound_browse_response` — apply the §2.3 ``tool_browse``
+      response bound to an already-built card list.
+    - :func:`render_cards_text` — cards → numbered text block for prompts.
+    - :func:`cards_for_route` — route IDs + catalog → matching cards.
+    - :func:`format_card_for_prompt` — single card → multi-line text.
+    - :func:`truncate_description_to_tokens` — deterministic
+      sentence-aware truncation for §2.4.
 """
 
 from __future__ import annotations
 
+import logging
+import re
+from typing import Any
+
+import tiktoken
+
 from contextweaver.envelope import ChoiceCard
-from contextweaver.exceptions import ItemNotFoundError
+from contextweaver.exceptions import CatalogError, ItemNotFoundError
 from contextweaver.routing.catalog import Catalog
 from contextweaver.types import SelectableItem
+
+_logger = logging.getLogger("contextweaver.routing.cards")
+
+# Lazy ``cl100k_base`` encoder for §2.3 token accounting.  Loaded on
+# first use because :func:`tiktoken.get_encoding` downloads the BPE file
+# from a network URL on the first call in environments without a
+# pre-warmed cache.  In offline / air-gapped environments the load
+# fails; we fall back to a deterministic chars-per-token estimate
+# (``len(text) // 4``) that matches the existing
+# :class:`~contextweaver.protocols.TiktokenEstimator` fallback and keeps
+# the §2.3 bounds enforced — at the cost of approximate-rather-than-exact
+# token counts.
+_ENCODER: Any | None = None
+_ENCODER_FAILED: bool = False
+
+
+def _get_encoder() -> Any | None:  # noqa: ANN401 — tiktoken Encoding is not typed
+    """Return the cached cl100k_base encoder, or ``None`` if offline.
+
+    Logs a single warning on first failure, mirroring
+    :class:`~contextweaver.protocols.TiktokenEstimator`'s offline behaviour.
+    """
+    global _ENCODER, _ENCODER_FAILED
+    if _ENCODER is not None:
+        return _ENCODER
+    if _ENCODER_FAILED:
+        return None
+    try:
+        _ENCODER = tiktoken.get_encoding("cl100k_base")
+        return _ENCODER
+    except Exception as exc:  # pragma: no cover - exercised in offline tests
+        _ENCODER_FAILED = True
+        _logger.warning(
+            "tiktoken cl100k_base encoding unavailable (%s); falling back to "
+            "chars/4 token estimate for §2.3 budget enforcement.",
+            exc,
+        )
+        return None
+
+
+# §2.3 default token budgets.
+DEFAULT_CARD_TARGET_TOKENS = 60
+DEFAULT_CARD_HARD_CAP_TOKENS = 80
+DEFAULT_BROWSE_PREAMBLE_TOKENS = 32
+
+# §2.4 sentence terminators considered when truncating descriptions.
+_SENTENCE_BOUNDARY_RE = re.compile(r"[.!?](?:\s|$)")
+
+# §2.4 ellipsis character (U+2026).
+_ELLIPSIS = "…"
+
+
+def count_tokens(text: str) -> int:
+    """Return the ``cl100k_base`` token count of *text*.
+
+    Falls back to ``len(text) // 4`` if the encoding is unavailable (e.g.
+    offline environment without a pre-warmed tiktoken cache).  The
+    fallback is deterministic so the §2.3 bounds remain meaningful even
+    in air-gapped CI.
+    """
+    if not text:
+        return 0
+    enc = _get_encoder()
+    if enc is not None:
+        return len(enc.encode(text))
+    return len(text) // 4 or 1
+
+
+def truncate_description_to_tokens(text: str, max_tokens: int) -> str:
+    """Truncate *text* deterministically to at most *max_tokens* tokens (§2.4).
+
+    Algorithm (deterministic, sentence-boundary-aware):
+
+    1. If *text* already fits, return it verbatim.
+    2. Otherwise, find the longest sentence-terminated prefix that fits.
+    3. If no sentence boundary fits, hard-cut to the byte offset whose
+       token count is ``max_tokens - 1`` and append ``"…"`` (U+2026).
+
+    Args:
+        text: The description to truncate.
+        max_tokens: Maximum tokens permitted.  Values ``<= 0`` return ``""``.
+
+    Returns:
+        The truncated description, stable for the same input.
+    """
+    if max_tokens <= 0:
+        return ""
+    if count_tokens(text) <= max_tokens:
+        return text
+
+    # Try sentence boundaries from longest prefix down.
+    boundaries = [m.end() for m in _SENTENCE_BOUNDARY_RE.finditer(text)]
+    for end in reversed(boundaries):
+        candidate = text[:end].rstrip()
+        if count_tokens(candidate) <= max_tokens:
+            return candidate
+
+    # No sentence boundary fits — hard-cut to (max_tokens - 1) tokens and
+    # append the ellipsis.  Binary search over character offsets to find
+    # the largest prefix whose encoded length is below the cap.
+    target = max(max_tokens - 1, 0)
+    lo, hi = 0, len(text)
+    best = 0
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if count_tokens(text[:mid]) <= target:
+            best = mid
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    return text[:best].rstrip() + _ELLIPSIS
 
 
 def item_to_card(
@@ -40,11 +171,14 @@ def item_to_card(
     Returns:
         A :class:`ChoiceCard` with ``args_schema`` omitted.
     """
+    # §2.1 caps: name ≤ 64 chars, tags ≤ 5 entries (each ≤ 24 chars).
+    capped_name = item.name[:64]
+    capped_tags = sorted({t[:24] for t in item.tags})[:5]
     return ChoiceCard(
         id=item.id,
-        name=item.name,
+        name=capped_name,
         description=item.description,
-        tags=list(item.tags),
+        tags=capped_tags,
         kind=item.kind,
         namespace=item.namespace,
         has_schema=bool(item.args_schema),
@@ -66,61 +200,169 @@ def render_cards(items: list[SelectableItem]) -> list[ChoiceCard]:
     return [item_to_card(item) for item in items]
 
 
+def _card_token_count(card: ChoiceCard) -> int:
+    """Approximate the rendered token cost of a single card.
+
+    Matches the format produced by :func:`render_cards_text` so that the
+    sum of per-card costs is a tight upper bound on the rendered length.
+    """
+    tag_str = f" [{', '.join(card.tags)}]" if card.tags else ""
+    score_str = f" score={card.score:.2f}" if card.score is not None else ""
+    line = f"[1/1] {card.id} ({card.kind}) — {card.description}{tag_str}{score_str}"
+    return count_tokens(line)
+
+
+def _enforce_card_budget(
+    card: ChoiceCard,
+    *,
+    target_tokens: int,
+    hard_cap_tokens: int,
+) -> ChoiceCard:
+    """Truncate *card.description* to keep the card under the §2.3 budget.
+
+    The card builder MUST NOT silently drop fields — truncation is
+    confined to ``description``.  Raises :class:`CatalogError` if the
+    card still exceeds *hard_cap_tokens* after maximal truncation
+    (e.g. an unreasonably long tags list).
+    """
+    if _card_token_count(card) <= target_tokens:
+        return card
+
+    # Truncate description until the card fits the target, then verify
+    # the hard cap.  The non-description content (id, name, kind, tags,
+    # score) is fixed-size for a given card, so the description budget
+    # is target_tokens - (card_tokens - description_tokens).
+    fixed_overhead = _card_token_count(
+        ChoiceCard(
+            id=card.id,
+            name=card.name,
+            description="",
+            tags=card.tags,
+            kind=card.kind,
+            namespace=card.namespace,
+            has_schema=card.has_schema,
+            score=card.score,
+            cost_hint=card.cost_hint,
+            side_effects=card.side_effects,
+        )
+    )
+    description_budget = max(target_tokens - fixed_overhead, 1)
+    truncated_desc = truncate_description_to_tokens(card.description, description_budget)
+    truncated = ChoiceCard(
+        id=card.id,
+        name=card.name,
+        description=truncated_desc,
+        tags=card.tags,
+        kind=card.kind,
+        namespace=card.namespace,
+        has_schema=card.has_schema,
+        score=card.score,
+        cost_hint=card.cost_hint,
+        side_effects=card.side_effects,
+    )
+    final_tokens = _card_token_count(truncated)
+    if final_tokens > hard_cap_tokens:
+        raise CatalogError(
+            f"ChoiceCard for {card.id!r} exceeds hard cap "
+            f"({final_tokens} > {hard_cap_tokens} tokens) "
+            "after description truncation; non-description fields too large."
+        )
+    return truncated
+
+
+def _sort_cards_for_browse(cards: list[ChoiceCard]) -> list[ChoiceCard]:
+    """Apply the §2.5 deterministic ordering: score desc, id asc."""
+    return sorted(cards, key=lambda c: (-(c.score or 0.0), c.id))
+
+
 def make_choice_cards(
     items: list[SelectableItem],
     *,
-    max_choices: int = 20,
-    max_desc_chars: int = 240,
-    max_total_chars: int | None = None,
+    max_cards: int = 20,
+    target_tokens_per_card: int = DEFAULT_CARD_TARGET_TOKENS,
+    hard_cap_tokens_per_card: int = DEFAULT_CARD_HARD_CAP_TOKENS,
     scores: dict[str, float] | None = None,
 ) -> list[ChoiceCard]:
     """Create a bounded list of :class:`ChoiceCard` objects.
 
-    Descriptions longer than *max_desc_chars* are truncated with ``"..."``.
-    If *max_total_chars* is set the lowest-scored cards are dropped until the
-    rendered text fits.
-
-    Cards are ordered by score descending.  When scores are equal (or absent),
-    the original input order is preserved as a stable tie-break.
+    Each card is rendered with a description truncated to fit
+    *target_tokens_per_card* (per §2.4).  Cards are then sorted per
+    §2.5 (score desc, ``id`` asc) and capped to *max_cards*.
 
     Args:
         items: Source items.
-        max_choices: Maximum number of cards to return.
-        max_desc_chars: Maximum description length before truncation
-            (clamped to a minimum of 4).
-        max_total_chars: Optional cap on total rendered text length.
-        scores: Optional mapping of item-id → score.
+        max_cards: Maximum number of cards to return.
+        target_tokens_per_card: Target per-card token budget (§2.3).
+            Defaults to :data:`DEFAULT_CARD_TARGET_TOKENS` (60).
+        hard_cap_tokens_per_card: Hard cap per card; truncation that
+            still exceeds this cap raises :class:`CatalogError`.
+            Defaults to :data:`DEFAULT_CARD_HARD_CAP_TOKENS` (80).
+        scores: Optional mapping of item-id → score.  When absent, the
+            original input order is preserved.
 
     Returns:
         A list of :class:`ChoiceCard` objects.
+
+    Raises:
+        CatalogError: If any card cannot be truncated below the hard cap.
     """
-    # Need at least 4 chars to produce "X..." (1 visible + "...")
-    max_desc_chars = max(max_desc_chars, 4)
     score_map = scores or {}
+    cards = [
+        _enforce_card_budget(
+            item_to_card(item, score=score_map.get(item.id)),
+            target_tokens=target_tokens_per_card,
+            hard_cap_tokens=hard_cap_tokens_per_card,
+        )
+        for item in items
+    ]
 
-    cards: list[ChoiceCard] = []
-    for item in items:
-        card = item_to_card(item, score=score_map.get(item.id))
-        # Truncate description
-        if len(card.description) > max_desc_chars:
-            card.description = card.description[: max_desc_chars - 3] + "..."
-        cards.append(card)
+    if score_map:
+        cards = _sort_cards_for_browse(cards)
 
-    # Cap at max_choices — keep highest-scored, tie-break by original index
-    if len(cards) > max_choices:
-        indexed = list(enumerate(cards))
-        indexed.sort(key=lambda t: (-(t[1].score or 0.0), t[0]))
-        cards = [c for _, c in indexed[:max_choices]]
+    return cards[:max_cards]
 
-    # Honour max_total_chars by dropping lowest-scored tail
-    if max_total_chars is not None:
-        indexed = list(enumerate(cards))
-        indexed.sort(key=lambda t: (-(t[1].score or 0.0), t[0]))
-        while indexed and len(render_cards_text([c for _, c in indexed])) > max_total_chars:
-            indexed.pop()
-        cards = [c for _, c in indexed]
 
-    return cards
+def bound_browse_response(
+    cards: list[ChoiceCard],
+    *,
+    target_tokens_per_card: int = DEFAULT_CARD_TARGET_TOKENS,
+    hard_cap_tokens_per_card: int = DEFAULT_CARD_HARD_CAP_TOKENS,
+    preamble_tokens: int = DEFAULT_BROWSE_PREAMBLE_TOKENS,
+) -> list[ChoiceCard]:
+    """Apply the §2.3 ``tool_browse`` response bound.
+
+    Drops the lowest-scoring cards (tail of the §2.5 ordering) until the
+    total rendered token count fits ``hard_cap_per_card * n +
+    preamble_tokens``.  Each retained card has already been individually
+    bounded by :func:`_enforce_card_budget`.
+
+    Args:
+        cards: Cards produced by :func:`make_choice_cards`.
+        target_tokens_per_card: §2.3 target.  Defaults to 60.
+        hard_cap_tokens_per_card: §2.3 hard cap.  Defaults to 80.
+        preamble_tokens: §2.3 preamble allowance.  Defaults to 32.
+
+    Returns:
+        A possibly shortened list of cards whose summed rendered tokens
+        fit the §2.3 bound.
+    """
+    ordered = _sort_cards_for_browse(list(cards))
+    enforced = [
+        _enforce_card_budget(
+            c,
+            target_tokens=target_tokens_per_card,
+            hard_cap_tokens=hard_cap_tokens_per_card,
+        )
+        for c in ordered
+    ]
+    # Drop from the tail (lowest score, highest id) until we fit.
+    while enforced:
+        total = sum(_card_token_count(c) for c in enforced) + preamble_tokens
+        cap = hard_cap_tokens_per_card * len(enforced) + preamble_tokens
+        if total <= cap:
+            break
+        enforced.pop()
+    return enforced
 
 
 def render_cards_text(cards: list[ChoiceCard]) -> str:
@@ -128,7 +370,7 @@ def render_cards_text(cards: list[ChoiceCard]) -> str:
 
     Format per line::
 
-        [1/5] billing.invoices.search (tool) — Search invoices by date [billing, search] score=0.82
+        [1/5] billing:invoices_search (tool) — Search invoices by date [billing, search] score=0.82
 
     Score is shown **only** when ``card.score is not None``.
 
@@ -144,8 +386,7 @@ def render_cards_text(cards: list[ChoiceCard]) -> str:
         tags_str = f" [{', '.join(sorted(card.tags))}]" if card.tags else ""
         score_str = f" score={card.score:.2f}" if card.score is not None else ""
         lines.append(
-            f"[{idx}/{total}] {card.id} ({card.kind}) "
-            f"\u2014 {card.description}{tags_str}{score_str}"
+            f"[{idx}/{total}] {card.id} ({card.kind}) — {card.description}{tags_str}{score_str}"
         )
     return "\n".join(lines)
 

--- a/src/contextweaver/routing/cards.py
+++ b/src/contextweaver/routing/cards.py
@@ -356,11 +356,15 @@ def bound_browse_response(
         for c in ordered
     ]
     # Drop from the tail (lowest score, highest id) until we fit.
+    # Precompute token counts once and maintain a running total to keep
+    # the loop O(n) rather than O(n²).
+    cached_counts = [_card_token_count(c) for c in enforced]
+    running_total = sum(cached_counts)
     while enforced:
-        total = sum(_card_token_count(c) for c in enforced) + preamble_tokens
         cap = hard_cap_tokens_per_card * len(enforced) + preamble_tokens
-        if total <= cap:
+        if running_total + preamble_tokens <= cap:
             break
+        running_total -= cached_counts.pop()
         enforced.pop()
     return enforced
 

--- a/src/contextweaver/routing/path.py
+++ b/src/contextweaver/routing/path.py
@@ -1,0 +1,177 @@
+"""``tool_browse`` path-navigation grammar (§3.2).
+
+Parses and validates hierarchical paths through a :class:`ChoiceGraph` for
+the gateway's ``tool_browse(path="/...")`` surface.  Grammar::
+
+    path     = "/" [ segment ( "/" segment )* ]
+    segment  = ( [a-z0-9] [a-z0-9_-]{0,63} ) | "*"
+
+- A bare ``/`` lists root-level cards (one per namespace).
+- A trailing ``/`` is invalid.
+- Empty segments are invalid (``//foo``).
+- The segment ``*`` lists all children at that level.
+- Segments are case-sensitive lowercase; root-level segments must begin
+  with ``[a-z]`` (deeper segments may begin with a digit per §3.2).
+
+Public API:
+    - :func:`parse_path` — string → list of segments (raises
+      :class:`PathInvalidError` on grammar violations).
+    - :func:`resolve_path` — segments + :class:`ChoiceGraph` → list of
+      node IDs (raises :class:`PathNotFoundError` if the path does not
+      resolve).
+"""
+
+from __future__ import annotations
+
+import re
+
+from contextweaver.exceptions import PathInvalidError, PathNotFoundError
+from contextweaver.routing.graph import ChoiceGraph
+
+_ROOT_SEGMENT_RE = re.compile(r"^[a-z][a-z0-9_\-]{0,63}$")
+_DEEP_SEGMENT_RE = re.compile(r"^[a-z0-9][a-z0-9_\-]{0,63}$")
+_WILDCARD = "*"
+
+
+def parse_path(path: str) -> list[str]:
+    """Validate and split a ``tool_browse`` path into its segments (§3.2).
+
+    Args:
+        path: The path string.  A bare ``"/"`` is valid and returns ``[]``.
+
+    Returns:
+        The list of segments (excluding the leading ``"/"``).  An empty
+        list means "root".
+
+    Raises:
+        PathInvalidError: For any §3.2 grammar violation (missing leading
+            ``"/"``, trailing ``"/"``, empty segment, malformed segment,
+            wildcard in a non-final position).
+    """
+    if not isinstance(path, str):
+        raise PathInvalidError(f"path must be a string, got {type(path).__name__}")
+    if not path:
+        raise PathInvalidError("path must not be empty")
+    if not path.startswith("/"):
+        raise PathInvalidError(f"path must start with '/' (got {path!r})")
+    if path == "/":
+        return []
+    if path.endswith("/"):
+        raise PathInvalidError(f"path must not end with '/' (got {path!r})")
+
+    segments = path[1:].split("/")
+    for i, seg in enumerate(segments):
+        if not seg:
+            raise PathInvalidError(f"empty segment at index {i} in {path!r}")
+        if seg == _WILDCARD:
+            if i != len(segments) - 1:
+                raise PathInvalidError(
+                    f"wildcard '*' may only appear as the final segment in {path!r}"
+                )
+            continue
+        if i == 0:
+            if not _ROOT_SEGMENT_RE.match(seg):
+                raise PathInvalidError(f"root segment {seg!r} must start with [a-z] (§3.2)")
+        else:
+            if not _DEEP_SEGMENT_RE.match(seg):
+                raise PathInvalidError(f"segment {seg!r} not matching §3.2 grammar")
+    return segments
+
+
+def resolve_path(graph: ChoiceGraph, segments: list[str]) -> list[str]:
+    """Walk *graph* down *segments* and return the addressed child IDs.
+
+    Behaviour by path shape:
+
+    - Empty *segments* → IDs of the root-level navigation children
+      (typically one per namespace).
+    - Final segment is :data:`_WILDCARD` (``"*"``) → all children at the
+      parent level, same as omitting the segment.
+    - Last segment matches a leaf node → ``[leaf_id]``.
+    - Last segment matches an interior node → that node's children.
+
+    Args:
+        graph: A :class:`~contextweaver.routing.graph.ChoiceGraph`.
+        segments: Output of :func:`parse_path`.
+
+    Returns:
+        Either the list of child IDs of the addressed node, or
+        ``[leaf_id]`` when the path lands on a leaf item.
+
+    Raises:
+        PathNotFoundError: If any segment does not resolve to a child of
+            the current node (and is not the wildcard ``"*"``).
+    """
+    root_id = graph.root_id
+    if not segments:
+        return graph.successors(root_id)
+
+    current_parent = root_id
+    walked: list[str] = []
+    final_id: str | None = None
+
+    for seg in segments:
+        walked.append(seg)
+        children = graph.successors(current_parent)
+        if seg == _WILDCARD:
+            # parse_path already enforces wildcard is in the final position.
+            return children
+
+        match = _match_segment(seg, children)
+        if match is None:
+            raise PathNotFoundError(f"path /{'/'.join(walked)} does not resolve in the catalog")
+        final_id = match
+        current_parent = match
+
+    next_children = graph.successors(current_parent)
+    if not next_children and final_id is not None:
+        return [final_id]
+    return next_children
+
+
+def _match_segment(segment: str, child_ids: list[str]) -> str | None:
+    """Return the *child_ids* entry whose path-segment label equals *segment*.
+
+    The path-segment label of a child ID is:
+
+    - The portion after the last ``/`` for hierarchical navigation node
+      IDs like ``root/github/issues`` (segment label = ``issues``).
+    - The portion before the first ``:`` for canonical ``tool_id`` leaves
+      like ``github:create_issue@1.4.0`` (segment label = ``github``).  In
+      practice canonical leaves only match deeper segments because root
+      segments are addressed by their namespace node, not their leaf id.
+    - Otherwise the entire ID, lowercased.
+
+    Matching is case-insensitive on the *child_ids* side because graph
+    construction may produce mixed-case labels for navigation nodes while
+    §3.2 mandates lowercase path segments.
+    """
+    target = segment.lower()
+    for child_id in child_ids:
+        if _segment_label_for(child_id) == target:
+            return child_id
+    return None
+
+
+def _segment_label_for(child_id: str) -> str:
+    """Return the canonical lowercase path-segment label for a child ID.
+
+    Two ID shapes are recognised:
+
+    - Hierarchical navigation node IDs like ``root/github/issues`` →
+      segment label = ``issues`` (text after the final ``"/"``).
+    - Canonical ``tool_id`` leaves like ``github:create_issue@1.0#abcdef01``
+      → segment label = ``create_issue`` (the ``name`` part: text
+      between the first ``":"`` and the first ``"@"`` or ``"#"``).
+
+    Any other shape lowercases the entire ID.
+    """
+    if "/" in child_id:
+        return child_id.rsplit("/", 1)[-1].lower()
+    if ":" in child_id:
+        rest = child_id.split(":", 1)[1]
+        for sep in ("@", "#"):
+            if sep in rest:
+                rest = rest.split(sep, 1)[0]
+        return rest.lower()
+    return child_id.lower()

--- a/src/contextweaver/routing/router.py
+++ b/src/contextweaver/routing/router.py
@@ -162,13 +162,13 @@ class RouteResult:
         if not self.candidate_items:
             raise RouteError("RoutingDecision requires at least one candidate item")
         score_map = dict(zip(self.candidate_ids, self.scores, strict=False))
-        # ``make_choice_cards`` defaults to ``max_choices=20``; pass an explicit
+        # ``make_choice_cards`` defaults to ``max_cards=20``; pass an explicit
         # cap so converting a router configured with ``top_k > 20`` does not
         # silently truncate candidates (PR #201 review).
         cards = make_choice_cards(
             self.candidate_items,
             scores=score_map,
-            max_choices=max(len(self.candidate_items), 1),
+            max_cards=max(len(self.candidate_items), 1),
         )
         resolved_card_id = selected_card_id
         if resolved_card_id is None and selected_item_id is not None:

--- a/src/contextweaver/routing/tool_id.py
+++ b/src/contextweaver/routing/tool_id.py
@@ -1,0 +1,200 @@
+"""Canonical ``tool_id`` parsing and formatting.
+
+Implements the grammar and hash function from
+:doc:`docs/gateway_spec.md` §1.  A canonical ``tool_id`` is::
+
+    tool_id   = namespace ":" name [ "@" version ] [ "#" hash8 ]
+    namespace = [a-z] [a-z0-9_-]{0,63}
+    name      = [A-Za-z_] [A-Za-z0-9_.-]{0,127}
+    version   = [A-Za-z0-9._-]{1,32}
+    hash8     = [0-9a-f]{8}
+
+Total length is bounded at 240 characters.  ``hash8`` is **required** when
+``version`` is absent.
+
+Public API:
+    - :class:`ToolIdParts` — destructured form of a canonical id.
+    - :func:`parse_tool_id` — string → :class:`ToolIdParts`.
+    - :func:`format_tool_id` — :class:`ToolIdParts` → string.
+    - :func:`compute_hash8` — sha256-based 8-char shape hash (§1.3).
+    - :func:`canonical_tool_id` — assemble a canonical id from upstream
+      metadata in one call.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from contextweaver.exceptions import CatalogError
+
+_NAMESPACE_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.\-]{0,127}$")
+_VERSION_RE = re.compile(r"^[A-Za-z0-9._\-]{1,32}$")
+_HASH8_RE = re.compile(r"^[0-9a-f]{8}$")
+
+_TOOL_ID_MAX_LEN = 240
+
+
+@dataclass(frozen=True)
+class ToolIdParts:
+    """Destructured form of a canonical ``tool_id``.
+
+    Attributes:
+        namespace: Lowercase prefix identifying the upstream server.
+        name: Tool name derived from the upstream tool's name (see §1.2/§1.4).
+        version: Optional upstream-declared version string.
+        hash8: Optional 8-char lowercase hex digest of the input-schema shape.
+            Required when *version* is ``None`` so the id is stable across
+            description-only updates.
+    """
+
+    namespace: str
+    name: str
+    version: str | None = None
+    hash8: str | None = None
+
+
+def _canonical_shape(input_schema: dict[str, Any] | None) -> str:
+    """Return the canonical JSON form of an input-schema *shape* (§1.3).
+
+    Only top-level ``properties`` keys and the ``required`` array are
+    considered — types and descriptions are deliberately excluded so that
+    prose-only edits do not churn the id.
+    """
+    schema = input_schema or {}
+    props = sorted((schema.get("properties") or {}).keys())
+    required = sorted(schema.get("required") or [])
+    return json.dumps(
+        {"properties": props, "required": required},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def compute_hash8(upstream_name: str, input_schema: dict[str, Any] | None) -> str:
+    """Compute the 8-char shape hash of an MCP tool (§1.3).
+
+    The hash is taken over ``upstream_name + "\\n" + canonical_shape``.
+    Including the upstream name disambiguates tools that share an
+    input-schema shape but originate in different namespaces (e.g.
+    ``github.create_issue`` vs ``gitlab.create_issue``).
+
+    Args:
+        upstream_name: The original tool name as reported by the upstream
+            server, *before* any namespace stripping.
+        input_schema: The tool's MCP ``inputSchema`` dict.  ``None`` and
+            ``{}`` are treated as the empty schema.
+
+    Returns:
+        An 8-character lowercase hex string.
+    """
+    canonical = upstream_name + "\n" + _canonical_shape(input_schema)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:8]
+
+
+def format_tool_id(parts: ToolIdParts) -> str:
+    """Assemble a canonical ``tool_id`` from its parts (§1.6).
+
+    Args:
+        parts: A :class:`ToolIdParts` instance.
+
+    Returns:
+        The canonical string form.
+
+    Raises:
+        CatalogError: If any field violates the §1.1 grammar, the total
+            length exceeds 240 characters, or both ``version`` and ``hash8``
+            are absent.
+    """
+    if not _NAMESPACE_RE.match(parts.namespace):
+        raise CatalogError(f"tool_id namespace not matching grammar: {parts.namespace!r}")
+    if not _NAME_RE.match(parts.name):
+        raise CatalogError(f"tool_id name not matching grammar: {parts.name!r}")
+    if parts.version is not None and not _VERSION_RE.match(parts.version):
+        raise CatalogError(f"tool_id version not matching grammar: {parts.version!r}")
+    if parts.hash8 is not None and not _HASH8_RE.match(parts.hash8):
+        raise CatalogError(f"tool_id hash8 not matching grammar: {parts.hash8!r}")
+    if parts.version is None and parts.hash8 is None:
+        raise CatalogError("tool_id requires hash8 when version is absent (§1.2)")
+
+    out = f"{parts.namespace}:{parts.name}"
+    if parts.version is not None:
+        out += f"@{parts.version}"
+    if parts.hash8 is not None:
+        out += f"#{parts.hash8}"
+    if len(out) > _TOOL_ID_MAX_LEN:
+        raise CatalogError(f"tool_id exceeds 240-char limit: {len(out)} chars")
+    return out
+
+
+def parse_tool_id(s: str) -> ToolIdParts:
+    """Split a canonical ``tool_id`` into its parts (§1.6).
+
+    Args:
+        s: A canonical ``tool_id`` string.
+
+    Returns:
+        A :class:`ToolIdParts` instance.
+
+    Raises:
+        CatalogError: If *s* is malformed, missing the namespace separator,
+            longer than 240 characters, or omits ``hash8`` when ``version``
+            is also absent.
+    """
+    if not isinstance(s, str):
+        raise CatalogError(f"tool_id must be a string, got {type(s).__name__}")
+    if len(s) > _TOOL_ID_MAX_LEN:
+        raise CatalogError(f"tool_id exceeds 240-char limit: {len(s)} chars")
+    if ":" not in s:
+        raise CatalogError(f"tool_id missing namespace separator ':' in {s!r}")
+
+    namespace, rest = s.split(":", 1)
+
+    hash8: str | None = None
+    if "#" in rest:
+        rest, hash8 = rest.rsplit("#", 1)
+
+    version: str | None = None
+    if "@" in rest:
+        rest, version = rest.rsplit("@", 1)
+
+    name = rest
+    parts = ToolIdParts(namespace=namespace, name=name, version=version, hash8=hash8)
+    # Re-run the grammar checks via format_tool_id so both directions agree.
+    format_tool_id(parts)
+    return parts
+
+
+def canonical_tool_id(
+    *,
+    namespace: str,
+    name: str,
+    upstream_name: str,
+    input_schema: dict[str, Any] | None,
+    version: str | None = None,
+) -> str:
+    """Assemble a canonical ``tool_id`` for an upstream MCP tool.
+
+    Convenience wrapper that computes ``hash8`` from *upstream_name* and
+    *input_schema* whenever *version* is absent, then calls
+    :func:`format_tool_id`.
+
+    Args:
+        namespace: Lowercase server-of-origin prefix.
+        name: Derived tool name (per §1.4).
+        upstream_name: The raw upstream tool name (pre-stripping).  Drives
+            ``hash8`` so that two tools sharing an input shape but different
+            origins produce distinct ids.
+        input_schema: The MCP ``inputSchema``; pass ``None`` if empty.
+        version: Optional upstream-declared version.  When provided,
+            ``hash8`` is omitted.
+
+    Returns:
+        The canonical ``tool_id`` string.
+    """
+    hash8 = None if version is not None else compute_hash8(upstream_name, input_schema)
+    return format_tool_id(ToolIdParts(namespace=namespace, name=name, version=version, hash8=hash8))

--- a/src/contextweaver/types.py
+++ b/src/contextweaver/types.py
@@ -124,21 +124,39 @@ ToolCard = SelectableItem
 
 @dataclass
 class ArtifactRef:
-    """A lightweight reference to an out-of-band artifact stored in an ArtifactStore."""
+    """A lightweight reference to an out-of-band artifact stored in an ArtifactStore.
+
+    Attributes:
+        handle: Opaque key used to retrieve the artifact via
+            :meth:`ArtifactStore.get` / :meth:`drilldown`.
+        media_type: MIME type of the stored bytes.
+        size_bytes: Size of the stored bytes in bytes.
+        label: Optional human-readable label.
+        content_hash: ``sha256`` digest of the stored bytes as a
+            lowercase hex string.  Empty when not populated by the
+            writing path (legacy ``ArtifactRef`` instances pre-#190).
+            Populated by :func:`~contextweaver.context.firewall.apply_firewall`
+            and used to short-circuit re-firewall passes on items that
+            already carry a firewall-processed body (issue #190).
+    """
 
     handle: str
     media_type: str
     size_bytes: int
     label: str = ""
+    content_hash: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise to a JSON-compatible dict."""
-        return {
+        out: dict[str, Any] = {
             "handle": self.handle,
             "media_type": self.media_type,
             "size_bytes": self.size_bytes,
             "label": self.label,
         }
+        if self.content_hash:
+            out["content_hash"] = self.content_hash
+        return out
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ArtifactRef:
@@ -148,6 +166,7 @@ class ArtifactRef:
             media_type=data["media_type"],
             size_bytes=int(data["size_bytes"]),
             label=data.get("label", ""),
+            content_hash=data.get("content_hash", ""),
         )
 
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -32,9 +32,17 @@ from contextweaver.exceptions import CatalogError
 
 
 def test_mcp_tool_to_selectable_basic() -> None:
+    from contextweaver.routing.tool_id import parse_tool_id
+
     tool_def = {"name": "search", "description": "Search the database"}
     item = mcp_tool_to_selectable(tool_def)
-    assert item.id == "mcp:search"
+    # Canonical tool_id per docs/gateway_spec.md §1: namespace=mcp (fallback),
+    # name=search (no separator → preserved), no version → hash8 required.
+    parsed = parse_tool_id(item.id)
+    assert parsed.namespace == "mcp"
+    assert parsed.name == "search"
+    assert parsed.version is None
+    assert parsed.hash8 is not None and len(parsed.hash8) == 8
     assert item.kind == "tool"
     assert item.name == "search"
     assert item.description == "Search the database"

--- a/tests/test_card_budget.py
+++ b/tests/test_card_budget.py
@@ -1,0 +1,203 @@
+"""Tests for the token-budget enforcement in routing.cards (gateway_spec.md §2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from contextweaver.envelope import ChoiceCard
+from contextweaver.exceptions import CatalogError
+from contextweaver.routing.cards import (
+    DEFAULT_BROWSE_PREAMBLE_TOKENS,
+    DEFAULT_CARD_HARD_CAP_TOKENS,
+    DEFAULT_CARD_TARGET_TOKENS,
+    bound_browse_response,
+    count_tokens,
+    make_choice_cards,
+    truncate_description_to_tokens,
+)
+from contextweaver.types import SelectableItem
+
+# ---------------------------------------------------------------------------
+# truncate_description_to_tokens — §2.4
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_within_budget_returns_verbatim() -> None:
+    text = "Short description that fits."
+    assert truncate_description_to_tokens(text, 100) == text
+
+
+def test_truncate_prefers_sentence_boundary() -> None:
+    text = "First sentence. Second sentence. Third sentence that is much longer than the rest."
+    result = truncate_description_to_tokens(text, 10)
+    # Sentence boundaries (".") appear at positions covering "First sentence."
+    # and "First sentence. Second sentence." — the longer prefix that fits
+    # below 10 tokens should be returned.
+    assert result.endswith(".")
+    assert count_tokens(result) <= 10
+
+
+def test_truncate_hard_cut_appends_ellipsis_when_no_sentence_fits() -> None:
+    """A very long word with no sentence terminator falls through to byte-cut."""
+    text = "x" * 800  # No sentence boundary at all
+    result = truncate_description_to_tokens(text, 5)
+    assert result.endswith("…")
+    assert count_tokens(result) <= 5
+
+
+def test_truncate_zero_budget_returns_empty() -> None:
+    assert truncate_description_to_tokens("anything", 0) == ""
+
+
+def test_truncate_deterministic() -> None:
+    text = "A " * 200
+    assert truncate_description_to_tokens(text, 20) == truncate_description_to_tokens(text, 20)
+
+
+# ---------------------------------------------------------------------------
+# make_choice_cards — token-budget enforcement
+# ---------------------------------------------------------------------------
+
+
+def _item(
+    iid: str, description: str = "Does the thing.", name: str | None = None
+) -> SelectableItem:
+    return SelectableItem(
+        id=iid,
+        kind="tool",
+        name=name or f"tool_{iid}",
+        description=description,
+        tags=["test"],
+    )
+
+
+def test_make_choice_cards_truncates_to_target_tokens() -> None:
+    long_desc = "A long sentence. " * 100
+    items = [_item("t1", description=long_desc)]
+    cards = make_choice_cards(items, target_tokens_per_card=60)
+    # Per-card rendering must fit within the hard cap.
+    rendered_line = f"[1/1] {cards[0].id} ({cards[0].kind}) — {cards[0].description}"
+    assert count_tokens(rendered_line) <= DEFAULT_CARD_HARD_CAP_TOKENS
+
+
+def test_make_choice_cards_score_desc_id_asc() -> None:
+    """§2.5: sort by score desc, ties by id asc."""
+    items = [_item("zzz"), _item("aaa"), _item("mmm")]
+    cards = make_choice_cards(items, scores={"zzz": 0.5, "aaa": 0.5, "mmm": 0.5})
+    assert [c.id for c in cards] == ["aaa", "mmm", "zzz"]
+
+
+def test_make_choice_cards_caps_name_to_64_chars() -> None:
+    """§2.1: name ≤ 64 characters."""
+    items = [_item("t1", name="X" * 200)]
+    cards = make_choice_cards(items)
+    assert len(cards[0].name) <= 64
+
+
+def test_make_choice_cards_caps_tags_to_5_entries() -> None:
+    """§2.1: tags max 5 entries."""
+    item = SelectableItem(
+        id="t1",
+        kind="tool",
+        name="t1",
+        description="d",
+        tags=[f"tag{i}" for i in range(20)],
+    )
+    cards = make_choice_cards([item])
+    assert len(cards[0].tags) <= 5
+
+
+def test_make_choice_cards_caps_tag_length_to_24_chars() -> None:
+    """§2.1: each tag ≤ 24 characters."""
+    item = SelectableItem(
+        id="t1",
+        kind="tool",
+        name="t1",
+        description="d",
+        tags=["x" * 100],
+    )
+    cards = make_choice_cards([item])
+    assert all(len(t) <= 24 for t in cards[0].tags)
+
+
+def test_make_choice_cards_raises_when_card_exceeds_hard_cap() -> None:
+    """If non-description content alone exceeds the hard cap, raise."""
+    # Tag entries are capped at 24 chars + 5 entries — the cap is large
+    # enough to exceed an artificially-low hard-cap.
+    item = SelectableItem(
+        id="t1",
+        kind="tool",
+        name="X" * 64,
+        description="d",
+        tags=["aaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbb"],
+    )
+    with pytest.raises(CatalogError, match="hard cap"):
+        make_choice_cards([item], target_tokens_per_card=5, hard_cap_tokens_per_card=5)
+
+
+# ---------------------------------------------------------------------------
+# bound_browse_response — §2.3
+# ---------------------------------------------------------------------------
+
+
+def test_bound_browse_response_fits_within_total_budget() -> None:
+    items = [_item(f"t{i:02d}") for i in range(50)]
+    scores = {f"t{i:02d}": float(i) for i in range(50)}
+    cards = make_choice_cards(items, max_cards=50, scores=scores)
+    bounded = bound_browse_response(cards)
+    total = sum(count_tokens(f"[1/1] {c.id} ({c.kind}) — {c.description}") for c in bounded)
+    cap = DEFAULT_CARD_HARD_CAP_TOKENS * len(bounded) + DEFAULT_BROWSE_PREAMBLE_TOKENS
+    assert total + DEFAULT_BROWSE_PREAMBLE_TOKENS <= cap
+
+
+def test_bound_browse_response_drops_lowest_scoring_tail() -> None:
+    """Lowest-scored tail is dropped first when the total budget is tight."""
+    # Build cards whose per-card cost is close to the hard cap so the
+    # response cannot fit all of them under the §2.3 total budget.
+    desc = "Detailed description with several words to fill the budget."
+    items = [_item(f"t{i:02d}", description=desc) for i in range(15)]
+    scores = {f"t{i:02d}": float(i) for i in range(15)}
+    cards = make_choice_cards(items, max_cards=15, scores=scores)
+    bounded = bound_browse_response(cards, preamble_tokens=4)
+    # The highest-scored card is always retained.
+    assert bounded[0].id == "t14"
+    # Ordering is preserved (score desc → t14, t13, ...).
+    ids = [c.id for c in bounded]
+    expected_prefix = [f"t{i:02d}" for i in range(14, 14 - len(bounded), -1)]
+    assert ids == expected_prefix
+
+
+def test_bound_browse_response_preserves_score_desc_tie_break() -> None:
+    items = [_item("zzz"), _item("aaa"), _item("mmm")]
+    cards = make_choice_cards(items, scores={"zzz": 0.5, "aaa": 0.5, "mmm": 0.5})
+    bounded = bound_browse_response(cards)
+    assert [c.id for c in bounded] == ["aaa", "mmm", "zzz"]
+
+
+def test_bound_browse_response_handles_empty() -> None:
+    assert bound_browse_response([]) == []
+
+
+def test_default_card_tokens_match_spec() -> None:
+    """Spec §2.3 anchors: target ≤ 60, hard cap ≤ 80, preamble = 32."""
+    assert DEFAULT_CARD_TARGET_TOKENS == 60
+    assert DEFAULT_CARD_HARD_CAP_TOKENS == 80
+    assert DEFAULT_BROWSE_PREAMBLE_TOKENS == 32
+
+
+# ---------------------------------------------------------------------------
+# ChoiceCard.to_dict — banned-field guard (§2.2)
+# ---------------------------------------------------------------------------
+
+
+def test_choice_card_to_dict_omits_schema_keys() -> None:
+    """§2.2: card serialisation MUST NOT carry args_schema / output_schema / examples."""
+    card = ChoiceCard(
+        id="t1",
+        name="t",
+        description="d",
+        has_schema=True,
+    )
+    d = card.to_dict()
+    for banned in ("args_schema", "output_schema", "examples", "annotations", "_meta"):
+        assert banned not in d

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -96,9 +96,9 @@ def test_make_choice_cards_default() -> None:
     assert len(cards) == 5
 
 
-def test_make_choice_cards_max_choices() -> None:
+def test_make_choice_cards_max_cards() -> None:
     items = [_item(f"t{i}") for i in range(30)]
-    cards = make_choice_cards(items, max_choices=10)
+    cards = make_choice_cards(items, max_cards=10)
     assert len(cards) <= 10
 
 
@@ -106,26 +106,21 @@ def test_make_choice_cards_preserves_order_no_scores() -> None:
     """Without scores, original input order is preserved when capping."""
     # IDs in reverse alphabetical order
     items = [_item(f"z{i}") for i in range(5)] + [_item(f"a{i}") for i in range(5)]
-    cards = make_choice_cards(items, max_choices=5)
+    cards = make_choice_cards(items, max_cards=5)
     # Should keep first 5 (z0..z4), not alphabetically first
     assert [c.id for c in cards] == [f"z{i}" for i in range(5)]
 
 
-def test_make_choice_cards_max_desc_chars_clamped() -> None:
-    """max_desc_chars < 4 is clamped to 4."""
-    items = [_item("t1", description="Hello world")]
-    cards = make_choice_cards(items, max_desc_chars=1)
-    # Should not crash; description is truncated to 4 chars
-    assert len(cards[0].description) <= 4
-    assert cards[0].description.endswith("...")
+def test_make_choice_cards_truncates_description_to_token_budget() -> None:
+    """Per docs/gateway_spec.md §2.4, descriptions are truncated by tokens."""
+    from contextweaver.routing.cards import count_tokens
 
-
-def test_make_choice_cards_truncates_description() -> None:
-    long_desc = "A" * 300
+    long_desc = "A long sentence. " * 100  # ~400 tokens
     items = [_item("t1", description=long_desc)]
-    cards = make_choice_cards(items, max_desc_chars=50)
-    assert len(cards[0].description) <= 50
-    assert cards[0].description.endswith("...")
+    cards = make_choice_cards(items, target_tokens_per_card=60)
+    # Truncated to fit the per-card target.
+    rendered_line = f"[1/1] {cards[0].id} ({cards[0].kind}) — {cards[0].description}"
+    assert count_tokens(rendered_line) <= 80  # hard cap
 
 
 def test_make_choice_cards_with_scores() -> None:
@@ -138,12 +133,13 @@ def test_make_choice_cards_with_scores() -> None:
     assert score_map["t2"] == 0.3
 
 
-def test_make_choice_cards_max_total_chars() -> None:
-    items = [_item(f"t{i}", description="X" * 100) for i in range(20)]
-    scores = {f"t{i}": float(i) for i in range(20)}
-    cards = make_choice_cards(items, max_total_chars=500, scores=scores)
-    text = render_cards_text(cards)
-    assert len(text) <= 500
+def test_make_choice_cards_score_desc_id_asc_ordering() -> None:
+    """§2.5: ties broken by tool_id ascending."""
+    items = [_item("t_zzz"), _item("t_aaa"), _item("t_mmm")]
+    # All same score → tie-break by id ascending.
+    scores = {"t_zzz": 0.5, "t_aaa": 0.5, "t_mmm": 0.5}
+    cards = make_choice_cards(items, scores=scores)
+    assert [c.id for c in cards] == ["t_aaa", "t_mmm", "t_zzz"]
 
 
 def test_make_choice_cards_no_schemas_in_output() -> None:
@@ -162,7 +158,7 @@ def test_make_choice_cards_no_schemas_in_output() -> None:
 def test_render_cards_text_format() -> None:
     cards = [
         ChoiceCard(
-            id="billing.invoices.search",
+            id="billing:invoices_search@1.0",
             name="search",
             description="Search invoices by date",
             tags=["billing", "search"],
@@ -172,7 +168,7 @@ def test_render_cards_text_format() -> None:
     ]
     text = render_cards_text(cards)
     assert "[1/1]" in text
-    assert "billing.invoices.search" in text
+    assert "billing:invoices_search@1.0" in text
     assert "(tool)" in text
     assert "score=0.82" in text
     assert "[billing, search]" in text

--- a/tests/test_firewall.py
+++ b/tests/test_firewall.py
@@ -188,3 +188,49 @@ def test_custom_extractor_error_falls_back() -> None:
     assert env is not None
     assert env.status == "partial"
     assert env.facts == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #190 — content-addressed idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_apply_firewall_sets_content_hash_on_returned_ref() -> None:
+    """The artifact ref returned from the first firewall pass carries a sha256 hash."""
+    import hashlib
+
+    raw = "raw tool output that should be stored verbatim"
+    item = ContextItem(id="r-hash", kind=ItemKind.tool_result, text=raw)
+    store = InMemoryArtifactStore()
+    processed, env = apply_firewall(item, store)
+    expected = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    assert processed.artifact_ref is not None
+    assert processed.artifact_ref.content_hash == expected
+
+
+def test_apply_firewall_is_idempotent_on_already_processed_items() -> None:
+    """Issue #190: re-running the firewall must not overwrite raw bytes.
+
+    The bug: ``apply_firewall`` would re-fire on items whose ``text``
+    had already been replaced with the summary, storing the summary
+    under the same handle and destroying the original raw payload.
+    """
+    raw = "x" * 10_000
+    item = ContextItem(id="r190", kind=ItemKind.tool_result, text=raw)
+    store = InMemoryArtifactStore()
+
+    # First pass — fires.
+    processed_a, env_a = apply_firewall(item, store)
+    assert env_a is not None
+    assert processed_a.artifact_ref is not None
+    handle = processed_a.artifact_ref.handle
+    raw_after_first = store.get(handle)
+
+    # Second pass on the post-firewall item — must be a no-op.
+    processed_b, env_b = apply_firewall(processed_a, store)
+    assert env_b is None  # nothing to compact a second time
+    raw_after_second = store.get(handle)
+
+    # Raw bytes preserved across the second pass.
+    assert raw_after_first == raw_after_second
+    assert raw_after_first.decode("utf-8") == raw

--- a/tests/test_mcp_gateway.py
+++ b/tests/test_mcp_gateway.py
@@ -1,0 +1,129 @@
+"""Tests for the two-tool gateway adapter (#28 + #34)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from contextweaver.adapters.mcp_gateway import (
+    GATEWAY_TOOL_NAMES,
+    TOOL_BROWSE,
+    TOOL_EXECUTE,
+    TOOL_VIEW,
+    dispatch_meta_tool,
+    make_gateway_meta_tools,
+)
+from contextweaver.adapters.mcp_upstream import StubUpstream
+from contextweaver.adapters.proxy_runtime import ProxyRuntime
+
+
+def _tool_defs() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "github.create_issue",
+            "description": "Open a new GitHub issue.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"title": {"type": "string"}},
+                "required": ["title"],
+            },
+            "_meta": {"version": "1.4.0"},
+        }
+    ]
+
+
+async def _ok_handler(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "content": [{"type": "text", "text": f"called {name}"}],
+        "isError": False,
+    }
+
+
+def _runtime() -> ProxyRuntime:
+    runtime = ProxyRuntime(StubUpstream(_tool_defs(), handler=_ok_handler))
+    runtime.register_tool_defs_sync(_tool_defs())
+    return runtime
+
+
+# ---------------------------------------------------------------------------
+# make_gateway_meta_tools
+# ---------------------------------------------------------------------------
+
+
+def test_make_gateway_meta_tools_returns_three_tools() -> None:
+    runtime = _runtime()
+    tools = make_gateway_meta_tools(runtime)
+    assert [t["name"] for t in tools] == list(GATEWAY_TOOL_NAMES)
+    assert {t["name"] for t in tools} == {TOOL_BROWSE, TOOL_EXECUTE, TOOL_VIEW}
+
+
+def test_gateway_tool_defs_have_no_banned_fields() -> None:
+    """§2.2: no banned fields on meta-tool entries either."""
+    runtime = _runtime()
+    for tool in make_gateway_meta_tools(runtime):
+        assert "outputSchema" not in tool
+        assert "annotations" not in tool
+        assert "_meta" not in tool
+
+
+# ---------------------------------------------------------------------------
+# dispatch_meta_tool — happy paths
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_tool_browse_returns_cards_payload() -> None:
+    runtime = _runtime()
+    result = await dispatch_meta_tool(runtime, TOOL_BROWSE, {"query": "issue"})
+    assert result["isError"] is False
+    cards = json.loads(result["content"][0]["text"])
+    assert isinstance(cards, list)
+
+
+async def test_dispatch_tool_browse_rejects_both_query_and_path() -> None:
+    runtime = _runtime()
+    result = await dispatch_meta_tool(runtime, TOOL_BROWSE, {"query": "q", "path": "/x"})
+    assert result["isError"] is True
+    body = json.loads(result["content"][0]["text"])
+    assert body["error"] == "ARGS_INVALID"
+
+
+async def test_dispatch_tool_execute_validates_args() -> None:
+    runtime = _runtime()
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:"))
+    result = await dispatch_meta_tool(runtime, TOOL_EXECUTE, {"tool_id": tool_id, "args": {}})
+    assert result["isError"] is True
+    body = json.loads(result["content"][0]["text"])
+    assert body["error"] == "ARGS_INVALID"
+
+
+async def test_dispatch_tool_execute_happy_path() -> None:
+    runtime = _runtime()
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:"))
+    result = await dispatch_meta_tool(
+        runtime, TOOL_EXECUTE, {"tool_id": tool_id, "args": {"title": "x"}}
+    )
+    assert result["isError"] is False
+
+
+async def test_dispatch_tool_execute_requires_string_tool_id() -> None:
+    runtime = _runtime()
+    result = await dispatch_meta_tool(runtime, TOOL_EXECUTE, {"tool_id": 42, "args": {}})
+    assert result["isError"] is True
+
+
+async def test_dispatch_tool_view_invalid_handle() -> None:
+    runtime = _runtime()
+    result = await dispatch_meta_tool(
+        runtime, TOOL_VIEW, {"handle": "missing", "selector": {"type": "head"}}
+    )
+    assert result["isError"] is True
+    body = json.loads(result["content"][0]["text"])
+    assert body["error"] == "VIEW_FAILED"
+
+
+async def test_dispatch_unknown_meta_tool_returns_args_invalid() -> None:
+    runtime = _runtime()
+    result = await dispatch_meta_tool(runtime, "tool_unknown", {})
+    assert result["isError"] is True
+    body = json.loads(result["content"][0]["text"])
+    assert body["error"] == "ARGS_INVALID"

--- a/tests/test_mcp_proxy.py
+++ b/tests/test_mcp_proxy.py
@@ -1,0 +1,157 @@
+"""Tests for the transparent MCP proxy adapter (#13)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from contextweaver.adapters.mcp_proxy import (
+    PROXY_META_TOOL_NAMES,
+    TOOL_EXECUTE,
+    TOOL_HYDRATE,
+    dispatch_proxy_request,
+    make_proxy_meta_tools,
+    make_stripped_tools_list,
+)
+from contextweaver.adapters.mcp_upstream import StubUpstream
+from contextweaver.adapters.proxy_runtime import ExposureMode, ProxyRuntime
+
+
+def _tool_defs() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "github.create_issue",
+            "description": "Open a new GitHub issue.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"title": {"type": "string"}},
+                "required": ["title"],
+            },
+            "_meta": {"version": "1.4.0"},
+        }
+    ]
+
+
+async def _ok_handler(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "content": [{"type": "text", "text": f"called {name} with {sorted(args.keys())}"}],
+        "isError": False,
+    }
+
+
+def _runtime() -> ProxyRuntime:
+    runtime = ProxyRuntime(
+        StubUpstream(_tool_defs(), handler=_ok_handler),
+        mode=ExposureMode.TRANSPARENT,
+    )
+    runtime.register_tool_defs_sync(_tool_defs())
+    return runtime
+
+
+# ---------------------------------------------------------------------------
+# make_stripped_tools_list — §4.1
+# ---------------------------------------------------------------------------
+
+
+def test_stripped_tools_list_includes_catalog_and_meta_tools() -> None:
+    runtime = _runtime()
+    entries = make_stripped_tools_list(runtime)
+    # 1 upstream tool + 2 meta-tools (tool_hydrate, tool_execute).
+    assert len(entries) == 3
+    names = [e["name"] for e in entries]
+    assert TOOL_HYDRATE in names
+    assert TOOL_EXECUTE in names
+
+
+def test_stripped_input_schemas_are_sentinel() -> None:
+    runtime = _runtime()
+    entries = make_stripped_tools_list(runtime)
+    # The catalog entries (everything except the meta-tools) carry
+    # ``{"type": "object"}`` with no properties (§4.1 sentinel).
+    for entry in entries:
+        if entry["name"] in PROXY_META_TOOL_NAMES:
+            continue
+        assert entry["inputSchema"] == {"type": "object"}
+
+
+def test_make_proxy_meta_tools_returns_two_tools() -> None:
+    runtime = _runtime()
+    metas = make_proxy_meta_tools(runtime)
+    assert [t["name"] for t in metas] == [TOOL_HYDRATE, TOOL_EXECUTE]
+
+
+# ---------------------------------------------------------------------------
+# dispatch_proxy_request
+# ---------------------------------------------------------------------------
+
+
+async def test_dispatch_tools_list_returns_stripped_catalog() -> None:
+    runtime = _runtime()
+    result = await dispatch_proxy_request(runtime, "tools/list", {})
+    assert "tools" in result
+    assert len(result["tools"]) == 3
+
+
+async def test_dispatch_tool_hydrate_returns_schema() -> None:
+    runtime = _runtime()
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:"))
+    result = await dispatch_proxy_request(
+        runtime,
+        "tools/call",
+        {"name": TOOL_HYDRATE, "arguments": {"tool_id": tool_id}},
+    )
+    assert result["isError"] is False
+    body = json.loads(result["content"][0]["text"])
+    assert body["tool_id"] == tool_id
+    assert "args_schema" in body
+    assert "title" in body["args_schema"].get("properties", {})
+
+
+async def test_dispatch_tool_hydrate_unknown_returns_error() -> None:
+    runtime = _runtime()
+    result = await dispatch_proxy_request(
+        runtime,
+        "tools/call",
+        {"name": TOOL_HYDRATE, "arguments": {"tool_id": "missing:tool#deadbeef"}},
+    )
+    assert result["isError"] is True
+    body = json.loads(result["content"][0]["text"])
+    assert body["error"] == "HYDRATE_FAILED"
+
+
+async def test_dispatch_tool_execute_validates_args() -> None:
+    runtime = _runtime()
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:"))
+    result = await dispatch_proxy_request(
+        runtime,
+        "tools/call",
+        {"name": TOOL_EXECUTE, "arguments": {"tool_id": tool_id, "args": {}}},
+    )
+    assert result["isError"] is True
+    body = json.loads(result["content"][0]["text"])
+    assert body["error"] == "ARGS_INVALID"
+
+
+async def test_dispatch_tool_execute_happy_path() -> None:
+    runtime = _runtime()
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:"))
+    result = await dispatch_proxy_request(
+        runtime,
+        "tools/call",
+        {"name": TOOL_EXECUTE, "arguments": {"tool_id": tool_id, "args": {"title": "x"}}},
+    )
+    assert result["isError"] is False
+
+
+async def test_dispatch_unsupported_method_returns_error() -> None:
+    runtime = _runtime()
+    result = await dispatch_proxy_request(runtime, "ping", {})
+    assert result["isError"] is True
+    body = json.loads(result["content"][0]["text"])
+    assert body["error"] == "ARGS_INVALID"
+
+
+async def test_dispatch_tools_call_requires_name() -> None:
+    runtime = _runtime()
+    result = await dispatch_proxy_request(runtime, "tools/call", {})
+    assert result["isError"] is True

--- a/tests/test_mcp_upstream.py
+++ b/tests/test_mcp_upstream.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+import pytest
+
 from contextweaver.adapters.mcp_upstream import (
     McpClientUpstream,
     MultiplexUpstream,
@@ -167,3 +169,36 @@ async def test_mcp_client_upstream_translates_exceptions() -> None:
     out = await upstream.call_tool("t", {})
     assert out["isError"] is True
     assert "network" in out["content"][0]["text"]
+
+
+async def test_mcp_client_upstream_call_tool_timeout() -> None:
+    """A hung call_tool returns an isError result after the timeout."""
+    import asyncio
+
+    class _HangSession:
+        async def list_tools(self) -> Any:  # noqa: ANN401
+            await asyncio.sleep(9999)
+
+        async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:  # noqa: ANN401
+            await asyncio.sleep(9999)
+
+    upstream = McpClientUpstream(_HangSession(), timeout=0.01)
+    out = await upstream.call_tool("slow_tool", {})
+    assert out["isError"] is True
+    assert "timeout" in out["content"][0]["text"].lower()
+
+
+async def test_mcp_client_upstream_list_tools_timeout() -> None:
+    """A hung list_tools raises TimeoutError (callers handle it)."""
+    import asyncio
+
+    class _HangSession:
+        async def list_tools(self) -> Any:  # noqa: ANN401
+            await asyncio.sleep(9999)
+
+        async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:  # noqa: ANN401
+            await asyncio.sleep(9999)
+
+    upstream = McpClientUpstream(_HangSession(), timeout=0.01)
+    with pytest.raises(asyncio.TimeoutError):
+        await upstream.list_tools()

--- a/tests/test_mcp_upstream.py
+++ b/tests/test_mcp_upstream.py
@@ -1,0 +1,169 @@
+"""Tests for the concrete UpstreamCall implementations."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from contextweaver.adapters.mcp_upstream import (
+    McpClientUpstream,
+    MultiplexUpstream,
+    StubUpstream,
+)
+
+# ---------------------------------------------------------------------------
+# StubUpstream
+# ---------------------------------------------------------------------------
+
+
+async def test_stub_upstream_list_tools_returns_defs() -> None:
+    defs = [{"name": "a", "description": "x", "inputSchema": {"type": "object"}}]
+    stub = StubUpstream(defs)
+    out = await stub.list_tools()
+    assert out == defs
+    # Defensive copy — mutating the result must not affect future calls.
+    out[0]["description"] = "mutated"
+    assert (await stub.list_tools())[0]["description"] == "x"
+
+
+async def test_stub_upstream_default_handler_returns_error() -> None:
+    stub = StubUpstream([])
+    result = await stub.call_tool("anything", {"arg": 1})
+    assert result["isError"] is True
+
+
+async def test_stub_upstream_custom_handler_runs() -> None:
+    async def handler(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {"content": [{"type": "text", "text": name}], "isError": False}
+
+    stub = StubUpstream([], handler=handler)
+    result = await stub.call_tool("my_tool", {})
+    assert result["isError"] is False
+    assert result["content"][0]["text"] == "my_tool"
+
+
+# ---------------------------------------------------------------------------
+# MultiplexUpstream
+# ---------------------------------------------------------------------------
+
+
+async def test_multiplex_lists_tools_from_all_sources() -> None:
+    a = StubUpstream([{"name": "a", "description": "from-a", "inputSchema": {}}])
+    b = StubUpstream([{"name": "b", "description": "from-b", "inputSchema": {}}])
+    mux = MultiplexUpstream([a, b])
+    listing = await mux.list_tools()
+    assert {t["name"] for t in listing} == {"a", "b"}
+
+
+async def test_multiplex_first_source_wins_on_collision() -> None:
+    a = StubUpstream([{"name": "shared", "description": "from-a", "inputSchema": {}}])
+    b = StubUpstream([{"name": "shared", "description": "from-b", "inputSchema": {}}])
+    mux = MultiplexUpstream([a, b])
+    listing = await mux.list_tools()
+    assert len(listing) == 1
+    assert listing[0]["description"] == "from-a"
+
+
+async def test_multiplex_routes_call_to_owner() -> None:
+    seen: dict[str, str] = {}
+
+    def make_handler(label: str) -> Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]]:
+        async def handler(name: str, args: dict[str, Any]) -> dict[str, Any]:
+            seen[name] = label
+            return {"content": [{"type": "text", "text": label}], "isError": False}
+
+        return handler
+
+    a = StubUpstream(
+        [{"name": "a_tool", "description": "x", "inputSchema": {}}],
+        handler=make_handler("a"),
+    )
+    b = StubUpstream(
+        [{"name": "b_tool", "description": "x", "inputSchema": {}}],
+        handler=make_handler("b"),
+    )
+    mux = MultiplexUpstream([a, b])
+    await mux.list_tools()  # populate ownership index
+    await mux.call_tool("a_tool", {})
+    await mux.call_tool("b_tool", {})
+    assert seen == {"a_tool": "a", "b_tool": "b"}
+
+
+async def test_multiplex_unknown_tool_returns_error() -> None:
+    mux = MultiplexUpstream([StubUpstream([])])
+    result = await mux.call_tool("ghost", {})
+    assert result["isError"] is True
+
+
+# ---------------------------------------------------------------------------
+# McpClientUpstream — coerces SDK objects to MCP-format dicts
+# ---------------------------------------------------------------------------
+
+
+class _FakeTool:
+    """A minimal stand-in for ``mcp.types.Tool`` to exercise the coercion path."""
+
+    def __init__(self, name: str, description: str, inputSchema: dict[str, Any]) -> None:  # noqa: N803
+        self.name = name
+        self.description = description
+        self.inputSchema = inputSchema
+
+
+class _FakeListing:
+    def __init__(self, tools: list[Any]) -> None:
+        self.tools = tools
+
+
+class _FakeResult:
+    def __init__(self, content: list[dict[str, Any]], isError: bool) -> None:  # noqa: N803
+        self.content = content
+        self.isError = isError
+
+
+class _FakeSession:
+    def __init__(self, tools: list[Any], result: Any) -> None:  # noqa: ANN401
+        self._tools = tools
+        self._result = result
+        self.last_call: tuple[str, dict[str, Any]] | None = None
+
+    async def list_tools(self) -> Any:  # noqa: ANN401
+        return _FakeListing(self._tools)
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:  # noqa: ANN401
+        self.last_call = (name, arguments)
+        return self._result
+
+
+async def test_mcp_client_upstream_list_tools_coerces() -> None:
+    session = _FakeSession(
+        [_FakeTool("a", "alpha", {"type": "object"})],
+        _FakeResult([], False),
+    )
+    upstream = McpClientUpstream(session)
+    out = await upstream.list_tools()
+    assert out == [{"name": "a", "description": "alpha", "inputSchema": {"type": "object"}}]
+
+
+async def test_mcp_client_upstream_call_tool_coerces() -> None:
+    session = _FakeSession(
+        [],
+        _FakeResult([{"type": "text", "text": "ok"}], False),
+    )
+    upstream = McpClientUpstream(session)
+    out = await upstream.call_tool("t", {"x": 1})
+    assert out == {"content": [{"type": "text", "text": "ok"}], "isError": False}
+    assert session.last_call == ("t", {"x": 1})
+
+
+async def test_mcp_client_upstream_translates_exceptions() -> None:
+    class _Boom:
+        async def list_tools(self) -> Any:  # noqa: ANN401
+            raise RuntimeError("network")
+
+        async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:  # noqa: ANN401
+            raise RuntimeError("network")
+
+    upstream = McpClientUpstream(_Boom())
+    out = await upstream.call_tool("t", {})
+    assert out["isError"] is True
+    assert "network" in out["content"][0]["text"]

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,0 +1,121 @@
+"""Tests for contextweaver.routing.path (gateway_spec.md §3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from contextweaver.exceptions import PathInvalidError, PathNotFoundError
+from contextweaver.routing.graph import ChoiceGraph
+from contextweaver.routing.path import parse_path, resolve_path
+
+# ---------------------------------------------------------------------------
+# parse_path — grammar acceptance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("/", []),
+        ("/github", ["github"]),
+        ("/github/issues", ["github", "issues"]),
+        ("/github/issues/create_issue", ["github", "issues", "create_issue"]),
+        ("/github/issues/*", ["github", "issues", "*"]),
+        ("/a/b-c/0_d", ["a", "b-c", "0_d"]),
+    ],
+)
+def test_parse_path_accepts_valid(path: str, expected: list[str]) -> None:
+    assert parse_path(path) == expected
+
+
+# ---------------------------------------------------------------------------
+# parse_path — grammar rejection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path,match",
+    [
+        ("", "empty"),
+        ("github", "start with '/'"),
+        ("/github/", "end with"),
+        ("//foo", "empty segment"),
+        ("/GitHub", "must start with"),  # uppercase root segment
+        ("/0digit", "root segment.*must start with"),
+        ("/a/*/b", "final segment"),
+        ("/a/b!c", "grammar"),
+    ],
+)
+def test_parse_path_rejects_invalid(path: str, match: str) -> None:
+    with pytest.raises(PathInvalidError, match=match):
+        parse_path(path)
+
+
+def test_parse_path_non_string() -> None:
+    with pytest.raises(PathInvalidError, match="must be a string"):
+        parse_path(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# resolve_path — traversal
+# ---------------------------------------------------------------------------
+
+
+def _three_namespace_graph() -> ChoiceGraph:
+    """Build a small ChoiceGraph with three namespace clusters."""
+    graph = ChoiceGraph(max_children=10)
+    graph.add_node("root", label="root")
+    graph.add_node("root/github", label="GitHub")
+    graph.add_node("root/slack", label="Slack")
+    graph.add_node("root/weather", label="Weather")
+    graph.add_edge("root", "root/github")
+    graph.add_edge("root", "root/slack")
+    graph.add_edge("root", "root/weather")
+    # GitHub leaf items
+    graph.add_item("github:create_issue@1.0#abcdef01")
+    graph.add_item("github:close_issue@1.0#abcdef02")
+    graph.add_edge("root/github", "github:create_issue@1.0#abcdef01")
+    graph.add_edge("root/github", "github:close_issue@1.0#abcdef02")
+    return graph
+
+
+def test_resolve_path_root_returns_namespace_children() -> None:
+    graph = _three_namespace_graph()
+    ids = resolve_path(graph, [])
+    # graph.successors returns sorted node IDs.
+    assert ids == ["root/github", "root/slack", "root/weather"]
+
+
+def test_resolve_path_walks_into_namespace() -> None:
+    graph = _three_namespace_graph()
+    ids = resolve_path(graph, ["github"])
+    assert ids == [
+        "github:close_issue@1.0#abcdef02",
+        "github:create_issue@1.0#abcdef01",
+    ]
+
+
+def test_resolve_path_lands_on_leaf() -> None:
+    graph = _three_namespace_graph()
+    ids = resolve_path(graph, ["github", "create_issue"])
+    # No children → single leaf returned.
+    assert ids == ["github:create_issue@1.0#abcdef01"]
+
+
+def test_resolve_path_wildcard_equivalent_to_omitting() -> None:
+    graph = _three_namespace_graph()
+    a = resolve_path(graph, ["github"])
+    b = resolve_path(graph, ["github", "*"])
+    assert a == b
+
+
+def test_resolve_path_missing_segment_raises() -> None:
+    graph = _three_namespace_graph()
+    with pytest.raises(PathNotFoundError, match="missing"):
+        resolve_path(graph, ["missing"])
+
+
+def test_resolve_path_missing_leaf_raises() -> None:
+    graph = _three_namespace_graph()
+    with pytest.raises(PathNotFoundError):
+        resolve_path(graph, ["github", "no_such_tool"])

--- a/tests/test_proxy_runtime.py
+++ b/tests/test_proxy_runtime.py
@@ -1,0 +1,254 @@
+"""Tests for contextweaver.adapters.proxy_runtime (#29).
+
+Exercises the shared core that both the transparent proxy (#13) and the
+two-tool gateway (#28) build on.  ``StubUpstream`` lets us drive every
+path without spinning up an MCP server.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from contextweaver.adapters.gateway_error import GatewayError
+from contextweaver.adapters.mcp_upstream import StubUpstream
+from contextweaver.adapters.proxy_runtime import ProxyRuntime
+from contextweaver.envelope import ChoiceCard, HydrationResult, ResultEnvelope
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _tool_defs() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "github.create_issue",
+            "description": "Open a new GitHub issue.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"title": {"type": "string"}, "body": {"type": "string"}},
+                "required": ["title"],
+                "additionalProperties": False,
+            },
+            "_meta": {"version": "1.4.0"},
+        },
+        {
+            "name": "github.close_issue",
+            "description": "Close an open GitHub issue.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"issue_id": {"type": "integer"}},
+                "required": ["issue_id"],
+                "additionalProperties": False,
+            },
+            "_meta": {"version": "1.4.0"},
+        },
+        {
+            "name": "slack_send_message",
+            "description": "Post a message to a Slack channel.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"channel": {"type": "string"}, "text": {"type": "string"}},
+                "required": ["channel", "text"],
+            },
+        },
+    ]
+
+
+async def _ok_handler(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "content": [{"type": "text", "text": f"called {name} with {sorted(args.keys())}"}],
+        "isError": False,
+    }
+
+
+def _make_runtime() -> ProxyRuntime:
+    runtime = ProxyRuntime(StubUpstream(_tool_defs(), handler=_ok_handler))
+    runtime.register_tool_defs_sync(_tool_defs())
+    return runtime
+
+
+# ---------------------------------------------------------------------------
+# Catalog management
+# ---------------------------------------------------------------------------
+
+
+def test_register_tool_defs_sync_populates_catalog() -> None:
+    runtime = _make_runtime()
+    ids = runtime.list_tool_ids()
+    assert len(ids) == 3
+    # Canonical tool_id shape: namespace:name@version or namespace:name#hash8
+    assert any(i.startswith("github:") for i in ids)
+    assert any(i.startswith("slack:") for i in ids)
+
+
+async def test_refresh_catalog_uses_upstream() -> None:
+    runtime = ProxyRuntime(StubUpstream(_tool_defs()))
+    n = await runtime.refresh_catalog()
+    assert n == 3
+    assert len(runtime.list_tool_ids()) == 3
+
+
+# ---------------------------------------------------------------------------
+# browse() — §3.1 mutual exclusion + query / path
+# ---------------------------------------------------------------------------
+
+
+def test_browse_requires_exactly_one_arg() -> None:
+    runtime = _make_runtime()
+    err = runtime.browse()
+    assert isinstance(err, GatewayError)
+    assert err.code == "ARGS_INVALID"
+
+
+def test_browse_rejects_both_query_and_path() -> None:
+    runtime = _make_runtime()
+    err = runtime.browse(query="issue", path="/github")
+    assert isinstance(err, GatewayError)
+    assert err.code == "ARGS_INVALID"
+
+
+def test_browse_by_query_returns_cards() -> None:
+    runtime = _make_runtime()
+    cards = runtime.browse(query="open a github issue")
+    assert isinstance(cards, list)
+    assert all(isinstance(c, ChoiceCard) for c in cards)
+    assert len(cards) > 0
+
+
+def test_browse_by_path_root_lists_namespaces() -> None:
+    runtime = _make_runtime()
+    cards = runtime.browse(path="/")
+    assert isinstance(cards, list)
+    assert len(cards) >= 1
+
+
+def test_browse_by_path_invalid_returns_path_invalid() -> None:
+    runtime = _make_runtime()
+    err = runtime.browse(path="bad-path-no-leading-slash")
+    assert isinstance(err, GatewayError)
+    assert err.code == "PATH_INVALID"
+
+
+def test_browse_by_path_unknown_returns_path_not_found() -> None:
+    runtime = _make_runtime()
+    err = runtime.browse(path="/no_such_namespace")
+    assert isinstance(err, GatewayError)
+    assert err.code == "PATH_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# hydrate() — §4.1
+# ---------------------------------------------------------------------------
+
+
+def test_hydrate_returns_full_schema() -> None:
+    runtime = _make_runtime()
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:create_issue"))
+    hydrated = runtime.hydrate(tool_id)
+    assert isinstance(hydrated, HydrationResult)
+    assert "title" in hydrated.args_schema.get("properties", {})
+
+
+def test_hydrate_unknown_returns_hydrate_failed() -> None:
+    runtime = _make_runtime()
+    err = runtime.hydrate("does:not_exist#deadbeef")
+    assert isinstance(err, GatewayError)
+    assert err.code == "HYDRATE_FAILED"
+
+
+# ---------------------------------------------------------------------------
+# execute() — §4.2 + §4.4
+# ---------------------------------------------------------------------------
+
+
+async def test_execute_validates_args_against_schema() -> None:
+    runtime = _make_runtime()
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:create_issue"))
+    # Missing required field "title" → ARGS_INVALID.
+    err = await runtime.execute(tool_id, {})
+    assert isinstance(err, GatewayError)
+    assert err.code == "ARGS_INVALID"
+
+
+async def test_execute_happy_path_returns_envelope() -> None:
+    runtime = _make_runtime()
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:create_issue"))
+    result = await runtime.execute(tool_id, {"title": "Bug report"})
+    assert isinstance(result, ResultEnvelope)
+    assert result.status == "ok"
+    assert result.provenance.get("tool_id") == tool_id
+
+
+async def test_execute_unknown_tool_returns_hydrate_failed() -> None:
+    runtime = _make_runtime()
+    err = await runtime.execute("missing:tool#00000000", {})
+    assert isinstance(err, GatewayError)
+    assert err.code == "HYDRATE_FAILED"
+
+
+async def test_execute_upstream_failure_returns_upstream_error() -> None:
+    async def boom(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("transport collapsed")
+
+    runtime = ProxyRuntime(StubUpstream(_tool_defs(), handler=boom))
+    runtime.register_tool_defs_sync(_tool_defs())
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:create_issue"))
+    err = await runtime.execute(tool_id, {"title": "x"})
+    assert isinstance(err, GatewayError)
+    assert err.code == "UPSTREAM_ERROR"
+    assert "transport collapsed" in err.message
+
+
+# ---------------------------------------------------------------------------
+# view() — #34
+# ---------------------------------------------------------------------------
+
+
+async def test_view_drilldown_returns_slice() -> None:
+    """tool_view returns a drilldown slice over a stored artifact."""
+    long_text = "line one\nline two\nline three\nline four\nline five"
+
+    async def textual(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "content": [{"type": "text", "text": long_text}],
+            "isError": False,
+        }
+
+    defs = _tool_defs()
+    runtime = ProxyRuntime(StubUpstream(defs, handler=textual))
+    runtime.register_tool_defs_sync(defs)
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:create_issue"))
+    envelope = await runtime.execute(tool_id, {"title": "x"})
+    assert isinstance(envelope, ResultEnvelope)
+    # The runtime persists either a structured artifact or a text:
+    # artifact under a deterministic handle when the response has no
+    # binaries.  Pick whichever exists.
+    handles = list(runtime.context_manager.artifact_store.list_refs())
+    assert handles, "execute must store the upstream response somewhere"
+    handle = handles[0].handle
+    sliced = runtime.view(handle, {"type": "head", "n_chars": 8})
+    assert isinstance(sliced, str)
+
+
+def test_view_unknown_handle_returns_view_failed() -> None:
+    runtime = _make_runtime()
+    err = runtime.view("no_such_handle", {"type": "head", "n_chars": 10})
+    assert isinstance(err, GatewayError)
+    assert err.code == "VIEW_FAILED"
+
+
+# ---------------------------------------------------------------------------
+# strip_tools_list() — §4.1
+# ---------------------------------------------------------------------------
+
+
+def test_strip_tools_list_emits_sentinel_input_schema() -> None:
+    runtime = _make_runtime()
+    stripped = runtime.strip_tools_list()
+    assert len(stripped) == 3
+    for entry in stripped:
+        assert entry["inputSchema"] == {"type": "object"}
+        # No banned fields per §2.2.
+        for banned in ("args_schema", "outputSchema", "output_schema", "annotations", "_meta"):
+            assert banned not in entry

--- a/tests/test_tool_id.py
+++ b/tests/test_tool_id.py
@@ -1,0 +1,172 @@
+"""Tests for contextweaver.routing.tool_id (gateway_spec.md §1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from contextweaver.exceptions import CatalogError
+from contextweaver.routing.tool_id import (
+    ToolIdParts,
+    canonical_tool_id,
+    compute_hash8,
+    format_tool_id,
+    parse_tool_id,
+)
+
+# ---------------------------------------------------------------------------
+# format_tool_id — grammar acceptance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "parts,expected",
+    [
+        (ToolIdParts("github", "create_issue", "1.4.0", None), "github:create_issue@1.4.0"),
+        (
+            ToolIdParts("slack", "slack_send_message", None, "3a91c7d2"),
+            "slack:slack_send_message#3a91c7d2",
+        ),
+        (ToolIdParts("mcp", "read_file", None, "7b2f0e14"), "mcp:read_file#7b2f0e14"),
+        (ToolIdParts("weather", "get", "2024-05", None), "weather:get@2024-05"),
+        (ToolIdParts("a", "b", "1", "0123abcd"), "a:b@1#0123abcd"),
+    ],
+)
+def test_format_tool_id_well_formed(parts: ToolIdParts, expected: str) -> None:
+    assert format_tool_id(parts) == expected
+
+
+def test_format_tool_id_requires_hash_when_version_absent() -> None:
+    with pytest.raises(CatalogError, match="hash8"):
+        format_tool_id(ToolIdParts(namespace="x", name="y", version=None, hash8=None))
+
+
+def test_format_tool_id_rejects_uppercase_namespace() -> None:
+    with pytest.raises(CatalogError, match="namespace"):
+        format_tool_id(ToolIdParts(namespace="GitHub", name="x", version="1", hash8=None))
+
+
+def test_format_tool_id_rejects_invalid_hash() -> None:
+    with pytest.raises(CatalogError, match="hash8"):
+        format_tool_id(ToolIdParts(namespace="g", name="x", version=None, hash8="GG"))
+
+
+def test_format_tool_id_rejects_invalid_version() -> None:
+    with pytest.raises(CatalogError, match="version"):
+        format_tool_id(ToolIdParts(namespace="g", name="x", version="bad/version", hash8=None))
+
+
+def test_parse_tool_id_length_limit() -> None:
+    """parse_tool_id enforces the 240-char total bound on its input."""
+    with pytest.raises(CatalogError, match="240"):
+        parse_tool_id("a:" + "b" * 300)
+
+
+# ---------------------------------------------------------------------------
+# parse_tool_id — round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "s,namespace,name,version,hash8",
+    [
+        ("github:create_issue@1.4.0", "github", "create_issue", "1.4.0", None),
+        ("slack:slack_send_message#3a91c7d2", "slack", "slack_send_message", None, "3a91c7d2"),
+        ("mcp:read_file#7b2f0e14", "mcp", "read_file", None, "7b2f0e14"),
+        ("weather:get@2024-05", "weather", "get", "2024-05", None),
+        ("a:b@1#0123abcd", "a", "b", "1", "0123abcd"),
+    ],
+)
+def test_parse_tool_id_round_trip(
+    s: str, namespace: str, name: str, version: str | None, hash8: str | None
+) -> None:
+    parts = parse_tool_id(s)
+    assert parts.namespace == namespace
+    assert parts.name == name
+    assert parts.version == version
+    assert parts.hash8 == hash8
+    assert format_tool_id(parts) == s
+
+
+def test_parse_tool_id_missing_namespace() -> None:
+    with pytest.raises(CatalogError, match="namespace separator"):
+        parse_tool_id("nosep")
+
+
+def test_parse_tool_id_oversized() -> None:
+    with pytest.raises(CatalogError, match="240"):
+        parse_tool_id("a:" + "b" * 300)
+
+
+def test_parse_tool_id_not_a_string() -> None:
+    with pytest.raises(CatalogError, match="must be a string"):
+        parse_tool_id(42)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# compute_hash8 — determinism and §1.3 algorithm
+# ---------------------------------------------------------------------------
+
+
+def test_compute_hash8_deterministic() -> None:
+    schema = {"properties": {"name": {"type": "string"}}, "required": ["name"]}
+    assert compute_hash8("foo", schema) == compute_hash8("foo", schema)
+
+
+def test_compute_hash8_independent_of_property_types() -> None:
+    """Per §1.3 the canonical shape includes property NAMES only, not types."""
+    a = compute_hash8("foo", {"properties": {"x": {"type": "string"}}})
+    b = compute_hash8("foo", {"properties": {"x": {"type": "integer"}}})
+    assert a == b
+
+
+def test_compute_hash8_changes_with_property_set() -> None:
+    a = compute_hash8("foo", {"properties": {"x": {}}})
+    b = compute_hash8("foo", {"properties": {"x": {}, "y": {}}})
+    assert a != b
+
+
+def test_compute_hash8_disambiguates_upstream_names() -> None:
+    """Per §1.3: same schema-shape across different upstream names → different hash."""
+    shape = {"properties": {"id": {}}, "required": ["id"]}
+    assert compute_hash8("github.create_issue", shape) != compute_hash8(
+        "gitlab.create_issue", shape
+    )
+
+
+def test_compute_hash8_empty_schema() -> None:
+    """Empty / None schema must still produce a valid 8-char hash."""
+    h = compute_hash8("read_file", None)
+    assert len(h) == 8
+    assert all(c in "0123456789abcdef" for c in h)
+    assert h == compute_hash8("read_file", {})
+
+
+# ---------------------------------------------------------------------------
+# canonical_tool_id — end-to-end helpers
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_tool_id_with_version_omits_hash() -> None:
+    s = canonical_tool_id(
+        namespace="github",
+        name="create_issue",
+        upstream_name="github.create_issue",
+        input_schema={"properties": {"title": {}}},
+        version="1.4.0",
+    )
+    parts = parse_tool_id(s)
+    assert parts.version == "1.4.0"
+    assert parts.hash8 is None
+
+
+def test_canonical_tool_id_without_version_requires_hash() -> None:
+    s = canonical_tool_id(
+        namespace="slack",
+        name="slack_send_message",
+        upstream_name="slack_send_message",
+        input_schema={"properties": {"text": {}}},
+        version=None,
+    )
+    parts = parse_tool_id(s)
+    assert parts.version is None
+    assert parts.hash8 is not None and len(parts.hash8) == 8


### PR DESCRIPTION
## Summary

Fixes #13, #28, #29, #34. Also fixes #190 (firewall idempotency regression).

Lands the full MCP proxy and two-tool gateway surface specified by `docs/gateway_spec.md`, enabling any MCP-capable agent to use contextweaver's routing engine and context firewall through standard tool calls — without bespoke per-consumer wiring.

**The problem:** contextweaver could build context and route tool catalogs internally, but had no protocol-level entry point. An agent connecting to an upstream MCP server had no way to benefit from contextweaver's token-budget enforcement, catalog navigation, or context firewall unless the consuming application wired it in manually. Issues #13, #28, #29, and #34 collectively specified the MCP adapter surface to close this gap.

**What this PR achieves:**

- **In scope.** A `ProxyRuntime` shared core that owns the upstream catalog, per-session `ContextManager`, `Catalog`+`Router` rebuild, and the browse/execute/view/hydrate/strip_tools_list primitives. Two dispatcher modules (`mcp_gateway.py`, `mcp_proxy.py`) and two stdio-binding modules (`mcp_gateway_server.py`, `mcp_proxy_server.py`). Three concrete `UpstreamCall` adapters (`StubUpstream`, `McpClientUpstream`, `MultiplexUpstream`). A `GatewayError` dataclass with the §3.4 wire shape. New routing primitives required by the spec: canonical `tool_id` grammar (`routing/tool_id.py`, §1), path-navigation grammar (`routing/path.py`, §3), and token-native card budget enforcement in `routing/cards.py` (§2.3). Firewall idempotency via `ArtifactRef.content_hash` (#190).
- **Out of scope.** No change to `Router.route()` shape or the Context Engine pipeline. No persistent catalog storage (in-memory per-session only). No HTTP transport (stdio only). No gateway auth or rate-limiting.

## Changes

### Shared core (#29)

- [`src/contextweaver/adapters/proxy_runtime.py`](src/contextweaver/adapters/proxy_runtime.py) — `ProxyRuntime` + `ExposureMode` enum + `UpstreamCall` Protocol. Owns the per-session `ContextManager`, `Catalog`/`Router`, upstream catalog fetch, and the gateway/proxy primitives: `browse`, `execute`, `view`, `hydrate`, `strip_tools_list`. Args are validated against the hydrated schema via `jsonschema` (§4.4) before dispatch. Large text results are sha256 content-addressed and stored on the session's `ArtifactStore` so subsequent `tool_view` calls can drilldown without re-fetching.
- [`src/contextweaver/adapters/gateway_error.py`](src/contextweaver/adapters/gateway_error.py) — `GatewayError` dataclass with the §3.4 wire shape (`code`, `message`, `path`, `details`).
- [`src/contextweaver/routing/tool_id.py`](src/contextweaver/routing/tool_id.py) — canonical `tool_id` grammar: `parse_tool_id` / `format_tool_id` / `compute_hash8` / `canonical_tool_id`. `mcp_tool_to_selectable` cut over to emit canonical `namespace:name#hash8` ids (§1.7 cutover); the legacy `mcp:{name}` form is retired.
- [`src/contextweaver/routing/path.py`](src/contextweaver/routing/path.py) — `tool_browse` path-navigation grammar: `parse_path` / `resolve_path` per §3. New `PathInvalidError` / `PathNotFoundError` exceptions.
- [`src/contextweaver/routing/cards.py`](src/contextweaver/routing/cards.py) — token-native enforcement of §2.3 ChoiceCard size bounds against `cl100k_base` (`make_choice_cards`, `bound_browse_response`, `truncate_description_to_tokens`). Drops the old `max_total_chars` / `max_desc_chars` char-count caps. `bound_browse_response` uses O(n) precomputed token counts rather than the earlier O(n²) loop.

### Two-tool gateway (#28 + #34)

- [`src/contextweaver/adapters/mcp_gateway.py`](src/contextweaver/adapters/mcp_gateway.py) — pure-logic dispatcher for `tool_browse` / `tool_execute` / `tool_view`. No MCP-SDK dependency at construction time; the server binding is separate. `envelope_call_result` is public — both the gateway and proxy dispatchers call it.
- [`src/contextweaver/adapters/mcp_gateway_server.py`](src/contextweaver/adapters/mcp_gateway_server.py) — binds the gateway dispatcher onto `mcp.server.Server` over stdio. Unexpected `ExposureMode` emits a warning, not a forced override.

### Transparent proxy (#13)

- [`src/contextweaver/adapters/mcp_proxy.py`](src/contextweaver/adapters/mcp_proxy.py) — stripped `tools/list` (sentinel `inputSchema: {"type": "object"}`) plus `tool_hydrate` + `tool_execute` invocation channel per §4.1.
- [`src/contextweaver/adapters/mcp_proxy_server.py`](src/contextweaver/adapters/mcp_proxy_server.py) — binds the proxy dispatcher onto `mcp.server.Server` over stdio.

### Upstream adapters

- [`src/contextweaver/adapters/mcp_upstream.py`](src/contextweaver/adapters/mcp_upstream.py) — `StubUpstream` (tests/demos), `McpClientUpstream` (single MCP `ClientSession` with configurable `asyncio.wait_for` timeout, default 30 s, on both `list_tools` and `call_tool` — prevents hung upstream servers from blocking indefinitely), `MultiplexUpstream` (multi-server fan-out, first-registration-wins collision policy).

### Firewall idempotency (#190)

- [`src/contextweaver/types.py`](src/contextweaver/types.py) — `ArtifactRef.content_hash` field (sha256 hex, default `""`, omitted from `to_dict()` when empty for backward compatibility).
- [`src/contextweaver/context/firewall.py`](src/contextweaver/context/firewall.py) — `apply_firewall` short-circuits when an item already carries a populated `content_hash`, preventing the regression where a second `build()` call after `ingest_tool_result_sync()` overwrote the original raw bytes with the summary.

### Cross-cutting

- [`pyproject.toml`](pyproject.toml) — `mcp>=1.0` and `jsonschema>=4.0` promoted to core runtime dependencies. Mode B justification: both have small wheels, are broadly used in the Python ecosystem, and cannot reasonably be approximated. Documented in `AGENTS.md` and `CONTRIBUTING.md`.
- [`examples/mcp_gateway_demo.py`](examples/mcp_gateway_demo.py), [`examples/mcp_proxy_demo.py`](examples/mcp_proxy_demo.py) — wired into `make example`; exercise a full browse → execute → view round-trip.
- `AGENTS.md`, `CHANGELOG.md` — module map, Key Types, and Commands updated; CHANGELOG entry under `[Unreleased]`.

## Testing & verification

All checks run locally on Windows 11 / Python 3.14:

| Check | Result |
|---|---|
| `ruff format src/ tests/ examples/` | clean |
| `ruff check src/ tests/ examples/` | `All checks passed!` |
| `mypy src/ --no-incremental` | `Success: no issues found in 64 source files` |
| `pytest --cov=contextweaver -q` | **879 passed, 8 skipped** (was 747 before this PR; +132 new tests across 7 new modules: `test_tool_id`, `test_path`, `test_proxy_runtime`, `test_mcp_gateway`, `test_mcp_upstream`, `test_card_budget`, `test_firewall` idempotency) |
| `python examples/mcp_gateway_demo.py` | OK — full browse → execute → view round-trip |
| `python -m contextweaver demo` | OK |

## Risks & rollback

- **`mcp` + `jsonschema` promoted to core.** Both were previously optional extras. Downstream library users that previously pinned contextweaver without these deps will see them added on the next install.
- **Legacy `tool_id` form retired.** `mcp_tool_to_selectable` now emits `namespace:name#hash8` ids. Any consumer that stored or matched the old `mcp:{name}` form will need to migrate (first public release of this form — no stable API existed before).
- **`routing/cards.py` breaking change.** `max_total_chars` / `max_desc_chars` keyword arguments removed from `make_choice_cards`. Callers using those kwargs will get a `TypeError` — easy one-line fix, but no deprecation warning was emitted.
- **Firewall idempotency (#190).** Legacy `ArtifactRef` instances without `content_hash` (e.g., loaded from serialized state from before this PR) fall through to the original code path — no regression, but pre-existing artifact state is not protected by the new guard until re-processed.
- **Rollback:** revert the branch. No schema, store, or pipeline migration needed; the `content_hash` field defaults to `""` so older deserialized state reads cleanly.

## Linked context

- Issues closed: #13 (transparent proxy), #28 (two-tool gateway), #29 (shared proxy/gateway core), #34 (tool_view drilldown), #190 (firewall idempotency)
- Spec: [`docs/gateway_spec.md`](docs/gateway_spec.md) — the full §1–§4 specification this PR implements.
- `ProxyRuntime` is kept under `adapters/` (not `context/` or `routing/`) because it is transport-facing and async. See `AGENTS.md` Path Conventions.

## Checklist

- [x] Tests added or updated for every new/changed public function
- [x] `make ci` passes locally (fmt + lint + type + test + example + demo)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docstrings added for all new public APIs (Google-style)
- [ ] Every modified module stays ≤ 300 lines — `proxy_runtime.py` (462 lines) is above the soft cap; intentionally kept whole as the runtime core is a single coherent subsystem. A decomposition issue can be linked if desired.
- [x] Related issues linked in the summary above (Fixes #13, #28, #29, #34, #190)
- [x] Agent-facing docs updated (`AGENTS.md` module map + Key Types; `CHANGELOG.md`)

## Notes for reviewers

- The cleanest review entry point is [`adapters/proxy_runtime.py`](src/contextweaver/adapters/proxy_runtime.py) — it owns all the logic; the gateway and proxy dispatcher modules are thin call-throughs. Read `docs/gateway_spec.md` §4 for the spec-level intent before reading the implementation.
- The `UpstreamCall` Protocol is the only interface `ProxyRuntime` depends on for transport. `McpClientUpstream` / `MultiplexUpstream` are the concrete adapters; `StubUpstream` is the test double.
- `envelope_call_result` is intentionally public — both `mcp_gateway.py` and `mcp_proxy.py` call it, and it is a legitimate public utility for callers who want to reuse the MCP-result-to-envelope conversion outside the dispatcher.
- The `content_hash` short-circuit in `apply_firewall` (#190) is the subtlest correctness constraint: it prevents a second `build()` call from clobbering raw artifact bytes with the summarized text. `test_apply_firewall_is_idempotent_on_already_processed_items` in `tests/test_firewall.py` is the lock.
- `McpClientUpstream` wraps both `list_tools` and `call_tool` in `asyncio.wait_for(timeout=30.0)`. The `timeout` is configurable at construction time; pass `timeout=None` to disable.