### PR TITLE
feat(adapters,docs): adoption layer — provider message adapters + 5-line quickstart + cache-stable card contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ It prepares context and routes tools but never calls models or executes tools.
 | `routing/trace.py` | `RouteTrace` + `TraceStep` structured routing audit (issue #51) |
 | `routing/tool_id.py` | Canonical `tool_id` grammar (`parse_tool_id` / `format_tool_id` / `compute_hash8`) per `docs/gateway_spec.md` §1 |
 | `routing/path.py` | `tool_browse` path-navigation grammar (`parse_path` / `resolve_path`) per `docs/gateway_spec.md` §3 |
-| `adapters/` | MCP, FastMCP, A2A, and weaver-spec protocol adapters + MCP proxy / gateway runtime (issues #13, #28, #29, #34) |
+| `adapters/` | MCP, FastMCP, A2A, weaver-spec protocol adapters + MCP proxy / gateway runtime + provider-message ingestion helpers for OpenAI / Anthropic / Gemini chat histories (issues #13, #28, #29, #34, #194, #219, #222) |
 | `adapters/proxy_runtime.py` | `ProxyRuntime` shared core + `ExposureMode` enum + `UpstreamCall` Protocol (issue #29) |
 | `adapters/mcp_gateway.py` | Two-tool gateway dispatch (`tool_browse` + `tool_execute` + `tool_view`, issues #28 / #34) |
 | `adapters/mcp_proxy.py` | Transparent proxy dispatch (stripped `tools/list` + `tool_hydrate` + `tool_execute`, issue #13) |
@@ -48,6 +48,9 @@ It prepares context and routes tools but never calls models or executes tools.
 | `adapters/mcp_gateway_server.py` | Bind `mcp_gateway` onto `mcp.server.Server` over stdio (issue #28) |
 | `adapters/mcp_proxy_server.py` | Bind `mcp_proxy` onto `mcp.server.Server` over stdio (issue #13) |
 | `adapters/gateway_error.py` | Structured `GatewayError` (codes + §3.4 wire shape) |
+| `adapters/openai_messages.py` | OpenAI Chat Completions `messages` ↔ `ContextItem` round-trip (`from_/to_openai_messages`, issue #219) |
+| `adapters/anthropic_messages.py` | Anthropic Messages API `messages` ↔ `ContextItem` round-trip (`from_/to_anthropic_messages`, issue #222) |
+| `adapters/gemini_contents.py` | Google Gemini `contents[]` ↔ `ContextItem` round-trip (`from_/to_gemini_contents`, issue #222) |
 | `__main__.py` | CLI: 7 subcommands (`demo`, `build`, `route`, `print-tree`, `init`, `ingest`, `replay`) |
 
 ## Pipelines (summary)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **One-shot provider-message ingestion adapters** (#194, #219, #222). Three
+  new sibling modules under `src/contextweaver/adapters/` —
+  `openai_messages.py`, `anthropic_messages.py`, `gemini_contents.py` — each
+  shipping a `from_*` decoder (plain provider dicts → `ContextItem`s with
+  `parent_id` chains, optional `into=ContextManager` for direct ingestion)
+  and a `to_*` inverse for round-tripping back into the provider SDK. Users
+  with existing OpenAI / Anthropic / Gemini agents can now drop contextweaver
+  in with 5 lines (excluding imports). No provider SDKs are imported at
+  module load time; adapters operate on plain `dict`s per the `adapters/`
+  path convention. Round-trip equality is enforced by parametrised fixture
+  tests for every provider (`tests/test_adapters_*_messages.py`,
+  `tests/test_adapters_gemini_contents.py`).
+- **Quickstart "Adopting from an existing chat history" section** (#220).
+  `docs/quickstart.md` now leads with a 5-line drop-in snippet for adopters
+  arriving with an existing OpenAI / Anthropic / Gemini session. `README.md`
+  Quickstart and `docs/which_pattern.md` cross-link to it.
+- **`make_choice_cards` byte-stable ordering contract** (#218). The existing
+  `(-score, +id)` ordering is now an explicit guarantee in the docstring and
+  is locked by a regression test
+  (`test_make_choice_cards_byte_identical_stable_order`) that asserts
+  byte-identical JSON across two consecutive calls on the same input. New
+  "Prompt-caching compatibility" section in `docs/integration_mcp.md`
+  documents how to leverage this for Anthropic `cache_control` prefixes
+  (and the OpenAI / Google equivalents).
+- **"Context engineering" positioning in docs landing** (#217). The
+  `docs/index.md` tagline and a new "Why context engineering matters"
+  callout in `docs/architecture.md` establish the discipline framing
+  alongside the existing README headline (already updated in 0.4.0) and the
+  `context-engineering` keyword in `pyproject.toml`.
+
 ## [0.4.0] - 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ pip install -e ".[dev]"
 
 ```python
 from contextweaver.adapters.openai_messages import from_openai_messages
+from contextweaver.context.manager import ContextManager
+from contextweaver.types import Phase
+
 mgr = ContextManager()
 from_openai_messages(messages, into=mgr)   # also: from_anthropic_messages / from_gemini_contents
 pack = mgr.build_sync(phase=Phase.answer, query="...")

--- a/README.md
+++ b/README.md
@@ -141,6 +141,19 @@ cd contextweaver
 pip install -e ".[dev]"
 ```
 
+### Adopting in 5 lines from an existing OpenAI / Anthropic / Gemini agent
+
+```python
+from contextweaver.adapters.openai_messages import from_openai_messages
+mgr = ContextManager()
+from_openai_messages(messages, into=mgr)   # also: from_anthropic_messages / from_gemini_contents
+pack = mgr.build_sync(phase=Phase.answer, query="...")
+```
+
+See [Adopting from an existing chat history](docs/quickstart.md#adopting-from-an-existing-chat-history-5-line-drop-in)
+for the full snippet (including the `to_*` inverse adapters for round-tripping
+back into the provider SDK).
+
 ## 10-Minute Quickstart
 
 For a guided setup with prerequisites, three runnable examples, expected output,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,6 +7,24 @@
 contextweaver is structured around two cooperating engines that together solve
 the "context window problem" for tool-using AI agents.
 
+## Why context engineering matters
+
+The discipline of **context engineering** — deciding *what* goes into a model's
+context window, *when*, and *at what cost* — has emerged as the lever that
+moves quality and latency once tool-use agents reach production scale. Even
+with 200K-token windows, dumping every tool schema and conversation turn into
+the prompt is expensive, slows latency, and degrades output quality as the
+model's effective attention thins. The lever is selective compilation
+(per-phase budgets, tool shortlisting, oversized-output firewalling), not raw
+window size.
+
+contextweaver implements that lever as two cooperating engines — the Context
+Engine (eight-stage pipeline) and the Routing Engine (bounded DAG + beam
+search) — and treats determinism, dependency closure, and sensitivity filters
+as load-bearing invariants rather than nice-to-haves. For background on the
+term itself, see Atlan's
+[*What Is Context Engineering*](https://atlan.com/know/what-is-context-engineering/).
+
 ## High-level overview
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,12 @@
 # contextweaver
 
-> Phase-specific, budget-aware context compilation for tool-using AI agents.
+> Phase-specific, budget-aware **context engineering** for tool-using AI agents.
 
 **Zero runtime dependencies · deterministic output · Python ≥ 3.10**
+
+> **Context engineering** is the discipline of deciding what goes into a model's
+> context window, when, and at what cost — see the
+> [canonical framing](https://atlan.com/know/what-is-context-engineering/).
 
 ---
 

--- a/docs/integration_mcp.md
+++ b/docs/integration_mcp.md
@@ -190,8 +190,14 @@ on identical inputs. The invariant survives across the full
 
 ### Worked example: Anthropic `cache_control`
 
+> **Illustrative — requires the Anthropic SDK.** This snippet imports
+> `anthropic` to show how the byte-stable cards array slots into the
+> provider's cache-control API. contextweaver itself does not depend on
+> the Anthropic SDK; install it separately with `pip install anthropic`
+> to run the example as-is, or read it as a pattern reference.
+
 ```python
-import anthropic
+import anthropic  # pip install anthropic
 from contextweaver.routing.cards import make_choice_cards
 from contextweaver.routing.catalog import Catalog
 

--- a/docs/integration_mcp.md
+++ b/docs/integration_mcp.md
@@ -172,6 +172,71 @@ print(pack.prompt)
 
 See `examples/mcp_adapter_demo.py` for the full runnable demo.
 
+## Prompt-caching compatibility
+
+Anthropic (90%), OpenAI (50%), and Google (75%) all discount the prompt-token
+cost of tool definitions when the same prefix is reused across requests.
+contextweaver's
+[`make_choice_cards`](../src/contextweaver/routing/cards.py) function is
+**deterministic and byte-stable** for identical inputs (sorted descending by
+score, ascending by `id` for ties — see issue #218 for the regression test
+that locks this guarantee), so the cards array your downstream prompt
+assembler renders is suitable for placement *before* a cache breakpoint.
+
+The repo guarantees this via `tests/test_cards.py::test_make_choice_cards_byte_identical_stable_order`,
+which asserts `bytes(card1) == bytes(card2)` across two consecutive calls
+on identical inputs. The invariant survives across the full
+`SelectableItem → ChoiceCard → cache prefix` chain.
+
+### Worked example: Anthropic `cache_control`
+
+```python
+import anthropic
+from contextweaver.routing.cards import make_choice_cards
+from contextweaver.routing.catalog import Catalog
+
+catalog = Catalog()  # populated elsewhere with stable IDs
+cards = make_choice_cards(
+    catalog.all(),
+    scores={item.id: 0.5 for item in catalog.all()},   # deterministic scoring
+    max_cards=20,
+)
+
+# Render cards into Anthropic's `tools` array (cacheable prefix).
+tools = [
+    {
+        "name": c.name,
+        "description": c.description,
+        "input_schema": {"type": "object"},  # hydrate per-call when selected
+    }
+    for c in cards
+]
+
+# Place the cache breakpoint on the LAST tool definition. As long as the
+# `cards` array is stable, every request reuses the cache prefix and only
+# the trailing user turn varies.
+if tools:
+    tools[-1]["cache_control"] = {"type": "ephemeral"}
+
+client = anthropic.Anthropic()
+client.messages.create(
+    model="claude-3-5-sonnet-latest",
+    max_tokens=1024,
+    tools=tools,
+    messages=[{"role": "user", "content": "..."}],
+)
+```
+
+> **Practical guidance for multi-turn navigation.** When the cards array
+> *naturally* changes between turns (e.g., user navigated into a sub-tree),
+> the cache prefix invalidates — that's expected. To keep the prefix stable
+> across navigation, sort hydrated cards by ID once and append newly-discovered
+> cards after the breakpoint. The
+> [Webfuse MCP cheat sheet](https://www.webfuse.com/mcp-cheat-sheet)
+> documents the canonical "append after cache breakpoint" pattern. A
+> first-class `cache_stable` runtime flag on `ProxyRuntime` is tracked as a
+> follow-up.
+
 ## Security Considerations
 
 ### MCP annotations are untrusted hints

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,6 +12,55 @@ Time budget:
 - Try tool routing: 2 minutes
 - What to try next: 1 minute
 
+## Adopting from an existing chat history (5-line drop-in)
+
+> **Already have an OpenAI, Anthropic, or Gemini agent?** You don't need to
+> walk the full quickstart — drop contextweaver in front of your existing
+> message history with one call. The full walkthrough below is for new agents.
+
+If you have an OpenAI Chat Completions session saved as JSON, you can build
+a context pack in five lines (plus imports):
+
+```python
+import json
+from contextweaver.adapters.openai_messages import from_openai_messages
+from contextweaver.context.manager import ContextManager
+from contextweaver.types import Phase
+
+mgr = ContextManager()
+from_openai_messages(json.load(open("session.json")), into=mgr)
+pack = mgr.build_sync(phase=Phase.answer, query="What did we decide?")
+print(pack.prompt)
+```
+
+The adapter handles every OpenAI Chat Completions role — `system`, `user`,
+`assistant` (with optional `tool_calls`), `tool` — and threads
+`tool_call_id` ↔ `ContextItem.id` so `to_openai_messages(...)` is the exact
+inverse for round-tripping back into the OpenAI SDK.
+
+Anthropic and Google Gemini have sibling adapters with the same shape:
+
+```python
+from contextweaver.adapters.anthropic_messages import from_anthropic_messages
+from contextweaver.adapters.gemini_contents import from_gemini_contents
+
+# Anthropic Messages API: content blocks (text / tool_use / tool_result)
+from_anthropic_messages(anthropic_messages, into=mgr)
+
+# Google Gemini: contents[].parts[] (text / functionCall / functionResponse)
+from_gemini_contents(gemini_contents, into=mgr)
+```
+
+All three adapters are pure stateless converters — they accept plain `dict`s
+and never import a provider SDK at module load time. Session payloads may
+contain sensitive prompt content; the adapters do not log message bodies
+above `DEBUG` level.
+
+> **Want to keep working with the provider SDK after building a pack?** Each
+> adapter ships an inverse: `to_openai_messages`, `to_anthropic_messages`,
+> `to_gemini_contents`. Round-trip equality holds for the representative
+> fixtures in `tests/test_adapters_*.py`.
+
 ## 1. Prerequisites (30 seconds)
 
 `contextweaver` requires Python 3.10 or newer.

--- a/docs/which_pattern.md
+++ b/docs/which_pattern.md
@@ -125,6 +125,20 @@ composed FastMCP servers.
 
 ---
 
+## "I already have an OpenAI / Anthropic / Gemini agent and want to drop contextweaver in."
+
+**Use the provider-message adapters.** They take your existing chat history
+(plain dicts, no SDK import required) and produce a populated
+`ContextManager` in one call — five lines including imports.
+
+Concrete next step:
+[Adopting from an existing chat history](quickstart.md#adopting-from-an-existing-chat-history-5-line-drop-in)
+shows the OpenAI, Anthropic, and Gemini variants side-by-side. The adapters
+ship inverse functions so you can hand the rebuilt array back to the
+provider SDK without changing the rest of your loop.
+
+---
+
 ## "I need to wrap my existing Python callables — no protocol."
 
 **Use the bring-your-own-tools recipe.** It's the canonical adapter shape:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -169,6 +169,19 @@ cd contextweaver
 pip install -e ".[dev]"
 ```
 
+### Adopting in 5 lines from an existing OpenAI / Anthropic / Gemini agent
+
+```python
+from contextweaver.adapters.openai_messages import from_openai_messages
+mgr = ContextManager()
+from_openai_messages(messages, into=mgr)   # also: from_anthropic_messages / from_gemini_contents
+pack = mgr.build_sync(phase=Phase.answer, query="...")
+```
+
+See [Adopting from an existing chat history](docs/quickstart.md#adopting-from-an-existing-chat-history-5-line-drop-in)
+for the full snippet (including the `to_*` inverse adapters for round-tripping
+back into the provider SDK).
+
 ## 10-Minute Quickstart
 
 For a guided setup with prerequisites, three runnable examples, expected output,
@@ -607,6 +620,24 @@ Apache-2.0
 contextweaver is structured around two cooperating engines that together solve
 the "context window problem" for tool-using AI agents.
 
+## Why context engineering matters
+
+The discipline of **context engineering** — deciding *what* goes into a model's
+context window, *when*, and *at what cost* — has emerged as the lever that
+moves quality and latency once tool-use agents reach production scale. Even
+with 200K-token windows, dumping every tool schema and conversation turn into
+the prompt is expensive, slows latency, and degrades output quality as the
+model's effective attention thins. The lever is selective compilation
+(per-phase budgets, tool shortlisting, oversized-output firewalling), not raw
+window size.
+
+contextweaver implements that lever as two cooperating engines — the Context
+Engine (eight-stage pipeline) and the Routing Engine (bounded DAG + beam
+search) — and treats determinism, dependency closure, and sensitivity filters
+as load-bearing invariants rather than nice-to-haves. For background on the
+term itself, see Atlan's
+[*What Is Context Engineering*](https://atlan.com/know/what-is-context-engineering/).
+
 ## High-level overview
 
 ```
@@ -879,6 +910,55 @@ Time budget:
 - Try the context firewall: 4 minutes
 - Try tool routing: 2 minutes
 - What to try next: 1 minute
+
+## Adopting from an existing chat history (5-line drop-in)
+
+> **Already have an OpenAI, Anthropic, or Gemini agent?** You don't need to
+> walk the full quickstart — drop contextweaver in front of your existing
+> message history with one call. The full walkthrough below is for new agents.
+
+If you have an OpenAI Chat Completions session saved as JSON, you can build
+a context pack in five lines (plus imports):
+
+```python
+import json
+from contextweaver.adapters.openai_messages import from_openai_messages
+from contextweaver.context.manager import ContextManager
+from contextweaver.types import Phase
+
+mgr = ContextManager()
+from_openai_messages(json.load(open("session.json")), into=mgr)
+pack = mgr.build_sync(phase=Phase.answer, query="What did we decide?")
+print(pack.prompt)
+```
+
+The adapter handles every OpenAI Chat Completions role — `system`, `user`,
+`assistant` (with optional `tool_calls`), `tool` — and threads
+`tool_call_id` ↔ `ContextItem.id` so `to_openai_messages(...)` is the exact
+inverse for round-tripping back into the OpenAI SDK.
+
+Anthropic and Google Gemini have sibling adapters with the same shape:
+
+```python
+from contextweaver.adapters.anthropic_messages import from_anthropic_messages
+from contextweaver.adapters.gemini_contents import from_gemini_contents
+
+# Anthropic Messages API: content blocks (text / tool_use / tool_result)
+from_anthropic_messages(anthropic_messages, into=mgr)
+
+# Google Gemini: contents[].parts[] (text / functionCall / functionResponse)
+from_gemini_contents(gemini_contents, into=mgr)
+```
+
+All three adapters are pure stateless converters — they accept plain `dict`s
+and never import a provider SDK at module load time. Session payloads may
+contain sensitive prompt content; the adapters do not log message bodies
+above `DEBUG` level.
+
+> **Want to keep working with the provider SDK after building a pack?** Each
+> adapter ships an inverse: `to_openai_messages`, `to_anthropic_messages`,
+> `to_gemini_contents`. Round-trip equality holds for the representative
+> fixtures in `tests/test_adapters_*.py`.
 
 ## 1. Prerequisites (30 seconds)
 
@@ -1328,6 +1408,71 @@ print(pack.prompt)
 ```
 
 See `examples/mcp_adapter_demo.py` for the full runnable demo.
+
+## Prompt-caching compatibility
+
+Anthropic (90%), OpenAI (50%), and Google (75%) all discount the prompt-token
+cost of tool definitions when the same prefix is reused across requests.
+contextweaver's
+[`make_choice_cards`](../src/contextweaver/routing/cards.py) function is
+**deterministic and byte-stable** for identical inputs (sorted descending by
+score, ascending by `id` for ties — see issue #218 for the regression test
+that locks this guarantee), so the cards array your downstream prompt
+assembler renders is suitable for placement *before* a cache breakpoint.
+
+The repo guarantees this via `tests/test_cards.py::test_make_choice_cards_byte_identical_stable_order`,
+which asserts `bytes(card1) == bytes(card2)` across two consecutive calls
+on identical inputs. The invariant survives across the full
+`SelectableItem → ChoiceCard → cache prefix` chain.
+
+### Worked example: Anthropic `cache_control`
+
+```python
+import anthropic
+from contextweaver.routing.cards import make_choice_cards
+from contextweaver.routing.catalog import Catalog
+
+catalog = Catalog()  # populated elsewhere with stable IDs
+cards = make_choice_cards(
+    catalog.all(),
+    scores={item.id: 0.5 for item in catalog.all()},   # deterministic scoring
+    max_cards=20,
+)
+
+# Render cards into Anthropic's `tools` array (cacheable prefix).
+tools = [
+    {
+        "name": c.name,
+        "description": c.description,
+        "input_schema": {"type": "object"},  # hydrate per-call when selected
+    }
+    for c in cards
+]
+
+# Place the cache breakpoint on the LAST tool definition. As long as the
+# `cards` array is stable, every request reuses the cache prefix and only
+# the trailing user turn varies.
+if tools:
+    tools[-1]["cache_control"] = {"type": "ephemeral"}
+
+client = anthropic.Anthropic()
+client.messages.create(
+    model="claude-3-5-sonnet-latest",
+    max_tokens=1024,
+    tools=tools,
+    messages=[{"role": "user", "content": "..."}],
+)
+```
+
+> **Practical guidance for multi-turn navigation.** When the cards array
+> *naturally* changes between turns (e.g., user navigated into a sub-tree),
+> the cache prefix invalidates — that's expected. To keep the prefix stable
+> across navigation, sort hydrated cards by ID once and append newly-discovered
+> cards after the breakpoint. The
+> [Webfuse MCP cheat sheet](https://www.webfuse.com/mcp-cheat-sheet)
+> documents the canonical "append after cache breakpoint" pattern. A
+> first-class `cache_stable` runtime flag on `ProxyRuntime` is tracked as a
+> follow-up.
 
 ## Security Considerations
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -173,6 +173,9 @@ pip install -e ".[dev]"
 
 ```python
 from contextweaver.adapters.openai_messages import from_openai_messages
+from contextweaver.context.manager import ContextManager
+from contextweaver.types import Phase
+
 mgr = ContextManager()
 from_openai_messages(messages, into=mgr)   # also: from_anthropic_messages / from_gemini_contents
 pack = mgr.build_sync(phase=Phase.answer, query="...")
@@ -1427,8 +1430,14 @@ on identical inputs. The invariant survives across the full
 
 ### Worked example: Anthropic `cache_control`
 
+> **Illustrative — requires the Anthropic SDK.** This snippet imports
+> `anthropic` to show how the byte-stable cards array slots into the
+> provider's cache-control API. contextweaver itself does not depend on
+> the Anthropic SDK; install it separately with `pip install anthropic`
+> to run the example as-is, or read it as a pattern reference.
+
 ```python
-import anthropic
+import anthropic  # pip install anthropic
 from contextweaver.routing.cards import make_choice_cards
 from contextweaver.routing.catalog import Catalog
 

--- a/src/contextweaver/adapters/__init__.py
+++ b/src/contextweaver/adapters/__init__.py
@@ -1,10 +1,23 @@
 """Adapters sub-package for contextweaver.
 
-Provides thin adapters that convert external protocol data (MCP, A2A, FastMCP,
-weaver-spec) into contextweaver-native types and back, runtime modes for
-fronting upstream MCP servers (proxy + gateway), and provider-message
-ingestion helpers for one-call adoption from existing OpenAI / Anthropic /
-Gemini agents (issues #194, #219, #222).
+Provides thin, pure stateless adapters across three responsibility groups:
+
+1. **Protocol adapters** — convert external protocol data into
+   contextweaver-native types and back: MCP (:mod:`.mcp`),
+   FastMCP (:mod:`.fastmcp`), A2A (:mod:`.a2a`), and weaver-spec
+   (:mod:`.weaver_contracts`).
+2. **Runtime modes** — front upstream MCP servers as a transparent
+   proxy or two-tool gateway: :mod:`.proxy_runtime`, :mod:`.mcp_proxy`,
+   :mod:`.mcp_gateway`, :mod:`.mcp_proxy_server`,
+   :mod:`.mcp_gateway_server`, :mod:`.mcp_upstream`.
+3. **Provider-message ingestion** — one-call adoption from existing
+   OpenAI / Anthropic / Gemini chat histories (issues #194, #219, #222):
+   :mod:`.openai_messages`, :mod:`.anthropic_messages`,
+   :mod:`.gemini_contents`. Each module ships a ``from_*`` decoder
+   (plain provider dicts → ``ContextItem`` event-log entries) and a
+   ``to_*`` inverse, with no provider SDK imported at module load time.
+
+See ``AGENTS.md`` Module Map for the full per-file responsibility list.
 """
 
 from __future__ import annotations

--- a/src/contextweaver/adapters/__init__.py
+++ b/src/contextweaver/adapters/__init__.py
@@ -1,8 +1,10 @@
 """Adapters sub-package for contextweaver.
 
 Provides thin adapters that convert external protocol data (MCP, A2A, FastMCP,
-weaver-spec) into contextweaver-native types and back, and shipping runtime
-modes for fronting upstream MCP servers (proxy + gateway).
+weaver-spec) into contextweaver-native types and back, runtime modes for
+fronting upstream MCP servers (proxy + gateway), and provider-message
+ingestion helpers for one-call adoption from existing OpenAI / Anthropic /
+Gemini agents (issues #194, #219, #222).
 """
 
 from __future__ import annotations
@@ -12,6 +14,10 @@ from contextweaver.adapters.a2a import (
     a2a_result_to_envelope,
     load_a2a_session_jsonl,
 )
+from contextweaver.adapters.anthropic_messages import (
+    from_anthropic_messages,
+    to_anthropic_messages,
+)
 from contextweaver.adapters.fastmcp import (
     fastmcp_tool_to_selectable,
     fastmcp_tools_to_catalog,
@@ -19,6 +25,10 @@ from contextweaver.adapters.fastmcp import (
     load_fastmcp_catalog,
 )
 from contextweaver.adapters.gateway_error import GatewayError
+from contextweaver.adapters.gemini_contents import (
+    from_gemini_contents,
+    to_gemini_contents,
+)
 from contextweaver.adapters.mcp import (
     infer_namespace,
     load_mcp_session_jsonl,
@@ -40,6 +50,10 @@ from contextweaver.adapters.mcp_upstream import (
     McpClientUpstream,
     MultiplexUpstream,
     StubUpstream,
+)
+from contextweaver.adapters.openai_messages import (
+    from_openai_messages,
+    to_openai_messages,
 )
 from contextweaver.adapters.proxy_runtime import ExposureMode, ProxyRuntime, UpstreamCall
 from contextweaver.adapters.weaver_contracts import (
@@ -71,6 +85,9 @@ __all__ = [
     "dispatch_proxy_request",
     "fastmcp_tool_to_selectable",
     "fastmcp_tools_to_catalog",
+    "from_anthropic_messages",
+    "from_gemini_contents",
+    "from_openai_messages",
     "from_weaver_choice_card",
     "from_weaver_choice_card_single",
     "from_weaver_frame",
@@ -86,6 +103,9 @@ __all__ = [
     "make_stripped_tools_list",
     "mcp_result_to_envelope",
     "mcp_tool_to_selectable",
+    "to_anthropic_messages",
+    "to_gemini_contents",
+    "to_openai_messages",
     "to_weaver_choice_card",
     "to_weaver_choice_cards",
     "to_weaver_frame",

--- a/src/contextweaver/adapters/_anthropic_decode.py
+++ b/src/contextweaver/adapters/_anthropic_decode.py
@@ -1,0 +1,177 @@
+"""Internal: Anthropic Messages → ContextItem decoders.
+
+Implementation detail of :mod:`contextweaver.adapters.anthropic_messages`;
+not part of the public API. Importing directly is unsupported. Lives in
+a separate module so the public adapter file stays within the repo's
+≤300-line module guideline (see ``AGENTS.md``).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from contextweaver.adapters._messages_common import expect_dict, json_args_dumps
+from contextweaver.exceptions import CatalogError
+from contextweaver.types import ContextItem, ItemKind
+
+_PREFIX_USER = "anthropic:user:"
+_PREFIX_ASSISTANT = "anthropic:assistant:"
+_PREFIX_TOOL_USE = "anthropic:tool_use:"
+_PREFIX_TOOL_RESULT = "anthropic:tool_result:"
+
+
+def _normalise_content(
+    content: Any,  # noqa: ANN401 — content is opaque provider JSON
+    idx: int,
+    role: str,
+) -> list[dict[str, Any]]:
+    """Coerce the ``content`` field to a list of content blocks."""
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    if isinstance(content, list):
+        for b_idx, block in enumerate(content):
+            expect_dict(block, label=f"Anthropic content block [{idx}][{b_idx}]")
+        return list(content)
+    raise CatalogError(
+        f"Anthropic {role} message at index {idx} has unsupported content type: "
+        f"{type(content).__name__}"
+    )
+
+
+def _blocks_to_items(
+    blocks: list[dict[str, Any]],
+    msg_idx: int,
+    role: str,
+    was_string_shorthand: bool,
+    seen_tool_use_ids: set[str],
+) -> list[ContextItem]:
+    """Convert a normalised content-block list into one or more items."""
+    out: list[ContextItem] = []
+    for b_idx, block in enumerate(blocks):
+        block_type = block.get("type")
+        base_meta: dict[str, Any] = {
+            "role": role,
+            "msg_index": msg_idx,
+            "block_index": b_idx,
+            "block_type": block_type,
+            # Only meaningful when this group has a single text block; we
+            # tag every block so the inverse adapter sees it on group[0].
+            "was_string_shorthand": was_string_shorthand,
+            # Preserve the full original block so the inverse adapter can
+            # re-emit unknown provider fields (e.g. `cache_control`) and
+            # distinguish an explicit `is_error: False` from a missing one
+            # (PR #230 review).
+            "original_block": block,
+        }
+        if block_type == "text":
+            text = str(block.get("text", ""))
+            kind = ItemKind.user_turn if role == "user" else ItemKind.agent_msg
+            prefix = _PREFIX_USER if role == "user" else _PREFIX_ASSISTANT
+            out.append(
+                ContextItem(
+                    id=f"{prefix}{msg_idx}:{b_idx}",
+                    kind=kind,
+                    text=text,
+                    metadata=base_meta,
+                )
+            )
+        elif block_type == "tool_use":
+            if role != "assistant":
+                raise CatalogError(
+                    f"tool_use block at [{msg_idx}][{b_idx}] must be on an "
+                    f"assistant message, got role={role!r}"
+                )
+            tool_use_id = block.get("id")
+            if not tool_use_id:
+                raise CatalogError(f"Anthropic tool_use block at [{msg_idx}][{b_idx}] missing 'id'")
+            tool_name = block.get("name", "")
+            input_payload = block.get("input", {})
+            args_str = json_args_dumps(
+                input_payload, label=f"Anthropic tool_use.input at [{msg_idx}][{b_idx}]"
+            )
+            meta = {
+                **base_meta,
+                "tool_use_id": tool_use_id,
+                "function_name": tool_name,
+                "input": input_payload,
+            }
+            out.append(
+                ContextItem(
+                    id=f"{_PREFIX_TOOL_USE}{tool_use_id}",
+                    kind=ItemKind.tool_call,
+                    text=args_str,
+                    metadata=meta,
+                )
+            )
+            seen_tool_use_ids.add(tool_use_id)
+        elif block_type == "tool_result":
+            if role != "user":
+                raise CatalogError(
+                    f"tool_result block at [{msg_idx}][{b_idx}] must be on a "
+                    f"user message, got role={role!r}"
+                )
+            tool_use_id = block.get("tool_use_id")
+            if not tool_use_id:
+                raise CatalogError(
+                    f"Anthropic tool_result block at [{msg_idx}][{b_idx}] missing 'tool_use_id'"
+                )
+            if tool_use_id not in seen_tool_use_ids:
+                # Mirrors the openai_messages orphan-tool-result check
+                # and the gemini_contents FIFO check (PR #230 review).
+                raise CatalogError(
+                    f"Anthropic tool_result block at [{msg_idx}][{b_idx}] has "
+                    f"tool_use_id={tool_use_id!r} that does not match any prior "
+                    "assistant tool_use block"
+                )
+            text, content_for_meta = _stringify_tool_result_content(block.get("content"))
+            meta = {
+                **base_meta,
+                "tool_use_id": tool_use_id,
+                "is_error": bool(block.get("is_error", False)),
+                # Preserve whether is_error was *present* in the original
+                # block (vs. defaulted) so we can re-emit explicit False.
+                "is_error_present": "is_error" in block,
+                "content_payload": content_for_meta,
+            }
+            out.append(
+                ContextItem(
+                    id=f"{_PREFIX_TOOL_RESULT}{tool_use_id}",
+                    kind=ItemKind.tool_result,
+                    text=text,
+                    metadata=meta,
+                    parent_id=f"{_PREFIX_TOOL_USE}{tool_use_id}",
+                )
+            )
+        else:
+            raise CatalogError(
+                f"Anthropic content block at [{msg_idx}][{b_idx}] has unsupported "
+                f"type: {block_type!r}"
+            )
+    return out
+
+
+def _stringify_tool_result_content(
+    content: Any,  # noqa: ANN401 — content is opaque provider JSON
+) -> tuple[str, Any]:
+    """Reduce a tool_result.content payload to a string for ``ContextItem.text``.
+
+    Returns a ``(text, original_content)`` tuple — the original is stashed
+    in metadata so the inverse adapter can re-emit the exact same shape.
+    """
+    if content is None:
+        return "", None
+    if isinstance(content, str):
+        return content, content
+    if isinstance(content, list):
+        text_parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                text_parts.append(str(part.get("text", "")))
+            else:
+                text_parts.append(json.dumps(part, sort_keys=True))
+        return "\n".join(text_parts), content
+    # Numbers, bools — coerce to string and store the original for round-trip.
+    return str(content), content

--- a/src/contextweaver/adapters/_anthropic_encode.py
+++ b/src/contextweaver/adapters/_anthropic_encode.py
@@ -1,0 +1,73 @@
+"""Internal: ContextItem → Anthropic Messages encoders.
+
+Implementation detail of :mod:`contextweaver.adapters.anthropic_messages`;
+not part of the public API. Importing directly is unsupported. Lives in
+a separate module so the public adapter file stays within the repo's
+≤300-line module guideline (see ``AGENTS.md``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from contextweaver.adapters._messages_common import sort_key_by_meta_index
+from contextweaver.exceptions import CatalogError
+from contextweaver.types import ContextItem
+
+_block_index_sort_key = sort_key_by_meta_index("block_index")
+
+
+def _item_to_block(item: ContextItem) -> dict[str, Any]:
+    """Convert a single ContextItem back into an Anthropic content block.
+
+    Starts from the original decoded block (so unknown provider fields like
+    ``cache_control`` survive the round-trip) and overlays the canonical
+    decoded fields. Falls back to a constructed block when no original is
+    available (hand-constructed items).
+    """
+    meta = item.metadata or {}
+    block_type = meta.get("block_type")
+    original_block = meta.get("original_block")
+    # When original_block is present, start from a copy and overlay the
+    # canonical decoded fields. This preserves unknown / non-decoded keys
+    # (e.g. cache_control, citations) verbatim.
+    block: dict[str, Any] = dict(original_block) if isinstance(original_block, dict) else {}
+
+    if block_type == "text":
+        block["type"] = "text"
+        block["text"] = item.text
+        return block
+    if block_type == "tool_use":
+        tool_use_id = meta.get("tool_use_id")
+        if not tool_use_id:
+            raise CatalogError(f"tool_call item {item.id!r} missing 'tool_use_id' metadata")
+        block["type"] = "tool_use"
+        block["id"] = tool_use_id
+        block["name"] = meta.get("function_name", "")
+        block["input"] = meta.get("input", {})
+        return block
+    if block_type == "tool_result":
+        tool_use_id = meta.get("tool_use_id")
+        if not tool_use_id:
+            raise CatalogError(f"tool_result item {item.id!r} missing 'tool_use_id' metadata")
+        block["type"] = "tool_result"
+        block["tool_use_id"] = tool_use_id
+        # Preserve the original content shape: string vs list vs missing.
+        content_payload = meta.get("content_payload")
+        if content_payload is not None:
+            block["content"] = content_payload
+        elif "content" in block:
+            # Original block had no content; ensure we don't accidentally
+            # keep a content key from the original_block snapshot.
+            del block["content"]
+        # is_error: re-emit only if it was present in the original block.
+        # Preserves explicit `is_error: False` and omits when absent.
+        if meta.get("is_error_present"):
+            block["is_error"] = bool(meta.get("is_error", False))
+        else:
+            block.pop("is_error", None)
+        return block
+    # Fallback for items that were assembled without the round-trip metadata
+    # (e.g., constructed by hand). Emit as a plain text block carrying the
+    # item's text so the message remains valid Anthropic input.
+    return {"type": "text", "text": item.text}

--- a/src/contextweaver/adapters/_messages_common.py
+++ b/src/contextweaver/adapters/_messages_common.py
@@ -1,0 +1,149 @@
+"""Shared helpers for provider-message ingestion adapters.
+
+Used by :mod:`.openai_messages`, :mod:`.anthropic_messages`, and
+:mod:`.gemini_contents` to keep per-provider modules focused on the
+provider-specific decoding rules. These helpers cover the patterns that
+recur identically across all three adapters: top-level type validation,
+``into=ContextManager.ingest()`` plumbing, JSON-args serialisation,
+``metadata["msg_index"]`` grouping, and prefix-stripping.
+
+This is a private module — its API is not exported from
+``contextweaver.adapters`` and is not part of the public contract.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from contextweaver.exceptions import CatalogError
+from contextweaver.types import ContextItem
+
+if TYPE_CHECKING:
+    from contextweaver.context.manager import ContextManager
+
+logger = logging.getLogger("contextweaver.adapters")
+
+
+def expect_list(value: Any, *, fn_name: str) -> None:  # noqa: ANN401 — provider JSON
+    """Raise :class:`CatalogError` when *value* is not a ``list``.
+
+    Args:
+        value: The opaque input to validate.
+        fn_name: Caller name, used in the error message.
+
+    Raises:
+        CatalogError: If *value* is not a ``list``.
+    """
+    if not isinstance(value, list):
+        raise CatalogError(f"{fn_name} expects a list, got {type(value).__name__}")
+
+
+def expect_dict(value: Any, *, label: str) -> None:  # noqa: ANN401 — provider JSON
+    """Raise :class:`CatalogError` when *value* is not a ``dict``.
+
+    Args:
+        value: The opaque input to validate.
+        label: Position label (e.g. ``"OpenAI message at index 3"``).
+
+    Raises:
+        CatalogError: If *value* is not a ``dict``.
+    """
+    if not isinstance(value, dict):
+        raise CatalogError(f"{label} is not a dict: {type(value).__name__}")
+
+
+def ingest_into_manager(items: list[ContextItem], into: ContextManager | None) -> None:
+    """Append each item to *into*'s event log when *into* is provided.
+
+    No-op when *into* is ``None``. Items are appended in list order.
+    """
+    if into is None:
+        return
+    for item in items:
+        into.ingest(item)
+
+
+def json_args_dumps(payload: Any, *, label: str) -> str:  # noqa: ANN401 — provider JSON
+    """JSON-encode tool-call args/input with deterministic key ordering.
+
+    Args:
+        payload: The arbitrary tool-call argument payload.
+        label: Position label for the error message.
+
+    Returns:
+        A canonical JSON string (sorted keys).
+
+    Raises:
+        CatalogError: When *payload* is not JSON-serialisable.
+    """
+    try:
+        return json.dumps(payload, sort_keys=True)
+    except (TypeError, ValueError) as exc:
+        raise CatalogError(f"{label} is not JSON-serialisable: {exc}") from exc
+
+
+def group_items_by_msg_index(
+    items: list[ContextItem], *, target_label: str
+) -> dict[int, list[ContextItem]]:
+    """Group items by ``metadata["msg_index"]``.
+
+    Used by the Anthropic and Gemini encoders, both of which need to
+    rebuild multi-block / multi-part messages from per-block items.
+
+    Args:
+        items: Items produced by a sibling ``from_*`` decoder.
+        target_label: Provider label for the error message
+            (e.g. ``"Anthropic messages"``, ``"Gemini contents"``).
+
+    Returns:
+        A dict mapping message index to its constituent items, in
+        insertion order within each group.
+
+    Raises:
+        CatalogError: If any item is missing the ``msg_index`` metadata
+            entry the inverse round-trip requires.
+    """
+    groups: dict[int, list[ContextItem]] = {}
+    for item in items:
+        meta = item.metadata or {}
+        msg_idx = meta.get("msg_index")
+        if msg_idx is None:
+            raise CatalogError(
+                f"ContextItem {item.id!r} missing 'msg_index' metadata; cannot "
+                f"round-trip back to {target_label}"
+            )
+        groups.setdefault(int(msg_idx), []).append(item)
+    return groups
+
+
+def sort_key_by_meta_index(meta_key: str) -> Callable[[ContextItem], int]:
+    """Build a sort key function reading ``metadata[meta_key]`` as ``int``.
+
+    Returns ``0`` when the key is missing or not convertible to ``int``.
+    Used by both ``_block_index_sort_key`` (Anthropic) and
+    ``_part_index_sort_key`` (Gemini) to keep multi-block / multi-part
+    output in original input order.
+    """
+
+    def key_fn(item: ContextItem) -> int:
+        meta = item.metadata or {}
+        val = meta.get(meta_key, 0)
+        try:
+            return int(val)
+        except (TypeError, ValueError):
+            return 0
+
+    return key_fn
+
+
+def strip_prefix(value: str, prefix: str) -> str:
+    """Strip *prefix* from *value*; return an empty string if it doesn't match.
+
+    Used by adapters that round-trip provider IDs through
+    ``ContextItem.id`` to recover the original ID when the
+    metadata-stored copy is missing.
+    """
+    return value[len(prefix) :] if value.startswith(prefix) else ""

--- a/src/contextweaver/adapters/_openai_decode.py
+++ b/src/contextweaver/adapters/_openai_decode.py
@@ -1,0 +1,156 @@
+"""Internal: OpenAI Chat Completions → ContextItem decoders.
+
+Implementation detail of :mod:`contextweaver.adapters.openai_messages`;
+not part of the public API. Importing directly is unsupported. Lives in
+a separate module so the public adapter file stays within the repo's
+≤300-line module guideline (see ``AGENTS.md``).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from contextweaver.adapters._messages_common import expect_dict
+from contextweaver.exceptions import CatalogError
+from contextweaver.types import ContextItem, ItemKind
+
+# ID prefix carries enough information to round-trip the OpenAI message:
+# - "openai:tool_call:<tool_call_id>"   → the assistant's tool-call entry
+# - "openai:tool_result:<tool_call_id>" → the matching role="tool" response
+# - "openai:{user,assistant,system}:<idx>" → turn entries
+_PREFIX_TOOL_CALL = "openai:tool_call:"
+_PREFIX_TOOL_RESULT = "openai:tool_result:"
+_PREFIX_USER = "openai:user:"
+_PREFIX_ASSISTANT = "openai:assistant:"
+_PREFIX_SYSTEM = "openai:system:"
+
+
+def _from_system(msg: dict[str, Any], idx: int) -> ContextItem:
+    return _make_turn(msg, idx, role="system", kind=ItemKind.policy, prefix=_PREFIX_SYSTEM)
+
+
+def _from_user(msg: dict[str, Any], idx: int) -> ContextItem:
+    return _make_turn(msg, idx, role="user", kind=ItemKind.user_turn, prefix=_PREFIX_USER)
+
+
+def _make_turn(
+    msg: dict[str, Any], idx: int, *, role: str, kind: ItemKind, prefix: str
+) -> ContextItem:
+    return ContextItem(
+        id=f"{prefix}{idx}",
+        kind=kind,
+        text=_string_content(msg, idx, role),
+        metadata={"role": role},
+    )
+
+
+def _from_assistant(
+    msg: dict[str, Any], idx: int, seen_tool_call_ids: set[str]
+) -> list[ContextItem]:
+    """Expand an assistant message into agent_msg + N tool_call items.
+
+    Metadata keys ``content_is_null`` and ``original_content`` preserve
+    the three input shapes (``None`` / ``""`` / list-of-parts) so the
+    inverse adapter can re-emit them exactly (PR #230 review).
+    """
+    out: list[ContextItem] = []
+    raw_content = msg.get("content")
+    text = "" if raw_content is None else _string_content(msg, idx, "assistant")
+    out.append(
+        ContextItem(
+            id=f"{_PREFIX_ASSISTANT}{idx}",
+            kind=ItemKind.agent_msg,
+            text=text,
+            metadata={
+                "role": "assistant",
+                "content_is_null": raw_content is None,
+                "original_content": raw_content,
+                "assistant_idx": idx,
+            },
+        )
+    )
+
+    tool_calls = msg.get("tool_calls") or []
+    if not isinstance(tool_calls, list):
+        raise CatalogError(f"OpenAI assistant message at index {idx} has non-list tool_calls")
+
+    for tc_idx, tc in enumerate(tool_calls):
+        loc = f"OpenAI tool_call at index [{idx}].tool_calls[{tc_idx}]"
+        expect_dict(tc, label=loc)
+        tc_id = tc.get("id")
+        if not tc_id:
+            raise CatalogError(f"{loc} missing id")
+        fn = tc.get("function") or {}
+        expect_dict(fn, label=f"OpenAI tool_call {tc_id!r} function payload")
+        fn_name = fn.get("name", "")
+        # Arguments are a JSON-encoded string in OpenAI's schema; preserve
+        # raw text + parsed args in metadata so to_openai_messages can
+        # re-emit the canonical shape.
+        args_str = fn.get("arguments", "")
+        if not isinstance(args_str, str):
+            args_str = json.dumps(args_str)
+        out.append(
+            ContextItem(
+                id=f"{_PREFIX_TOOL_CALL}{tc_id}",
+                kind=ItemKind.tool_call,
+                text=args_str,
+                metadata={
+                    "tool_call_id": tc_id,
+                    "tool_call_type": tc.get("type", "function"),
+                    "function_name": fn_name,
+                    "arguments": args_str,
+                    "assistant_idx": idx,
+                },
+            )
+        )
+        seen_tool_call_ids.add(tc_id)
+    return out
+
+
+def _from_tool(msg: dict[str, Any], idx: int, seen_tool_call_ids: set[str]) -> ContextItem:
+    tool_call_id = msg.get("tool_call_id")
+    if not tool_call_id:
+        raise CatalogError(f"OpenAI tool message at index {idx} missing tool_call_id")
+    if tool_call_id not in seen_tool_call_ids:
+        # The tool_call_id must reference a prior assistant tool_calls entry
+        # so the resulting ContextItem.parent_id points at a real item (PR
+        # #230 review). Mirrors the Gemini adapter's unmatched-response check.
+        raise CatalogError(
+            f"OpenAI tool message at index {idx} has tool_call_id={tool_call_id!r} "
+            "that does not match any prior assistant tool_calls entry"
+        )
+    content = _string_content(msg, idx, "tool")
+    return ContextItem(
+        id=f"{_PREFIX_TOOL_RESULT}{tool_call_id}",
+        kind=ItemKind.tool_result,
+        text=content,
+        metadata={"role": "tool", "tool_call_id": tool_call_id},
+        parent_id=f"{_PREFIX_TOOL_CALL}{tool_call_id}",
+    )
+
+
+def _string_content(msg: dict[str, Any], idx: int, role: str) -> str:
+    """Coerce ``content`` to a string; collapse list-of-parts to joined text.
+
+    The list path supports OpenAI's multimodal `content` shape. The original
+    list payload is preserved separately in metadata so the round-trip is
+    lossless (see :func:`_from_assistant`).
+    """
+    content = msg.get("content")
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            str(p.get("text", ""))
+            if isinstance(p, dict) and p.get("type") == "text"
+            else json.dumps(p, sort_keys=True)
+            for p in content
+        ]
+        return "\n".join(parts)
+    raise CatalogError(
+        f"OpenAI {role} message at index {idx} has unsupported content type: "
+        f"{type(content).__name__}"
+    )

--- a/src/contextweaver/adapters/_openai_encode.py
+++ b/src/contextweaver/adapters/_openai_encode.py
@@ -1,0 +1,77 @@
+"""Internal: ContextItem → OpenAI Chat Completions encoders.
+
+Implementation detail of :mod:`contextweaver.adapters.openai_messages`;
+not part of the public API. Importing directly is unsupported. Lives in
+a separate module so the public adapter file stays within the repo's
+≤300-line module guideline (see ``AGENTS.md``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from contextweaver.adapters._messages_common import strip_prefix
+from contextweaver.adapters._openai_decode import _PREFIX_TOOL_CALL
+from contextweaver.exceptions import CatalogError
+from contextweaver.types import ContextItem, ItemKind
+
+
+def _collect_assistant_tool_calls(items: list[ContextItem], start: int) -> list[dict[str, Any]]:
+    """Collect tool_call items that follow an assistant agent_msg.
+
+    A tool_call belongs to the immediately-preceding agent_msg iff its
+    ``metadata["assistant_idx"]`` matches the agent_msg's input index. We
+    look at consecutive tool_call items and stop at the first non-match.
+    """
+    out: list[dict[str, Any]] = []
+    if start == 0:
+        return out
+    prev = items[start - 1]
+    if prev.kind is not ItemKind.agent_msg:
+        return out
+    expected_idx = prev.metadata.get("assistant_idx") if prev.metadata else None
+    cursor = start
+    while cursor < len(items):
+        candidate = items[cursor]
+        if candidate.kind is not ItemKind.tool_call:
+            break
+        # Only consume tool_calls that came from this assistant turn.
+        cand_idx = candidate.metadata.get("assistant_idx") if candidate.metadata else None
+        if cand_idx != expected_idx:
+            break
+        out.append({"payload": _tool_call_payload(candidate)})
+        cursor += 1
+    return out
+
+
+def _tool_call_payload(item: ContextItem) -> dict[str, Any]:
+    """Build an OpenAI ``tool_calls[]`` entry from a stored tool_call item."""
+    tool_call_id = item.metadata.get("tool_call_id") if item.metadata else None
+    if not tool_call_id:
+        # Fall back to stripping the prefix; rejects items that weren't
+        # produced by this adapter.
+        tool_call_id = strip_prefix(item.id, _PREFIX_TOOL_CALL)
+    if not tool_call_id:
+        raise CatalogError(
+            f"tool_call item {item.id!r} cannot round-trip: missing "
+            "tool_call_id metadata and id is not openai-prefixed"
+        )
+    fn_name = item.metadata.get("function_name", "") if item.metadata else ""
+    arguments = item.metadata.get("arguments") if item.metadata else None
+    if arguments is None:
+        arguments = item.text
+    return {
+        "id": tool_call_id,
+        "type": item.metadata.get("tool_call_type", "function") if item.metadata else "function",
+        "function": {"name": fn_name, "arguments": arguments},
+    }
+
+
+def _restore_assistant_content(item: ContextItem, meta: dict[str, Any]) -> Any:  # noqa: ANN401 — provider-shaped JSON
+    """Reconstruct assistant ``content``: None / list / string (PR #230)."""
+    if meta.get("content_is_null"):
+        return None
+    original = meta.get("original_content")
+    if isinstance(original, list):
+        return original
+    return item.text

--- a/src/contextweaver/adapters/anthropic_messages.py
+++ b/src/contextweaver/adapters/anthropic_messages.py
@@ -100,6 +100,10 @@ def from_anthropic_messages(
     if not isinstance(messages, list):
         raise CatalogError(f"from_anthropic_messages expects a list, got {type(messages).__name__}")
 
+    # Track tool_use ids announced by prior assistant turns so a subsequent
+    # tool_result block must reference one of them. Without this check, an
+    # orphan tool_result would leave a dangling parent_id (PR #230 review).
+    seen_tool_use_ids: set[str] = set()
     items: list[ContextItem] = []
     for idx, msg in enumerate(messages):
         if not isinstance(msg, dict):
@@ -111,7 +115,7 @@ def from_anthropic_messages(
             raise CatalogError(f"Anthropic message at index {idx} has unknown role: {role!r}")
         blocks = _normalise_content(msg.get("content"), idx, role)
         original_is_string = isinstance(msg.get("content"), str)
-        items.extend(_blocks_to_items(blocks, idx, role, original_is_string))
+        items.extend(_blocks_to_items(blocks, idx, role, original_is_string, seen_tool_use_ids))
 
     if into is not None:
         for item in items:
@@ -213,6 +217,7 @@ def _blocks_to_items(
     msg_idx: int,
     role: str,
     was_string_shorthand: bool,
+    seen_tool_use_ids: set[str],
 ) -> list[ContextItem]:
     """Convert a normalised content-block list into one or more items."""
     out: list[ContextItem] = []
@@ -226,6 +231,11 @@ def _blocks_to_items(
             # Only meaningful when this group has a single text block; we
             # tag every block so the inverse adapter sees it on group[0].
             "was_string_shorthand": was_string_shorthand,
+            # Preserve the full original block so the inverse adapter can
+            # re-emit unknown provider fields (e.g. `cache_control`) and
+            # distinguish an explicit `is_error: False` from a missing one
+            # (PR #230 review).
+            "original_block": block,
         }
         if block_type == "text":
             text = str(block.get("text", ""))
@@ -271,6 +281,7 @@ def _blocks_to_items(
                     metadata=meta,
                 )
             )
+            seen_tool_use_ids.add(tool_use_id)
         elif block_type == "tool_result":
             if role != "user":
                 raise CatalogError(
@@ -282,11 +293,22 @@ def _blocks_to_items(
                 raise CatalogError(
                     f"Anthropic tool_result block at [{msg_idx}][{b_idx}] missing 'tool_use_id'"
                 )
+            if tool_use_id not in seen_tool_use_ids:
+                # Mirrors the openai_messages orphan-tool-result check
+                # and the gemini_contents FIFO check (PR #230 review).
+                raise CatalogError(
+                    f"Anthropic tool_result block at [{msg_idx}][{b_idx}] has "
+                    f"tool_use_id={tool_use_id!r} that does not match any prior "
+                    "assistant tool_use block"
+                )
             text, content_for_meta = _stringify_tool_result_content(block.get("content"))
             meta = {
                 **base_meta,
                 "tool_use_id": tool_use_id,
                 "is_error": bool(block.get("is_error", False)),
+                # Preserve whether is_error was *present* in the original
+                # block (vs. defaulted) so we can re-emit explicit False.
+                "is_error_present": "is_error" in block,
                 "content_payload": content_for_meta,
             }
             out.append(
@@ -346,35 +368,54 @@ def _block_index_sort_key(item: ContextItem) -> int:
 
 
 def _item_to_block(item: ContextItem) -> dict[str, Any]:
-    """Convert a single ContextItem back into an Anthropic content block."""
+    """Convert a single ContextItem back into an Anthropic content block.
+
+    Starts from the original decoded block (so unknown provider fields like
+    ``cache_control`` survive the round-trip) and overlays the canonical
+    decoded fields. Falls back to a constructed block when no original is
+    available (hand-constructed items).
+    """
     meta = item.metadata or {}
     block_type = meta.get("block_type")
+    original_block = meta.get("original_block")
+    # When original_block is present, start from a copy and overlay the
+    # canonical decoded fields. This preserves unknown / non-decoded keys
+    # (e.g. cache_control, citations) verbatim.
+    block: dict[str, Any] = dict(original_block) if isinstance(original_block, dict) else {}
+
     if block_type == "text":
-        return {"type": "text", "text": item.text}
+        block["type"] = "text"
+        block["text"] = item.text
+        return block
     if block_type == "tool_use":
         tool_use_id = meta.get("tool_use_id")
         if not tool_use_id:
             raise CatalogError(f"tool_call item {item.id!r} missing 'tool_use_id' metadata")
-        return {
-            "type": "tool_use",
-            "id": tool_use_id,
-            "name": meta.get("function_name", ""),
-            "input": meta.get("input", {}),
-        }
+        block["type"] = "tool_use"
+        block["id"] = tool_use_id
+        block["name"] = meta.get("function_name", "")
+        block["input"] = meta.get("input", {})
+        return block
     if block_type == "tool_result":
         tool_use_id = meta.get("tool_use_id")
         if not tool_use_id:
             raise CatalogError(f"tool_result item {item.id!r} missing 'tool_use_id' metadata")
-        block: dict[str, Any] = {
-            "type": "tool_result",
-            "tool_use_id": tool_use_id,
-        }
+        block["type"] = "tool_result"
+        block["tool_use_id"] = tool_use_id
         # Preserve the original content shape: string vs list vs missing.
         content_payload = meta.get("content_payload")
         if content_payload is not None:
             block["content"] = content_payload
-        if meta.get("is_error"):
-            block["is_error"] = True
+        elif "content" in block:
+            # Original block had no content; ensure we don't accidentally
+            # keep a content key from the original_block snapshot.
+            del block["content"]
+        # is_error: re-emit only if it was present in the original block.
+        # Preserves explicit `is_error: False` and omits when absent.
+        if meta.get("is_error_present"):
+            block["is_error"] = bool(meta.get("is_error", False))
+        else:
+            block.pop("is_error", None)
         return block
     # Fallback for items that were assembled without the round-trip metadata
     # (e.g., constructed by hand). Emit as a plain text block carrying the

--- a/src/contextweaver/adapters/anthropic_messages.py
+++ b/src/contextweaver/adapters/anthropic_messages.py
@@ -1,7 +1,9 @@
 """Anthropic Messages-API message-array adapter for contextweaver.
 
-Bridges the Anthropic Messages API ``messages`` schema and contextweaver's
-:class:`~contextweaver.types.ContextItem` event log:
+Pure stateless converter between the Anthropic Messages API
+``messages`` schema and contextweaver's :class:`~contextweaver.types.ContextItem`
+event log. No provider SDK is imported at module load time; operate on
+plain ``dict``s following the documented Anthropic Messages JSON schema.
 
 .. code-block:: python
 
@@ -11,38 +13,24 @@ Bridges the Anthropic Messages API ``messages`` schema and contextweaver's
     mgr = ContextManager()
     from_anthropic_messages(messages, into=mgr)
 
-The adapter is a pure stateless converter — no provider SDK is imported
-at module load time (per the ``adapters/`` path convention).  Operate
-on plain ``dict``s following the documented Anthropic Messages JSON
-schema; SDK callers should convert via ``.model_dump()`` first.
-
-Anthropic messages differ from OpenAI's flat shape in two ways that the
-adapter handles explicitly:
+Anthropic differs from OpenAI's flat shape in two ways the adapter handles:
 
 - ``content`` is **always a list of content blocks** (``text``,
-  ``tool_use``, ``tool_result``), even for simple string messages —
-  Anthropic accepts ``content: "..."`` as a shorthand but the API
-  normalises it to ``[{"type": "text", "text": "..."}]``.  We preserve
-  whichever shape the caller used so the round-trip is exact.
-- The IDs that thread tool calls and tool results live **inside** the
-  content blocks (``tool_use.id`` ↔ ``tool_result.tool_use_id``), not as
-  top-level fields like OpenAI's ``tool_call_id``.
+  ``tool_use``, ``tool_result``); ``content: "..."`` is a string-shorthand
+  the API normalises. The adapter preserves whichever shape the caller
+  used so the round-trip is exact.
+- IDs that thread tool calls and tool results live **inside** the content
+  blocks (``tool_use.id`` ↔ ``tool_result.tool_use_id``).
 
-Mapping rules:
+Mapping (see ``AGENTS.md`` for the full ``ItemKind`` map):
 
-- ``role="user"`` with text-only content → :data:`ItemKind.user_turn`
-- ``role="assistant"`` with text-only content → :data:`ItemKind.agent_msg`
-- ``role="assistant"`` with ``tool_use`` blocks → one
-  :data:`ItemKind.agent_msg` (text portion) followed by one
-  :data:`ItemKind.tool_call` per ``tool_use`` block
-- ``role="user"`` with ``tool_result`` blocks → one
-  :data:`ItemKind.tool_result` per block, with ``parent_id`` set to the
-  matching ``tool_use.id`` on the prior assistant turn.
+- ``user`` text → :data:`ItemKind.user_turn`;
+  ``assistant`` text → :data:`ItemKind.agent_msg`.
+- ``assistant`` ``tool_use`` blocks → :data:`ItemKind.tool_call` items.
+- ``user`` ``tool_result`` blocks → :data:`ItemKind.tool_result` items
+  with ``parent_id`` pointing at the matching ``tool_use`` item.
 
-System prompts in the Anthropic API are passed as a separate top-level
-``system`` parameter (not a message); they are out of scope here. Users
-with a system prompt should append it manually as an
-:data:`ItemKind.policy` item if needed.
+System prompts (top-level API param, not a message) are out of scope.
 
 Issue #222 (closes #194 together with the OpenAI slice #219).
 """
@@ -53,6 +41,14 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from contextweaver.adapters._messages_common import (
+    expect_dict,
+    expect_list,
+    group_items_by_msg_index,
+    ingest_into_manager,
+    json_args_dumps,
+    sort_key_by_meta_index,
+)
 from contextweaver.exceptions import CatalogError
 from contextweaver.types import ContextItem, ItemKind
 
@@ -68,9 +64,7 @@ _PREFIX_TOOL_USE = "anthropic:tool_use:"
 _PREFIX_TOOL_RESULT = "anthropic:tool_result:"
 
 
-# ---------------------------------------------------------------------------
-# Public: from_anthropic_messages
-# ---------------------------------------------------------------------------
+# --- Public: from_anthropic_messages ---
 
 
 def from_anthropic_messages(
@@ -97,8 +91,7 @@ def from_anthropic_messages(
         CatalogError: On unknown role, unknown block ``type``, malformed
             input, or missing ``tool_use_id`` on a ``tool_result`` block.
     """
-    if not isinstance(messages, list):
-        raise CatalogError(f"from_anthropic_messages expects a list, got {type(messages).__name__}")
+    expect_list(messages, fn_name="from_anthropic_messages")
 
     # Track tool_use ids announced by prior assistant turns so a subsequent
     # tool_result block must reference one of them. Without this check, an
@@ -106,10 +99,7 @@ def from_anthropic_messages(
     seen_tool_use_ids: set[str] = set()
     items: list[ContextItem] = []
     for idx, msg in enumerate(messages):
-        if not isinstance(msg, dict):
-            raise CatalogError(
-                f"Anthropic message at index {idx} is not a dict: {type(msg).__name__}"
-            )
+        expect_dict(msg, label=f"Anthropic message at index {idx}")
         role = msg.get("role")
         if role not in ("user", "assistant"):
             raise CatalogError(f"Anthropic message at index {idx} has unknown role: {role!r}")
@@ -117,21 +107,12 @@ def from_anthropic_messages(
         original_is_string = isinstance(msg.get("content"), str)
         items.extend(_blocks_to_items(blocks, idx, role, original_is_string, seen_tool_use_ids))
 
-    if into is not None:
-        for item in items:
-            into.ingest(item)
-
-    logger.debug(
-        "from_anthropic_messages: messages_in=%d, items_out=%d",
-        len(messages),
-        len(items),
-    )
+    ingest_into_manager(items, into)
+    logger.debug("from_anthropic_messages: messages_in=%d, items_out=%d", len(messages), len(items))
     return items
 
 
-# ---------------------------------------------------------------------------
-# Public: to_anthropic_messages
-# ---------------------------------------------------------------------------
+# --- Public: to_anthropic_messages ---
 
 
 def to_anthropic_messages(items: list[ContextItem]) -> list[dict[str, Any]]:
@@ -153,17 +134,7 @@ def to_anthropic_messages(items: list[ContextItem]) -> list[dict[str, Any]]:
         CatalogError: If items are missing the round-trip metadata
             (``msg_index``, ``block_index``, ``role``).
     """
-    # Group items by their original message index.
-    groups: dict[int, list[ContextItem]] = {}
-    for item in items:
-        meta = item.metadata or {}
-        msg_idx = meta.get("msg_index")
-        if msg_idx is None:
-            raise CatalogError(
-                f"ContextItem {item.id!r} missing 'msg_index' metadata; cannot "
-                "round-trip back to Anthropic messages"
-            )
-        groups.setdefault(int(msg_idx), []).append(item)
+    groups = group_items_by_msg_index(items, target_label="Anthropic messages")
 
     out: list[dict[str, Any]] = []
     for msg_idx in sorted(groups):
@@ -181,9 +152,7 @@ def to_anthropic_messages(items: list[ContextItem]) -> list[dict[str, Any]]:
     return out
 
 
-# ---------------------------------------------------------------------------
-# Decoding (messages → items)
-# ---------------------------------------------------------------------------
+# --- Decoding (messages → items) ---
 
 
 def _normalise_content(
@@ -197,15 +166,9 @@ def _normalise_content(
     if isinstance(content, str):
         return [{"type": "text", "text": content}]
     if isinstance(content, list):
-        normalised: list[dict[str, Any]] = []
         for b_idx, block in enumerate(content):
-            if not isinstance(block, dict):
-                raise CatalogError(
-                    f"Anthropic content block [{idx}][{b_idx}] is not a dict: "
-                    f"{type(block).__name__}"
-                )
-            normalised.append(block)
-        return normalised
+            expect_dict(block, label=f"Anthropic content block [{idx}][{b_idx}]")
+        return list(content)
     raise CatalogError(
         f"Anthropic {role} message at index {idx} has unsupported content type: "
         f"{type(content).__name__}"
@@ -260,13 +223,9 @@ def _blocks_to_items(
                 raise CatalogError(f"Anthropic tool_use block at [{msg_idx}][{b_idx}] missing 'id'")
             tool_name = block.get("name", "")
             input_payload = block.get("input", {})
-            try:
-                args_str = json.dumps(input_payload, sort_keys=True)
-            except (TypeError, ValueError) as exc:
-                raise CatalogError(
-                    f"Anthropic tool_use.input at [{msg_idx}][{b_idx}] is not JSON-"
-                    f"serialisable: {exc}"
-                ) from exc
+            args_str = json_args_dumps(
+                input_payload, label=f"Anthropic tool_use.input at [{msg_idx}][{b_idx}]"
+            )
             meta = {
                 **base_meta,
                 "tool_use_id": tool_use_id,
@@ -352,19 +311,10 @@ def _stringify_tool_result_content(
     return str(content), content
 
 
-# ---------------------------------------------------------------------------
-# Encoding (items → messages)
-# ---------------------------------------------------------------------------
+# --- Encoding (items → messages) ---
 
 
-def _block_index_sort_key(item: ContextItem) -> int:
-    """Return the original block index (or 0) for stable per-group ordering."""
-    meta = item.metadata or {}
-    block_idx = meta.get("block_index", 0)
-    try:
-        return int(block_idx)
-    except (TypeError, ValueError):
-        return 0
+_block_index_sort_key = sort_key_by_meta_index("block_index")
 
 
 def _item_to_block(item: ContextItem) -> dict[str, Any]:

--- a/src/contextweaver/adapters/anthropic_messages.py
+++ b/src/contextweaver/adapters/anthropic_messages.py
@@ -1,0 +1,382 @@
+"""Anthropic Messages-API message-array adapter for contextweaver.
+
+Bridges the Anthropic Messages API ``messages`` schema and contextweaver's
+:class:`~contextweaver.types.ContextItem` event log:
+
+.. code-block:: python
+
+    from contextweaver.context.manager import ContextManager
+    from contextweaver.adapters.anthropic_messages import from_anthropic_messages
+
+    mgr = ContextManager()
+    from_anthropic_messages(messages, into=mgr)
+
+The adapter is a pure stateless converter — no provider SDK is imported
+at module load time (per the ``adapters/`` path convention).  Operate
+on plain ``dict``s following the documented Anthropic Messages JSON
+schema; SDK callers should convert via ``.model_dump()`` first.
+
+Anthropic messages differ from OpenAI's flat shape in two ways that the
+adapter handles explicitly:
+
+- ``content`` is **always a list of content blocks** (``text``,
+  ``tool_use``, ``tool_result``), even for simple string messages —
+  Anthropic accepts ``content: "..."`` as a shorthand but the API
+  normalises it to ``[{"type": "text", "text": "..."}]``.  We preserve
+  whichever shape the caller used so the round-trip is exact.
+- The IDs that thread tool calls and tool results live **inside** the
+  content blocks (``tool_use.id`` ↔ ``tool_result.tool_use_id``), not as
+  top-level fields like OpenAI's ``tool_call_id``.
+
+Mapping rules:
+
+- ``role="user"`` with text-only content → :data:`ItemKind.user_turn`
+- ``role="assistant"`` with text-only content → :data:`ItemKind.agent_msg`
+- ``role="assistant"`` with ``tool_use`` blocks → one
+  :data:`ItemKind.agent_msg` (text portion) followed by one
+  :data:`ItemKind.tool_call` per ``tool_use`` block
+- ``role="user"`` with ``tool_result`` blocks → one
+  :data:`ItemKind.tool_result` per block, with ``parent_id`` set to the
+  matching ``tool_use.id`` on the prior assistant turn.
+
+System prompts in the Anthropic API are passed as a separate top-level
+``system`` parameter (not a message); they are out of scope here. Users
+with a system prompt should append it manually as an
+:data:`ItemKind.policy` item if needed.
+
+Issue #222 (closes #194 together with the OpenAI slice #219).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from contextweaver.exceptions import CatalogError
+from contextweaver.types import ContextItem, ItemKind
+
+if TYPE_CHECKING:
+    from contextweaver.context.manager import ContextManager
+
+logger = logging.getLogger("contextweaver.adapters")
+
+
+_PREFIX_USER = "anthropic:user:"
+_PREFIX_ASSISTANT = "anthropic:assistant:"
+_PREFIX_TOOL_USE = "anthropic:tool_use:"
+_PREFIX_TOOL_RESULT = "anthropic:tool_result:"
+
+
+# ---------------------------------------------------------------------------
+# Public: from_anthropic_messages
+# ---------------------------------------------------------------------------
+
+
+def from_anthropic_messages(
+    messages: list[dict[str, Any]],
+    into: ContextManager | None = None,
+) -> list[ContextItem]:
+    """Convert an Anthropic Messages API ``messages`` array into ContextItems.
+
+    Args:
+        messages: A list of Anthropic message dicts. Each must have ``role``
+            (``"user"`` or ``"assistant"``) and ``content`` (either a plain
+            string or a list of content-block dicts).
+        into: Optional :class:`~contextweaver.context.manager.ContextManager`.
+            When provided, each returned item is appended via
+            :meth:`ContextManager.ingest` in order.
+
+    Returns:
+        A list of :class:`ContextItem` in input message order. Multi-block
+        messages expand into multiple items (one per block); the block
+        index is preserved in ``metadata["block_index"]`` so the inverse
+        adapter can rebuild the original block order.
+
+    Raises:
+        CatalogError: On unknown role, unknown block ``type``, malformed
+            input, or missing ``tool_use_id`` on a ``tool_result`` block.
+    """
+    if not isinstance(messages, list):
+        raise CatalogError(f"from_anthropic_messages expects a list, got {type(messages).__name__}")
+
+    items: list[ContextItem] = []
+    for idx, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            raise CatalogError(
+                f"Anthropic message at index {idx} is not a dict: {type(msg).__name__}"
+            )
+        role = msg.get("role")
+        if role not in ("user", "assistant"):
+            raise CatalogError(f"Anthropic message at index {idx} has unknown role: {role!r}")
+        blocks = _normalise_content(msg.get("content"), idx, role)
+        original_is_string = isinstance(msg.get("content"), str)
+        items.extend(_blocks_to_items(blocks, idx, role, original_is_string))
+
+    if into is not None:
+        for item in items:
+            into.ingest(item)
+
+    logger.debug(
+        "from_anthropic_messages: messages_in=%d, items_out=%d",
+        len(messages),
+        len(items),
+    )
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Public: to_anthropic_messages
+# ---------------------------------------------------------------------------
+
+
+def to_anthropic_messages(items: list[ContextItem]) -> list[dict[str, Any]]:
+    """Inverse of :func:`from_anthropic_messages`.
+
+    Re-groups ``ContextItem``s carrying the same ``metadata["msg_index"]``
+    back into a single Anthropic message and emits their original content
+    blocks in original ``block_index`` order. If a message was originally
+    a string shorthand, the inverse re-emits it as a string.
+
+    Args:
+        items: Items produced by :func:`from_anthropic_messages` (or any
+            sequence carrying the same metadata).
+
+    Returns:
+        A list of Anthropic message dicts.
+
+    Raises:
+        CatalogError: If items are missing the round-trip metadata
+            (``msg_index``, ``block_index``, ``role``).
+    """
+    # Group items by their original message index.
+    groups: dict[int, list[ContextItem]] = {}
+    for item in items:
+        meta = item.metadata or {}
+        msg_idx = meta.get("msg_index")
+        if msg_idx is None:
+            raise CatalogError(
+                f"ContextItem {item.id!r} missing 'msg_index' metadata; cannot "
+                "round-trip back to Anthropic messages"
+            )
+        groups.setdefault(int(msg_idx), []).append(item)
+
+    out: list[dict[str, Any]] = []
+    for msg_idx in sorted(groups):
+        group = sorted(groups[msg_idx], key=_block_index_sort_key)
+        first_meta = group[0].metadata or {}
+        role = first_meta.get("role")
+        if role not in ("user", "assistant"):
+            raise CatalogError(f"ContextItem group msg_index={msg_idx} has invalid role={role!r}")
+        blocks = [_item_to_block(item) for item in group]
+        was_string_shorthand = bool(first_meta.get("was_string_shorthand", False))
+        if was_string_shorthand and len(blocks) == 1 and blocks[0].get("type") == "text":
+            out.append({"role": role, "content": blocks[0]["text"]})
+        else:
+            out.append({"role": role, "content": blocks})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Decoding (messages → items)
+# ---------------------------------------------------------------------------
+
+
+def _normalise_content(
+    content: Any,  # noqa: ANN401 — content is opaque provider JSON
+    idx: int,
+    role: str,
+) -> list[dict[str, Any]]:
+    """Coerce the ``content`` field to a list of content blocks."""
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    if isinstance(content, list):
+        normalised: list[dict[str, Any]] = []
+        for b_idx, block in enumerate(content):
+            if not isinstance(block, dict):
+                raise CatalogError(
+                    f"Anthropic content block [{idx}][{b_idx}] is not a dict: "
+                    f"{type(block).__name__}"
+                )
+            normalised.append(block)
+        return normalised
+    raise CatalogError(
+        f"Anthropic {role} message at index {idx} has unsupported content type: "
+        f"{type(content).__name__}"
+    )
+
+
+def _blocks_to_items(
+    blocks: list[dict[str, Any]],
+    msg_idx: int,
+    role: str,
+    was_string_shorthand: bool,
+) -> list[ContextItem]:
+    """Convert a normalised content-block list into one or more items."""
+    out: list[ContextItem] = []
+    for b_idx, block in enumerate(blocks):
+        block_type = block.get("type")
+        base_meta: dict[str, Any] = {
+            "role": role,
+            "msg_index": msg_idx,
+            "block_index": b_idx,
+            "block_type": block_type,
+            # Only meaningful when this group has a single text block; we
+            # tag every block so the inverse adapter sees it on group[0].
+            "was_string_shorthand": was_string_shorthand,
+        }
+        if block_type == "text":
+            text = str(block.get("text", ""))
+            kind = ItemKind.user_turn if role == "user" else ItemKind.agent_msg
+            prefix = _PREFIX_USER if role == "user" else _PREFIX_ASSISTANT
+            out.append(
+                ContextItem(
+                    id=f"{prefix}{msg_idx}:{b_idx}",
+                    kind=kind,
+                    text=text,
+                    metadata=base_meta,
+                )
+            )
+        elif block_type == "tool_use":
+            if role != "assistant":
+                raise CatalogError(
+                    f"tool_use block at [{msg_idx}][{b_idx}] must be on an "
+                    f"assistant message, got role={role!r}"
+                )
+            tool_use_id = block.get("id")
+            if not tool_use_id:
+                raise CatalogError(f"Anthropic tool_use block at [{msg_idx}][{b_idx}] missing 'id'")
+            tool_name = block.get("name", "")
+            input_payload = block.get("input", {})
+            try:
+                args_str = json.dumps(input_payload, sort_keys=True)
+            except (TypeError, ValueError) as exc:
+                raise CatalogError(
+                    f"Anthropic tool_use.input at [{msg_idx}][{b_idx}] is not JSON-"
+                    f"serialisable: {exc}"
+                ) from exc
+            meta = {
+                **base_meta,
+                "tool_use_id": tool_use_id,
+                "function_name": tool_name,
+                "input": input_payload,
+            }
+            out.append(
+                ContextItem(
+                    id=f"{_PREFIX_TOOL_USE}{tool_use_id}",
+                    kind=ItemKind.tool_call,
+                    text=args_str,
+                    metadata=meta,
+                )
+            )
+        elif block_type == "tool_result":
+            if role != "user":
+                raise CatalogError(
+                    f"tool_result block at [{msg_idx}][{b_idx}] must be on a "
+                    f"user message, got role={role!r}"
+                )
+            tool_use_id = block.get("tool_use_id")
+            if not tool_use_id:
+                raise CatalogError(
+                    f"Anthropic tool_result block at [{msg_idx}][{b_idx}] missing 'tool_use_id'"
+                )
+            text, content_for_meta = _stringify_tool_result_content(block.get("content"))
+            meta = {
+                **base_meta,
+                "tool_use_id": tool_use_id,
+                "is_error": bool(block.get("is_error", False)),
+                "content_payload": content_for_meta,
+            }
+            out.append(
+                ContextItem(
+                    id=f"{_PREFIX_TOOL_RESULT}{tool_use_id}",
+                    kind=ItemKind.tool_result,
+                    text=text,
+                    metadata=meta,
+                    parent_id=f"{_PREFIX_TOOL_USE}{tool_use_id}",
+                )
+            )
+        else:
+            raise CatalogError(
+                f"Anthropic content block at [{msg_idx}][{b_idx}] has unsupported "
+                f"type: {block_type!r}"
+            )
+    return out
+
+
+def _stringify_tool_result_content(
+    content: Any,  # noqa: ANN401 — content is opaque provider JSON
+) -> tuple[str, Any]:
+    """Reduce a tool_result.content payload to a string for ``ContextItem.text``.
+
+    Returns a ``(text, original_content)`` tuple — the original is stashed
+    in metadata so the inverse adapter can re-emit the exact same shape.
+    """
+    if content is None:
+        return "", None
+    if isinstance(content, str):
+        return content, content
+    if isinstance(content, list):
+        text_parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                text_parts.append(str(part.get("text", "")))
+            else:
+                text_parts.append(json.dumps(part, sort_keys=True))
+        return "\n".join(text_parts), content
+    # Numbers, bools — coerce to string and store the original for round-trip.
+    return str(content), content
+
+
+# ---------------------------------------------------------------------------
+# Encoding (items → messages)
+# ---------------------------------------------------------------------------
+
+
+def _block_index_sort_key(item: ContextItem) -> int:
+    """Return the original block index (or 0) for stable per-group ordering."""
+    meta = item.metadata or {}
+    block_idx = meta.get("block_index", 0)
+    try:
+        return int(block_idx)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _item_to_block(item: ContextItem) -> dict[str, Any]:
+    """Convert a single ContextItem back into an Anthropic content block."""
+    meta = item.metadata or {}
+    block_type = meta.get("block_type")
+    if block_type == "text":
+        return {"type": "text", "text": item.text}
+    if block_type == "tool_use":
+        tool_use_id = meta.get("tool_use_id")
+        if not tool_use_id:
+            raise CatalogError(f"tool_call item {item.id!r} missing 'tool_use_id' metadata")
+        return {
+            "type": "tool_use",
+            "id": tool_use_id,
+            "name": meta.get("function_name", ""),
+            "input": meta.get("input", {}),
+        }
+    if block_type == "tool_result":
+        tool_use_id = meta.get("tool_use_id")
+        if not tool_use_id:
+            raise CatalogError(f"tool_result item {item.id!r} missing 'tool_use_id' metadata")
+        block: dict[str, Any] = {
+            "type": "tool_result",
+            "tool_use_id": tool_use_id,
+        }
+        # Preserve the original content shape: string vs list vs missing.
+        content_payload = meta.get("content_payload")
+        if content_payload is not None:
+            block["content"] = content_payload
+        if meta.get("is_error"):
+            block["is_error"] = True
+        return block
+    # Fallback for items that were assembled without the round-trip metadata
+    # (e.g., constructed by hand). Emit as a plain text block carrying the
+    # item's text so the message remains valid Anthropic input.
+    return {"type": "text", "text": item.text}

--- a/src/contextweaver/adapters/anthropic_messages.py
+++ b/src/contextweaver/adapters/anthropic_messages.py
@@ -32,39 +32,36 @@ Mapping (see ``AGENTS.md`` for the full ``ItemKind`` map):
 
 System prompts (top-level API param, not a message) are out of scope.
 
+The decoder helpers live in :mod:`._anthropic_decode` and the encoder
+helpers in :mod:`._anthropic_encode` to keep this public surface focused
+and within the repo's ≤300-line module guideline.
+
 Issue #222 (closes #194 together with the OpenAI slice #219).
 """
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from contextweaver.adapters._anthropic_decode import (
+    _blocks_to_items,
+    _normalise_content,
+)
+from contextweaver.adapters._anthropic_encode import _block_index_sort_key, _item_to_block
 from contextweaver.adapters._messages_common import (
     expect_dict,
     expect_list,
     group_items_by_msg_index,
     ingest_into_manager,
-    json_args_dumps,
-    sort_key_by_meta_index,
 )
 from contextweaver.exceptions import CatalogError
-from contextweaver.types import ContextItem, ItemKind
+from contextweaver.types import ContextItem
 
 if TYPE_CHECKING:
     from contextweaver.context.manager import ContextManager
 
 logger = logging.getLogger("contextweaver.adapters")
-
-
-_PREFIX_USER = "anthropic:user:"
-_PREFIX_ASSISTANT = "anthropic:assistant:"
-_PREFIX_TOOL_USE = "anthropic:tool_use:"
-_PREFIX_TOOL_RESULT = "anthropic:tool_result:"
-
-
-# --- Public: from_anthropic_messages ---
 
 
 def from_anthropic_messages(
@@ -112,9 +109,6 @@ def from_anthropic_messages(
     return items
 
 
-# --- Public: to_anthropic_messages ---
-
-
 def to_anthropic_messages(items: list[ContextItem]) -> list[dict[str, Any]]:
     """Inverse of :func:`from_anthropic_messages`.
 
@@ -150,224 +144,3 @@ def to_anthropic_messages(items: list[ContextItem]) -> list[dict[str, Any]]:
         else:
             out.append({"role": role, "content": blocks})
     return out
-
-
-# --- Decoding (messages → items) ---
-
-
-def _normalise_content(
-    content: Any,  # noqa: ANN401 — content is opaque provider JSON
-    idx: int,
-    role: str,
-) -> list[dict[str, Any]]:
-    """Coerce the ``content`` field to a list of content blocks."""
-    if content is None:
-        return []
-    if isinstance(content, str):
-        return [{"type": "text", "text": content}]
-    if isinstance(content, list):
-        for b_idx, block in enumerate(content):
-            expect_dict(block, label=f"Anthropic content block [{idx}][{b_idx}]")
-        return list(content)
-    raise CatalogError(
-        f"Anthropic {role} message at index {idx} has unsupported content type: "
-        f"{type(content).__name__}"
-    )
-
-
-def _blocks_to_items(
-    blocks: list[dict[str, Any]],
-    msg_idx: int,
-    role: str,
-    was_string_shorthand: bool,
-    seen_tool_use_ids: set[str],
-) -> list[ContextItem]:
-    """Convert a normalised content-block list into one or more items."""
-    out: list[ContextItem] = []
-    for b_idx, block in enumerate(blocks):
-        block_type = block.get("type")
-        base_meta: dict[str, Any] = {
-            "role": role,
-            "msg_index": msg_idx,
-            "block_index": b_idx,
-            "block_type": block_type,
-            # Only meaningful when this group has a single text block; we
-            # tag every block so the inverse adapter sees it on group[0].
-            "was_string_shorthand": was_string_shorthand,
-            # Preserve the full original block so the inverse adapter can
-            # re-emit unknown provider fields (e.g. `cache_control`) and
-            # distinguish an explicit `is_error: False` from a missing one
-            # (PR #230 review).
-            "original_block": block,
-        }
-        if block_type == "text":
-            text = str(block.get("text", ""))
-            kind = ItemKind.user_turn if role == "user" else ItemKind.agent_msg
-            prefix = _PREFIX_USER if role == "user" else _PREFIX_ASSISTANT
-            out.append(
-                ContextItem(
-                    id=f"{prefix}{msg_idx}:{b_idx}",
-                    kind=kind,
-                    text=text,
-                    metadata=base_meta,
-                )
-            )
-        elif block_type == "tool_use":
-            if role != "assistant":
-                raise CatalogError(
-                    f"tool_use block at [{msg_idx}][{b_idx}] must be on an "
-                    f"assistant message, got role={role!r}"
-                )
-            tool_use_id = block.get("id")
-            if not tool_use_id:
-                raise CatalogError(f"Anthropic tool_use block at [{msg_idx}][{b_idx}] missing 'id'")
-            tool_name = block.get("name", "")
-            input_payload = block.get("input", {})
-            args_str = json_args_dumps(
-                input_payload, label=f"Anthropic tool_use.input at [{msg_idx}][{b_idx}]"
-            )
-            meta = {
-                **base_meta,
-                "tool_use_id": tool_use_id,
-                "function_name": tool_name,
-                "input": input_payload,
-            }
-            out.append(
-                ContextItem(
-                    id=f"{_PREFIX_TOOL_USE}{tool_use_id}",
-                    kind=ItemKind.tool_call,
-                    text=args_str,
-                    metadata=meta,
-                )
-            )
-            seen_tool_use_ids.add(tool_use_id)
-        elif block_type == "tool_result":
-            if role != "user":
-                raise CatalogError(
-                    f"tool_result block at [{msg_idx}][{b_idx}] must be on a "
-                    f"user message, got role={role!r}"
-                )
-            tool_use_id = block.get("tool_use_id")
-            if not tool_use_id:
-                raise CatalogError(
-                    f"Anthropic tool_result block at [{msg_idx}][{b_idx}] missing 'tool_use_id'"
-                )
-            if tool_use_id not in seen_tool_use_ids:
-                # Mirrors the openai_messages orphan-tool-result check
-                # and the gemini_contents FIFO check (PR #230 review).
-                raise CatalogError(
-                    f"Anthropic tool_result block at [{msg_idx}][{b_idx}] has "
-                    f"tool_use_id={tool_use_id!r} that does not match any prior "
-                    "assistant tool_use block"
-                )
-            text, content_for_meta = _stringify_tool_result_content(block.get("content"))
-            meta = {
-                **base_meta,
-                "tool_use_id": tool_use_id,
-                "is_error": bool(block.get("is_error", False)),
-                # Preserve whether is_error was *present* in the original
-                # block (vs. defaulted) so we can re-emit explicit False.
-                "is_error_present": "is_error" in block,
-                "content_payload": content_for_meta,
-            }
-            out.append(
-                ContextItem(
-                    id=f"{_PREFIX_TOOL_RESULT}{tool_use_id}",
-                    kind=ItemKind.tool_result,
-                    text=text,
-                    metadata=meta,
-                    parent_id=f"{_PREFIX_TOOL_USE}{tool_use_id}",
-                )
-            )
-        else:
-            raise CatalogError(
-                f"Anthropic content block at [{msg_idx}][{b_idx}] has unsupported "
-                f"type: {block_type!r}"
-            )
-    return out
-
-
-def _stringify_tool_result_content(
-    content: Any,  # noqa: ANN401 — content is opaque provider JSON
-) -> tuple[str, Any]:
-    """Reduce a tool_result.content payload to a string for ``ContextItem.text``.
-
-    Returns a ``(text, original_content)`` tuple — the original is stashed
-    in metadata so the inverse adapter can re-emit the exact same shape.
-    """
-    if content is None:
-        return "", None
-    if isinstance(content, str):
-        return content, content
-    if isinstance(content, list):
-        text_parts: list[str] = []
-        for part in content:
-            if isinstance(part, dict) and part.get("type") == "text":
-                text_parts.append(str(part.get("text", "")))
-            else:
-                text_parts.append(json.dumps(part, sort_keys=True))
-        return "\n".join(text_parts), content
-    # Numbers, bools — coerce to string and store the original for round-trip.
-    return str(content), content
-
-
-# --- Encoding (items → messages) ---
-
-
-_block_index_sort_key = sort_key_by_meta_index("block_index")
-
-
-def _item_to_block(item: ContextItem) -> dict[str, Any]:
-    """Convert a single ContextItem back into an Anthropic content block.
-
-    Starts from the original decoded block (so unknown provider fields like
-    ``cache_control`` survive the round-trip) and overlays the canonical
-    decoded fields. Falls back to a constructed block when no original is
-    available (hand-constructed items).
-    """
-    meta = item.metadata or {}
-    block_type = meta.get("block_type")
-    original_block = meta.get("original_block")
-    # When original_block is present, start from a copy and overlay the
-    # canonical decoded fields. This preserves unknown / non-decoded keys
-    # (e.g. cache_control, citations) verbatim.
-    block: dict[str, Any] = dict(original_block) if isinstance(original_block, dict) else {}
-
-    if block_type == "text":
-        block["type"] = "text"
-        block["text"] = item.text
-        return block
-    if block_type == "tool_use":
-        tool_use_id = meta.get("tool_use_id")
-        if not tool_use_id:
-            raise CatalogError(f"tool_call item {item.id!r} missing 'tool_use_id' metadata")
-        block["type"] = "tool_use"
-        block["id"] = tool_use_id
-        block["name"] = meta.get("function_name", "")
-        block["input"] = meta.get("input", {})
-        return block
-    if block_type == "tool_result":
-        tool_use_id = meta.get("tool_use_id")
-        if not tool_use_id:
-            raise CatalogError(f"tool_result item {item.id!r} missing 'tool_use_id' metadata")
-        block["type"] = "tool_result"
-        block["tool_use_id"] = tool_use_id
-        # Preserve the original content shape: string vs list vs missing.
-        content_payload = meta.get("content_payload")
-        if content_payload is not None:
-            block["content"] = content_payload
-        elif "content" in block:
-            # Original block had no content; ensure we don't accidentally
-            # keep a content key from the original_block snapshot.
-            del block["content"]
-        # is_error: re-emit only if it was present in the original block.
-        # Preserves explicit `is_error: False` and omits when absent.
-        if meta.get("is_error_present"):
-            block["is_error"] = bool(meta.get("is_error", False))
-        else:
-            block.pop("is_error", None)
-        return block
-    # Fallback for items that were assembled without the round-trip metadata
-    # (e.g., constructed by hand). Emit as a plain text block carrying the
-    # item's text so the message remains valid Anthropic input.
-    return {"type": "text", "text": item.text}

--- a/src/contextweaver/adapters/gemini_contents.py
+++ b/src/contextweaver/adapters/gemini_contents.py
@@ -1,0 +1,327 @@
+"""Google Gemini ``contents``-array adapter for contextweaver.
+
+Bridges the Google Gemini API ``contents[]`` schema and contextweaver's
+:class:`~contextweaver.types.ContextItem` event log:
+
+.. code-block:: python
+
+    from contextweaver.context.manager import ContextManager
+    from contextweaver.adapters.gemini_contents import from_gemini_contents
+
+    mgr = ContextManager()
+    from_gemini_contents(contents, into=mgr)
+
+The adapter is a pure stateless converter — no provider SDK is imported
+at module load time (per the ``adapters/`` path convention). Operate on
+plain ``dict``s following the documented Gemini JSON schema.
+
+Gemini's native shape differs from OpenAI's and Anthropic's:
+
+- Top-level is a list of ``Content`` objects (``contents[]``), each with
+  ``role`` and ``parts[]``.
+- Roles are ``"user"`` and ``"model"`` (not ``"assistant"``). Tool
+  responses use the synthetic role ``"function"`` per the SDK.
+- Each ``Part`` is one of: ``text``, ``functionCall``, ``functionResponse``,
+  ``inlineData`` (skipped), ``fileData`` (skipped).
+- **There is no native ID** on ``functionCall`` — we synthesise a
+  deterministic one as ``"<name>:<msg_index>:<part_index>"`` so the
+  inverse adapter is reproducible.
+
+Mapping rules:
+
+- ``role="user"`` ``text`` part → :data:`ItemKind.user_turn`
+- ``role="model"`` ``text`` part → :data:`ItemKind.agent_msg`
+- ``role="model"`` ``functionCall`` part → :data:`ItemKind.tool_call`
+- ``role="function"`` ``functionResponse`` part → :data:`ItemKind.tool_result`
+  with ``parent_id`` set to the matching ``functionCall``'s synthetic id.
+
+Issue #222 (closes #194 together with the OpenAI slice #219 and the
+Anthropic adapter).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from contextweaver.exceptions import CatalogError
+from contextweaver.types import ContextItem, ItemKind
+
+if TYPE_CHECKING:
+    from contextweaver.context.manager import ContextManager
+
+logger = logging.getLogger("contextweaver.adapters")
+
+_PREFIX_USER = "gemini:user:"
+_PREFIX_MODEL = "gemini:model:"
+_PREFIX_FUNCTION_CALL = "gemini:functionCall:"
+_PREFIX_FUNCTION_RESPONSE = "gemini:functionResponse:"
+
+
+# ---------------------------------------------------------------------------
+# Public: from_gemini_contents
+# ---------------------------------------------------------------------------
+
+
+def from_gemini_contents(
+    contents: list[dict[str, Any]],
+    into: ContextManager | None = None,
+) -> list[ContextItem]:
+    """Convert a Gemini ``contents`` array into ContextItems.
+
+    Args:
+        contents: A list of Gemini ``Content`` dicts. Each must have
+            ``role`` and ``parts`` (a list of part dicts).
+        into: Optional :class:`~contextweaver.context.manager.ContextManager`.
+            When provided, each returned item is appended via
+            :meth:`ContextManager.ingest` in order.
+
+    Returns:
+        A list of :class:`ContextItem` in input order. Multi-part contents
+        expand into multiple items; the part index is stored in
+        ``metadata["part_index"]`` so the inverse adapter can rebuild the
+        original ``parts`` order.
+
+    Raises:
+        CatalogError: On unknown role, unknown part type, malformed input,
+            or a ``functionResponse`` whose ``name`` does not match a prior
+            ``functionCall``.
+    """
+    if not isinstance(contents, list):
+        raise CatalogError(f"from_gemini_contents expects a list, got {type(contents).__name__}")
+
+    items: list[ContextItem] = []
+    # name → list of synthesised IDs from prior functionCalls (FIFO). When a
+    # functionResponse arrives with role="function", it pops the oldest unmatched
+    # functionCall with the same `name` to set parent_id. This matches Gemini's
+    # convention of pairing function calls and responses by name in order.
+    pending_calls: dict[str, list[str]] = {}
+
+    for msg_idx, content in enumerate(contents):
+        if not isinstance(content, dict):
+            raise CatalogError(
+                f"Gemini content at index {msg_idx} is not a dict: {type(content).__name__}"
+            )
+        role = content.get("role")
+        if role not in ("user", "model", "function"):
+            raise CatalogError(f"Gemini content at index {msg_idx} has unknown role: {role!r}")
+        parts = content.get("parts")
+        if not isinstance(parts, list):
+            raise CatalogError(
+                f"Gemini content at index {msg_idx} has non-list parts: {type(parts).__name__}"
+            )
+        for p_idx, part in enumerate(parts):
+            if not isinstance(part, dict):
+                raise CatalogError(
+                    f"Gemini part at [{msg_idx}][{p_idx}] is not a dict: {type(part).__name__}"
+                )
+            items.append(_part_to_item(part, role, msg_idx, p_idx, pending_calls))
+
+    if into is not None:
+        for item in items:
+            into.ingest(item)
+
+    logger.debug("from_gemini_contents: contents_in=%d, items_out=%d", len(contents), len(items))
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Public: to_gemini_contents
+# ---------------------------------------------------------------------------
+
+
+def to_gemini_contents(items: list[ContextItem]) -> list[dict[str, Any]]:
+    """Inverse of :func:`from_gemini_contents`.
+
+    Re-groups items by ``metadata["msg_index"]`` and emits their parts in
+    original ``part_index`` order. Functions calls and responses are placed
+    under the original role of their parent content.
+
+    Args:
+        items: Items produced by :func:`from_gemini_contents`.
+
+    Returns:
+        A list of Gemini content dicts.
+
+    Raises:
+        CatalogError: If items lack the required round-trip metadata.
+    """
+    groups: dict[int, list[ContextItem]] = {}
+    for item in items:
+        meta = item.metadata or {}
+        msg_idx = meta.get("msg_index")
+        if msg_idx is None:
+            raise CatalogError(
+                f"ContextItem {item.id!r} missing 'msg_index' metadata; cannot "
+                "round-trip back to Gemini contents"
+            )
+        groups.setdefault(int(msg_idx), []).append(item)
+
+    out: list[dict[str, Any]] = []
+    for msg_idx in sorted(groups):
+        group = sorted(groups[msg_idx], key=_part_index_sort_key)
+        first_meta = group[0].metadata or {}
+        role = first_meta.get("role")
+        if role not in ("user", "model", "function"):
+            raise CatalogError(f"ContextItem group msg_index={msg_idx} has invalid role={role!r}")
+        parts = [_item_to_part(item) for item in group]
+        out.append({"role": role, "parts": parts})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Decoders
+# ---------------------------------------------------------------------------
+
+
+def _part_to_item(
+    part: dict[str, Any],
+    role: str,
+    msg_idx: int,
+    p_idx: int,
+    pending_calls: dict[str, list[str]],
+) -> ContextItem:
+    base_meta: dict[str, Any] = {
+        "role": role,
+        "msg_index": msg_idx,
+        "part_index": p_idx,
+    }
+    if "text" in part:
+        base_meta["part_type"] = "text"
+        text = str(part.get("text", ""))
+        if role == "user":
+            kind = ItemKind.user_turn
+            prefix = _PREFIX_USER
+        elif role == "model":
+            kind = ItemKind.agent_msg
+            prefix = _PREFIX_MODEL
+        else:
+            # role="function" with a text part is exotic; preserve as agent_msg
+            # so the round-trip is lossless.
+            kind = ItemKind.agent_msg
+            prefix = _PREFIX_MODEL
+        return ContextItem(
+            id=f"{prefix}{msg_idx}:{p_idx}",
+            kind=kind,
+            text=text,
+            metadata=base_meta,
+        )
+    if "functionCall" in part:
+        if role != "model":
+            raise CatalogError(
+                f"Gemini functionCall at [{msg_idx}][{p_idx}] must be on a "
+                f"'model' content, got role={role!r}"
+            )
+        fc = part["functionCall"]
+        if not isinstance(fc, dict):
+            raise CatalogError(f"Gemini functionCall at [{msg_idx}][{p_idx}] is not a dict")
+        name = fc.get("name")
+        if not isinstance(name, str) or not name:
+            raise CatalogError(f"Gemini functionCall at [{msg_idx}][{p_idx}] missing 'name'")
+        # Synthesise a deterministic ID. Gemini doesn't ship one natively;
+        # name + position is reproducible and survives the round-trip.
+        synthesised_id = f"{name}:{msg_idx}:{p_idx}"
+        pending_calls.setdefault(name, []).append(synthesised_id)
+        args = fc.get("args", {})
+        try:
+            args_str = json.dumps(args, sort_keys=True)
+        except (TypeError, ValueError) as exc:
+            raise CatalogError(
+                f"Gemini functionCall.args at [{msg_idx}][{p_idx}] is not JSON-serialisable: {exc}"
+            ) from exc
+        meta = {
+            **base_meta,
+            "part_type": "functionCall",
+            "function_name": name,
+            "function_call_id": synthesised_id,
+            "args": args,
+        }
+        return ContextItem(
+            id=f"{_PREFIX_FUNCTION_CALL}{synthesised_id}",
+            kind=ItemKind.tool_call,
+            text=args_str,
+            metadata=meta,
+        )
+    if "functionResponse" in part:
+        if role != "function":
+            raise CatalogError(
+                f"Gemini functionResponse at [{msg_idx}][{p_idx}] must be on a "
+                f"'function' content, got role={role!r}"
+            )
+        fr = part["functionResponse"]
+        if not isinstance(fr, dict):
+            raise CatalogError(f"Gemini functionResponse at [{msg_idx}][{p_idx}] is not a dict")
+        name = fr.get("name")
+        if not isinstance(name, str) or not name:
+            raise CatalogError(f"Gemini functionResponse at [{msg_idx}][{p_idx}] missing 'name'")
+        queue = pending_calls.get(name) or []
+        if not queue:
+            raise CatalogError(
+                f"Gemini functionResponse at [{msg_idx}][{p_idx}] for name={name!r} "
+                "has no matching prior functionCall"
+            )
+        # FIFO: match the oldest unanswered call with this name.
+        matched_call_id = queue.pop(0)
+        if not queue:
+            pending_calls.pop(name, None)
+        response = fr.get("response", {})
+        try:
+            response_str = json.dumps(response, sort_keys=True)
+        except (TypeError, ValueError) as exc:
+            raise CatalogError(
+                f"Gemini functionResponse.response at [{msg_idx}][{p_idx}] is "
+                f"not JSON-serialisable: {exc}"
+            ) from exc
+        meta = {
+            **base_meta,
+            "part_type": "functionResponse",
+            "function_name": name,
+            "function_call_id": matched_call_id,
+            "response": response,
+        }
+        return ContextItem(
+            id=f"{_PREFIX_FUNCTION_RESPONSE}{matched_call_id}",
+            kind=ItemKind.tool_result,
+            text=response_str,
+            metadata=meta,
+            parent_id=f"{_PREFIX_FUNCTION_CALL}{matched_call_id}",
+        )
+    raise CatalogError(
+        f"Gemini part at [{msg_idx}][{p_idx}] has no recognised content "
+        f"(text / functionCall / functionResponse); got keys {list(part.keys())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Encoders
+# ---------------------------------------------------------------------------
+
+
+def _part_index_sort_key(item: ContextItem) -> int:
+    meta = item.metadata or {}
+    part_idx = meta.get("part_index", 0)
+    try:
+        return int(part_idx)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _item_to_part(item: ContextItem) -> dict[str, Any]:
+    meta = item.metadata or {}
+    part_type = meta.get("part_type")
+    if part_type == "text":
+        return {"text": item.text}
+    if part_type == "functionCall":
+        name = meta.get("function_name")
+        if not name:
+            raise CatalogError(f"tool_call item {item.id!r} missing 'function_name' metadata")
+        return {"functionCall": {"name": name, "args": meta.get("args", {})}}
+    if part_type == "functionResponse":
+        name = meta.get("function_name")
+        if not name:
+            raise CatalogError(f"tool_result item {item.id!r} missing 'function_name' metadata")
+        return {"functionResponse": {"name": name, "response": meta.get("response", {})}}
+    # Fallback: round-trip what we can as a text part so the message stays
+    # valid Gemini input.
+    return {"text": item.text}

--- a/src/contextweaver/adapters/gemini_contents.py
+++ b/src/contextweaver/adapters/gemini_contents.py
@@ -44,10 +44,17 @@ Anthropic adapter).
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from contextweaver.adapters._messages_common import (
+    expect_dict,
+    expect_list,
+    group_items_by_msg_index,
+    ingest_into_manager,
+    json_args_dumps,
+    sort_key_by_meta_index,
+)
 from contextweaver.exceptions import CatalogError
 from contextweaver.types import ContextItem, ItemKind
 
@@ -91,8 +98,7 @@ def from_gemini_contents(
             or a ``functionResponse`` whose ``name`` does not match a prior
             ``functionCall``.
     """
-    if not isinstance(contents, list):
-        raise CatalogError(f"from_gemini_contents expects a list, got {type(contents).__name__}")
+    expect_list(contents, fn_name="from_gemini_contents")
 
     items: list[ContextItem] = []
     # name → list of synthesised IDs from prior functionCalls (FIFO). When a
@@ -102,10 +108,7 @@ def from_gemini_contents(
     pending_calls: dict[str, list[str]] = {}
 
     for msg_idx, content in enumerate(contents):
-        if not isinstance(content, dict):
-            raise CatalogError(
-                f"Gemini content at index {msg_idx} is not a dict: {type(content).__name__}"
-            )
+        expect_dict(content, label=f"Gemini content at index {msg_idx}")
         role = content.get("role")
         if role not in ("user", "model", "function"):
             raise CatalogError(f"Gemini content at index {msg_idx} has unknown role: {role!r}")
@@ -115,16 +118,10 @@ def from_gemini_contents(
                 f"Gemini content at index {msg_idx} has non-list parts: {type(parts).__name__}"
             )
         for p_idx, part in enumerate(parts):
-            if not isinstance(part, dict):
-                raise CatalogError(
-                    f"Gemini part at [{msg_idx}][{p_idx}] is not a dict: {type(part).__name__}"
-                )
+            expect_dict(part, label=f"Gemini part at [{msg_idx}][{p_idx}]")
             items.append(_part_to_item(part, role, msg_idx, p_idx, pending_calls))
 
-    if into is not None:
-        for item in items:
-            into.ingest(item)
-
+    ingest_into_manager(items, into)
     logger.debug("from_gemini_contents: contents_in=%d, items_out=%d", len(contents), len(items))
     return items
 
@@ -150,16 +147,7 @@ def to_gemini_contents(items: list[ContextItem]) -> list[dict[str, Any]]:
     Raises:
         CatalogError: If items lack the required round-trip metadata.
     """
-    groups: dict[int, list[ContextItem]] = {}
-    for item in items:
-        meta = item.metadata or {}
-        msg_idx = meta.get("msg_index")
-        if msg_idx is None:
-            raise CatalogError(
-                f"ContextItem {item.id!r} missing 'msg_index' metadata; cannot "
-                "round-trip back to Gemini contents"
-            )
-        groups.setdefault(int(msg_idx), []).append(item)
+    groups = group_items_by_msg_index(items, target_label="Gemini contents")
 
     out: list[dict[str, Any]] = []
     for msg_idx in sorted(groups):
@@ -173,9 +161,7 @@ def to_gemini_contents(items: list[ContextItem]) -> list[dict[str, Any]]:
     return out
 
 
-# ---------------------------------------------------------------------------
-# Decoders
-# ---------------------------------------------------------------------------
+# --- Decoders ---
 
 
 def _part_to_item(
@@ -227,12 +213,7 @@ def _part_to_item(
         synthesised_id = f"{name}:{msg_idx}:{p_idx}"
         pending_calls.setdefault(name, []).append(synthesised_id)
         args = fc.get("args", {})
-        try:
-            args_str = json.dumps(args, sort_keys=True)
-        except (TypeError, ValueError) as exc:
-            raise CatalogError(
-                f"Gemini functionCall.args at [{msg_idx}][{p_idx}] is not JSON-serialisable: {exc}"
-            ) from exc
+        args_str = json_args_dumps(args, label=f"Gemini functionCall.args at [{msg_idx}][{p_idx}]")
         meta = {
             **base_meta,
             "part_type": "functionCall",
@@ -269,13 +250,9 @@ def _part_to_item(
         if not queue:
             pending_calls.pop(name, None)
         response = fr.get("response", {})
-        try:
-            response_str = json.dumps(response, sort_keys=True)
-        except (TypeError, ValueError) as exc:
-            raise CatalogError(
-                f"Gemini functionResponse.response at [{msg_idx}][{p_idx}] is "
-                f"not JSON-serialisable: {exc}"
-            ) from exc
+        response_str = json_args_dumps(
+            response, label=f"Gemini functionResponse.response at [{msg_idx}][{p_idx}]"
+        )
         meta = {
             **base_meta,
             "part_type": "functionResponse",
@@ -296,18 +273,10 @@ def _part_to_item(
     )
 
 
-# ---------------------------------------------------------------------------
-# Encoders
-# ---------------------------------------------------------------------------
+# --- Encoders ---
 
 
-def _part_index_sort_key(item: ContextItem) -> int:
-    meta = item.metadata or {}
-    part_idx = meta.get("part_index", 0)
-    try:
-        return int(part_idx)
-    except (TypeError, ValueError):
-        return 0
+_part_index_sort_key = sort_key_by_meta_index("part_index")
 
 
 def _item_to_part(item: ContextItem) -> dict[str, Any]:

--- a/src/contextweaver/adapters/gemini_contents.py
+++ b/src/contextweaver/adapters/gemini_contents.py
@@ -21,8 +21,11 @@ Gemini's native shape differs from OpenAI's and Anthropic's:
   ``role`` and ``parts[]``.
 - Roles are ``"user"`` and ``"model"`` (not ``"assistant"``). Tool
   responses use the synthetic role ``"function"`` per the SDK.
-- Each ``Part`` is one of: ``text``, ``functionCall``, ``functionResponse``,
-  ``inlineData`` (skipped), ``fileData`` (skipped).
+- Supported ``Part`` types: ``text``, ``functionCall``, ``functionResponse``.
+  Multimodal parts (``inlineData``, ``fileData``, etc.) are **not yet
+  supported** — the decoder raises :class:`CatalogError` rather than
+  silently dropping them, so callers know multimodal histories need a
+  preprocessing step before ingestion.
 - **There is no native ID** on ``functionCall`` — we synthesise a
   deterministic one as ``"<name>:<msg_index>:<part_index>"`` so the
   inverse adapter is reproducible.

--- a/src/contextweaver/adapters/openai_messages.py
+++ b/src/contextweaver/adapters/openai_messages.py
@@ -94,6 +94,11 @@ def from_openai_messages(
     if not isinstance(messages, list):
         raise CatalogError(f"from_openai_messages expects a list, got {type(messages).__name__}")
 
+    # Track tool_call_ids announced by prior assistant messages so a
+    # subsequent role="tool" entry must reference one of them. Without
+    # this check, an orphan tool result would leave a dangling parent_id
+    # pointing at a non-existent ContextItem (PR #230 review).
+    seen_tool_call_ids: set[str] = set()
     items: list[ContextItem] = []
     for idx, msg in enumerate(messages):
         if not isinstance(msg, dict):
@@ -104,9 +109,9 @@ def from_openai_messages(
         elif role == "user":
             items.append(_from_user(msg, idx))
         elif role == "assistant":
-            items.extend(_from_assistant(msg, idx))
+            items.extend(_from_assistant(msg, idx, seen_tool_call_ids))
         elif role == "tool":
-            items.append(_from_tool(msg, idx))
+            items.append(_from_tool(msg, idx, seen_tool_call_ids))
         else:
             raise CatalogError(f"OpenAI message at index {idx} has unknown role: {role!r}")
 
@@ -157,7 +162,12 @@ def to_openai_messages(items: list[ContextItem]) -> list[dict[str, Any]]:
             # Walk forward and collect any directly-adjacent tool_call items
             # that originated from this assistant turn.
             tool_calls = _collect_assistant_tool_calls(items, i + 1)
-            msg: dict[str, Any] = {"role": "assistant", "content": item.text or None}
+            meta = item.metadata or {}
+            # Use stored metadata to distinguish content=None / "" / list-of-
+            # parts at decode time. Without this, all three collapse to None
+            # (or to a str) on the round-trip (PR #230 review).
+            content_value = _restore_assistant_content(item, meta)
+            msg: dict[str, Any] = {"role": "assistant", "content": content_value}
             if tool_calls:
                 msg["tool_calls"] = [tc["payload"] for tc in tool_calls]
                 # Advance past the agent_msg AND the tool_call items we just
@@ -216,12 +226,18 @@ def _from_user(msg: dict[str, Any], idx: int) -> ContextItem:
     )
 
 
-def _from_assistant(msg: dict[str, Any], idx: int) -> list[ContextItem]:
+def _from_assistant(
+    msg: dict[str, Any], idx: int, seen_tool_call_ids: set[str]
+) -> list[ContextItem]:
     """Expand an assistant message into agent_msg + N tool_call items."""
     out: list[ContextItem] = []
     raw_content = msg.get("content")
-    # Assistant messages may have content=None when only tool_calls are present.
-    text = "" if raw_content is None else str(raw_content)
+    # Capture whether `content` was a list-of-parts (multimodal input).
+    # When it is, _string_content collapses it to text; we keep the original
+    # so to_openai_messages can re-emit the same list and avoid a lossy
+    # str round-trip (PR #230 review).
+    original_content: Any = raw_content
+    text = "" if raw_content is None else _string_content(msg, idx, "assistant")
     out.append(
         ContextItem(
             id=f"{_PREFIX_ASSISTANT}{idx}",
@@ -231,6 +247,8 @@ def _from_assistant(msg: dict[str, Any], idx: int) -> list[ContextItem]:
                 "role": "assistant",
                 # Preserve None vs "" so to_openai_messages can re-emit None.
                 "content_is_null": raw_content is None,
+                # Preserve list-of-parts content for lossless round-trip.
+                "original_content": original_content,
                 # Tag both agent_msg and its child tool_calls with the same
                 # input index so to_openai_messages can re-associate them.
                 "assistant_idx": idx,
@@ -274,13 +292,22 @@ def _from_assistant(msg: dict[str, Any], idx: int) -> list[ContextItem]:
                 },
             )
         )
+        seen_tool_call_ids.add(tc_id)
     return out
 
 
-def _from_tool(msg: dict[str, Any], idx: int) -> ContextItem:
+def _from_tool(msg: dict[str, Any], idx: int, seen_tool_call_ids: set[str]) -> ContextItem:
     tool_call_id = msg.get("tool_call_id")
     if not tool_call_id:
         raise CatalogError(f"OpenAI tool message at index {idx} missing tool_call_id")
+    if tool_call_id not in seen_tool_call_ids:
+        # The tool_call_id must reference a prior assistant tool_calls entry
+        # so the resulting ContextItem.parent_id points at a real item (PR
+        # #230 review). Mirrors the Gemini adapter's unmatched-response check.
+        raise CatalogError(
+            f"OpenAI tool message at index {idx} has tool_call_id={tool_call_id!r} "
+            "that does not match any prior assistant tool_calls entry"
+        )
     content = _string_content(msg, idx, "tool")
     return ContextItem(
         id=f"{_PREFIX_TOOL_RESULT}{tool_call_id}",
@@ -350,6 +377,29 @@ def _tool_call_payload(item: ContextItem) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
+
+
+def _restore_assistant_content(item: ContextItem, meta: dict[str, Any]) -> Any:  # noqa: ANN401 — provider-shaped JSON
+    """Reconstruct the OpenAI assistant ``content`` field for round-trip.
+
+    Three distinct decoder inputs map to distinct outputs here:
+
+    - ``content`` originally ``None`` → emit ``None`` (uses ``content_is_null``).
+    - ``content`` originally a list of parts → emit the original list
+      (uses ``original_content``).
+    - ``content`` originally a string (including ``""``) → emit ``item.text``.
+
+    Without this restoration, all three would collapse via ``item.text or
+    None`` (PR #230 review).
+    """
+    if meta.get("content_is_null"):
+        return None
+    original = meta.get("original_content")
+    if isinstance(original, list):
+        return original
+    # Strings (including empty) and any non-list originals fall through to
+    # the canonical text the decoder stored.
+    return item.text
 
 
 def _string_content(msg: dict[str, Any], idx: int, role: str) -> str:

--- a/src/contextweaver/adapters/openai_messages.py
+++ b/src/contextweaver/adapters/openai_messages.py
@@ -1,0 +1,380 @@
+"""OpenAI Chat Completions message-array adapter for contextweaver.
+
+Bridges the OpenAI Chat Completions ``messages`` schema and
+contextweaver's :class:`~contextweaver.types.ContextItem` event log.
+Users with an existing OpenAI agent can drop the library in with a single
+call:
+
+.. code-block:: python
+
+    from contextweaver.context.manager import ContextManager
+    from contextweaver.types import Phase
+    from contextweaver.adapters.openai_messages import from_openai_messages
+
+    mgr = ContextManager()
+    from_openai_messages(messages, into=mgr)
+    pack = mgr.build_sync(phase=Phase.answer, query=user_query)
+
+The adapter is a pure stateless converter — no provider SDK is imported
+at module load time (per the ``adapters/`` path convention in
+``AGENTS.md``).  Operate on plain ``dict``s following the documented
+OpenAI Chat Completions JSON schema; Pydantic / OpenAI-SDK callers
+should convert via ``.model_dump()`` before calling.
+
+Mapping rules:
+
+- ``role="system"``    → :data:`ItemKind.policy`
+- ``role="user"``      → :data:`ItemKind.user_turn`
+- ``role="assistant"`` → :data:`ItemKind.agent_msg`
+  (and one :data:`ItemKind.tool_call` per entry in ``tool_calls``)
+- ``role="tool"`` with ``tool_call_id`` → :data:`ItemKind.tool_result`
+  with ``parent_id`` set to the originating ``tool_call_id``.
+
+``tool_call_id`` round-trips to/from ``ContextItem.id`` so
+:func:`to_openai_messages` is the inverse of :func:`from_openai_messages`
+for any well-formed input.
+
+Issue #219 (slice of #194).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from contextweaver.exceptions import CatalogError
+from contextweaver.types import ContextItem, ItemKind
+
+if TYPE_CHECKING:
+    from contextweaver.context.manager import ContextManager
+
+logger = logging.getLogger("contextweaver.adapters")
+
+# ID prefix carries enough information to round-trip the OpenAI message:
+# - "openai:tool_call:<tool_call_id>" → the assistant's tool-call entry
+# - "openai:tool_result:<tool_call_id>" → the matching role="tool" response
+# - "openai:user:<idx>" / "openai:assistant:<idx>" / "openai:system:<idx>" → turn entries
+_PREFIX_TOOL_CALL = "openai:tool_call:"
+_PREFIX_TOOL_RESULT = "openai:tool_result:"
+_PREFIX_USER = "openai:user:"
+_PREFIX_ASSISTANT = "openai:assistant:"
+_PREFIX_SYSTEM = "openai:system:"
+
+
+# ---------------------------------------------------------------------------
+# Public: from_openai_messages
+# ---------------------------------------------------------------------------
+
+
+def from_openai_messages(
+    messages: list[dict[str, Any]],
+    into: ContextManager | None = None,
+) -> list[ContextItem]:
+    """Convert OpenAI Chat Completions messages into ContextItems.
+
+    Args:
+        messages: A list of OpenAI Chat Completions message dicts. Each must
+            have a ``role`` key (``"system"``, ``"user"``, ``"assistant"``,
+            or ``"tool"``). ``content`` may be a plain string or ``None``
+            (assistant messages with only ``tool_calls`` may omit content).
+        into: Optional :class:`~contextweaver.context.manager.ContextManager`
+            instance. When provided, every returned item is appended to the
+            manager's event log via :meth:`ContextManager.ingest` in order.
+
+    Returns:
+        A list of :class:`ContextItem` in input message order.  Assistant
+        messages with ``tool_calls`` expand into one ``agent_msg`` item
+        followed by one ``tool_call`` item per call.
+
+    Raises:
+        CatalogError: If a message is missing required fields, has an
+            unknown role, or a ``role="tool"`` entry omits ``tool_call_id``.
+    """
+    if not isinstance(messages, list):
+        raise CatalogError(f"from_openai_messages expects a list, got {type(messages).__name__}")
+
+    items: list[ContextItem] = []
+    for idx, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            raise CatalogError(f"OpenAI message at index {idx} is not a dict: {type(msg).__name__}")
+        role = msg.get("role")
+        if role == "system":
+            items.append(_from_system(msg, idx))
+        elif role == "user":
+            items.append(_from_user(msg, idx))
+        elif role == "assistant":
+            items.extend(_from_assistant(msg, idx))
+        elif role == "tool":
+            items.append(_from_tool(msg, idx))
+        else:
+            raise CatalogError(f"OpenAI message at index {idx} has unknown role: {role!r}")
+
+    if into is not None:
+        for item in items:
+            into.ingest(item)
+
+    logger.debug("from_openai_messages: messages_in=%d, items_out=%d", len(messages), len(items))
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Public: to_openai_messages
+# ---------------------------------------------------------------------------
+
+
+def to_openai_messages(items: list[ContextItem]) -> list[dict[str, Any]]:
+    """Convert ContextItems back into OpenAI Chat Completions messages.
+
+    Inverse of :func:`from_openai_messages` — for any list produced by
+    ``from_openai_messages(msgs)``, calling ``to_openai_messages(...)`` on
+    it produces a list structurally equal to ``msgs``.
+
+    Tool calls are re-assembled by walking consecutive
+    :data:`ItemKind.agent_msg` + N :data:`ItemKind.tool_call` runs back
+    into a single assistant message with a ``tool_calls`` array.
+
+    Args:
+        items: List of context items, typically produced by
+            :func:`from_openai_messages`.
+
+    Returns:
+        A list of OpenAI Chat Completions message dicts.
+
+    Raises:
+        CatalogError: If a tool_call item lacks the required round-trip
+            metadata (``tool_call_id``, ``function_name``, ``arguments``).
+    """
+    messages: list[dict[str, Any]] = []
+    i = 0
+    while i < len(items):
+        item = items[i]
+        if item.kind is ItemKind.policy:
+            messages.append({"role": "system", "content": item.text})
+        elif item.kind is ItemKind.user_turn:
+            messages.append({"role": "user", "content": item.text})
+        elif item.kind is ItemKind.agent_msg:
+            # Walk forward and collect any directly-adjacent tool_call items
+            # that originated from this assistant turn.
+            tool_calls = _collect_assistant_tool_calls(items, i + 1)
+            msg: dict[str, Any] = {"role": "assistant", "content": item.text or None}
+            if tool_calls:
+                msg["tool_calls"] = [tc["payload"] for tc in tool_calls]
+                # Advance past the agent_msg AND the tool_call items we just
+                # consumed; without this they would be re-emitted as orphans.
+                i += len(tool_calls)
+            messages.append(msg)
+        elif item.kind is ItemKind.tool_call:
+            # Orphan tool_call (no preceding agent_msg from this adapter) —
+            # emit as a standalone assistant message with one tool_call.
+            payload = _tool_call_payload(item)
+            messages.append({"role": "assistant", "content": None, "tool_calls": [payload]})
+        elif item.kind is ItemKind.tool_result:
+            tool_call_id = item.metadata.get("tool_call_id") or _strip_prefix(
+                item.id, _PREFIX_TOOL_RESULT
+            )
+            if not tool_call_id:
+                raise CatalogError(
+                    f"tool_result item {item.id!r} cannot round-trip: missing "
+                    "tool_call_id in metadata and id does not carry the openai prefix"
+                )
+            messages.append({"role": "tool", "tool_call_id": tool_call_id, "content": item.text})
+        else:
+            # Other ItemKind values (doc_snippet, memory_fact, plan_state) are
+            # not produced by from_openai_messages; reject explicitly rather
+            # than silently dropping.
+            raise CatalogError(
+                f"to_openai_messages cannot serialise ContextItem of kind "
+                f"{item.kind.value!r} (id={item.id!r})"
+            )
+        i += 1
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# Per-role decoders
+# ---------------------------------------------------------------------------
+
+
+def _from_system(msg: dict[str, Any], idx: int) -> ContextItem:
+    content = _string_content(msg, idx, "system")
+    return ContextItem(
+        id=f"{_PREFIX_SYSTEM}{idx}",
+        kind=ItemKind.policy,
+        text=content,
+        metadata={"role": "system"},
+    )
+
+
+def _from_user(msg: dict[str, Any], idx: int) -> ContextItem:
+    content = _string_content(msg, idx, "user")
+    return ContextItem(
+        id=f"{_PREFIX_USER}{idx}",
+        kind=ItemKind.user_turn,
+        text=content,
+        metadata={"role": "user"},
+    )
+
+
+def _from_assistant(msg: dict[str, Any], idx: int) -> list[ContextItem]:
+    """Expand an assistant message into agent_msg + N tool_call items."""
+    out: list[ContextItem] = []
+    raw_content = msg.get("content")
+    # Assistant messages may have content=None when only tool_calls are present.
+    text = "" if raw_content is None else str(raw_content)
+    out.append(
+        ContextItem(
+            id=f"{_PREFIX_ASSISTANT}{idx}",
+            kind=ItemKind.agent_msg,
+            text=text,
+            metadata={
+                "role": "assistant",
+                # Preserve None vs "" so to_openai_messages can re-emit None.
+                "content_is_null": raw_content is None,
+                # Tag both agent_msg and its child tool_calls with the same
+                # input index so to_openai_messages can re-associate them.
+                "assistant_idx": idx,
+            },
+        )
+    )
+
+    tool_calls = msg.get("tool_calls") or []
+    if not isinstance(tool_calls, list):
+        raise CatalogError(f"OpenAI assistant message at index {idx} has non-list tool_calls")
+
+    for tc_idx, tc in enumerate(tool_calls):
+        if not isinstance(tc, dict):
+            raise CatalogError(
+                f"OpenAI tool_call at index [{idx}].tool_calls[{tc_idx}] is not a dict"
+            )
+        tc_id = tc.get("id")
+        if not tc_id:
+            raise CatalogError(f"OpenAI tool_call at index [{idx}].tool_calls[{tc_idx}] missing id")
+        fn = tc.get("function") or {}
+        if not isinstance(fn, dict):
+            raise CatalogError(f"OpenAI tool_call {tc_id!r} has non-dict function payload")
+        fn_name = fn.get("name", "")
+        # Arguments are a JSON-encoded string in OpenAI's schema. Preserve
+        # the raw string in text for inspection AND store the parsed args
+        # in metadata so to_openai_messages can re-emit the canonical shape.
+        args_str = fn.get("arguments", "")
+        if not isinstance(args_str, str):
+            args_str = json.dumps(args_str)
+        out.append(
+            ContextItem(
+                id=f"{_PREFIX_TOOL_CALL}{tc_id}",
+                kind=ItemKind.tool_call,
+                text=args_str,
+                metadata={
+                    "tool_call_id": tc_id,
+                    "tool_call_type": tc.get("type", "function"),
+                    "function_name": fn_name,
+                    "arguments": args_str,
+                    "assistant_idx": idx,
+                },
+            )
+        )
+    return out
+
+
+def _from_tool(msg: dict[str, Any], idx: int) -> ContextItem:
+    tool_call_id = msg.get("tool_call_id")
+    if not tool_call_id:
+        raise CatalogError(f"OpenAI tool message at index {idx} missing tool_call_id")
+    content = _string_content(msg, idx, "tool")
+    return ContextItem(
+        id=f"{_PREFIX_TOOL_RESULT}{tool_call_id}",
+        kind=ItemKind.tool_result,
+        text=content,
+        metadata={"role": "tool", "tool_call_id": tool_call_id},
+        parent_id=f"{_PREFIX_TOOL_CALL}{tool_call_id}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# to_openai_messages helpers
+# ---------------------------------------------------------------------------
+
+
+def _collect_assistant_tool_calls(items: list[ContextItem], start: int) -> list[dict[str, Any]]:
+    """Collect tool_call items that follow an assistant agent_msg.
+
+    A tool_call belongs to the immediately-preceding agent_msg iff its
+    ``metadata["assistant_idx"]`` matches the agent_msg's input index. We
+    look at consecutive tool_call items and stop at the first non-match.
+    """
+    out: list[dict[str, Any]] = []
+    if start == 0:
+        return out
+    prev = items[start - 1]
+    if prev.kind is not ItemKind.agent_msg:
+        return out
+    expected_idx = prev.metadata.get("assistant_idx") if prev.metadata else None
+    cursor = start
+    while cursor < len(items):
+        candidate = items[cursor]
+        if candidate.kind is not ItemKind.tool_call:
+            break
+        # Only consume tool_calls that came from this assistant turn.
+        cand_idx = candidate.metadata.get("assistant_idx") if candidate.metadata else None
+        if cand_idx != expected_idx:
+            break
+        out.append({"payload": _tool_call_payload(candidate)})
+        cursor += 1
+    return out
+
+
+def _tool_call_payload(item: ContextItem) -> dict[str, Any]:
+    """Build an OpenAI ``tool_calls[]`` entry from a stored tool_call item."""
+    tool_call_id = item.metadata.get("tool_call_id") if item.metadata else None
+    if not tool_call_id:
+        # Fall back to stripping the prefix; rejects items that weren't
+        # produced by this adapter.
+        tool_call_id = _strip_prefix(item.id, _PREFIX_TOOL_CALL)
+    if not tool_call_id:
+        raise CatalogError(
+            f"tool_call item {item.id!r} cannot round-trip: missing "
+            "tool_call_id metadata and id is not openai-prefixed"
+        )
+    fn_name = item.metadata.get("function_name", "") if item.metadata else ""
+    arguments = item.metadata.get("arguments") if item.metadata else None
+    if arguments is None:
+        arguments = item.text
+    return {
+        "id": tool_call_id,
+        "type": item.metadata.get("tool_call_type", "function") if item.metadata else "function",
+        "function": {"name": fn_name, "arguments": arguments},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _string_content(msg: dict[str, Any], idx: int, role: str) -> str:
+    """Coerce the ``content`` field to a string with a clear error on misuse."""
+    content = msg.get("content")
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    # OpenAI also supports `content` as a list of content parts (vision /
+    # multimodal); we collapse the text parts and preserve unknown blocks
+    # via JSON so callers see *something* rather than silently losing data.
+    if isinstance(content, list):
+        text_parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                text_parts.append(str(part.get("text", "")))
+            else:
+                text_parts.append(json.dumps(part, sort_keys=True))
+        return "\n".join(text_parts)
+    raise CatalogError(
+        f"OpenAI {role} message at index {idx} has unsupported content type: "
+        f"{type(content).__name__}"
+    )
+
+
+def _strip_prefix(value: str, prefix: str) -> str:
+    return value[len(prefix) :] if value.startswith(prefix) else ""

--- a/src/contextweaver/adapters/openai_messages.py
+++ b/src/contextweaver/adapters/openai_messages.py
@@ -1,9 +1,11 @@
 """OpenAI Chat Completions message-array adapter for contextweaver.
 
-Bridges the OpenAI Chat Completions ``messages`` schema and
-contextweaver's :class:`~contextweaver.types.ContextItem` event log.
-Users with an existing OpenAI agent can drop the library in with a single
-call:
+Pure stateless converter between the OpenAI Chat Completions ``messages``
+schema and contextweaver's :class:`~contextweaver.types.ContextItem`
+event log. No provider SDK is imported at module load time (per the
+``adapters/`` path convention in ``AGENTS.md``); operate on plain
+``dict``s following the OpenAI Chat Completions JSON schema. Pydantic /
+OpenAI-SDK callers should convert via ``.model_dump()`` first.
 
 .. code-block:: python
 
@@ -14,12 +16,6 @@ call:
     mgr = ContextManager()
     from_openai_messages(messages, into=mgr)
     pack = mgr.build_sync(phase=Phase.answer, query=user_query)
-
-The adapter is a pure stateless converter — no provider SDK is imported
-at module load time (per the ``adapters/`` path convention in
-``AGENTS.md``).  Operate on plain ``dict``s following the documented
-OpenAI Chat Completions JSON schema; Pydantic / OpenAI-SDK callers
-should convert via ``.model_dump()`` before calling.
 
 Mapping rules:
 
@@ -43,6 +39,12 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from contextweaver.adapters._messages_common import (
+    expect_dict,
+    expect_list,
+    ingest_into_manager,
+    strip_prefix,
+)
 from contextweaver.exceptions import CatalogError
 from contextweaver.types import ContextItem, ItemKind
 
@@ -52,9 +54,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger("contextweaver.adapters")
 
 # ID prefix carries enough information to round-trip the OpenAI message:
-# - "openai:tool_call:<tool_call_id>" → the assistant's tool-call entry
+# - "openai:tool_call:<tool_call_id>"   → the assistant's tool-call entry
 # - "openai:tool_result:<tool_call_id>" → the matching role="tool" response
-# - "openai:user:<idx>" / "openai:assistant:<idx>" / "openai:system:<idx>" → turn entries
+# - "openai:{user,assistant,system}:<idx>" → turn entries
 _PREFIX_TOOL_CALL = "openai:tool_call:"
 _PREFIX_TOOL_RESULT = "openai:tool_result:"
 _PREFIX_USER = "openai:user:"
@@ -62,9 +64,7 @@ _PREFIX_ASSISTANT = "openai:assistant:"
 _PREFIX_SYSTEM = "openai:system:"
 
 
-# ---------------------------------------------------------------------------
-# Public: from_openai_messages
-# ---------------------------------------------------------------------------
+# --- Public: from_openai_messages ---
 
 
 def from_openai_messages(
@@ -91,8 +91,7 @@ def from_openai_messages(
         CatalogError: If a message is missing required fields, has an
             unknown role, or a ``role="tool"`` entry omits ``tool_call_id``.
     """
-    if not isinstance(messages, list):
-        raise CatalogError(f"from_openai_messages expects a list, got {type(messages).__name__}")
+    expect_list(messages, fn_name="from_openai_messages")
 
     # Track tool_call_ids announced by prior assistant messages so a
     # subsequent role="tool" entry must reference one of them. Without
@@ -101,8 +100,7 @@ def from_openai_messages(
     seen_tool_call_ids: set[str] = set()
     items: list[ContextItem] = []
     for idx, msg in enumerate(messages):
-        if not isinstance(msg, dict):
-            raise CatalogError(f"OpenAI message at index {idx} is not a dict: {type(msg).__name__}")
+        expect_dict(msg, label=f"OpenAI message at index {idx}")
         role = msg.get("role")
         if role == "system":
             items.append(_from_system(msg, idx))
@@ -115,17 +113,12 @@ def from_openai_messages(
         else:
             raise CatalogError(f"OpenAI message at index {idx} has unknown role: {role!r}")
 
-    if into is not None:
-        for item in items:
-            into.ingest(item)
-
+    ingest_into_manager(items, into)
     logger.debug("from_openai_messages: messages_in=%d, items_out=%d", len(messages), len(items))
     return items
 
 
-# ---------------------------------------------------------------------------
-# Public: to_openai_messages
-# ---------------------------------------------------------------------------
+# --- Public: to_openai_messages ---
 
 
 def to_openai_messages(items: list[ContextItem]) -> list[dict[str, Any]]:
@@ -180,7 +173,7 @@ def to_openai_messages(items: list[ContextItem]) -> list[dict[str, Any]]:
             payload = _tool_call_payload(item)
             messages.append({"role": "assistant", "content": None, "tool_calls": [payload]})
         elif item.kind is ItemKind.tool_result:
-            tool_call_id = item.metadata.get("tool_call_id") or _strip_prefix(
+            tool_call_id = item.metadata.get("tool_call_id") or strip_prefix(
                 item.id, _PREFIX_TOOL_RESULT
             )
             if not tool_call_id:
@@ -201,42 +194,39 @@ def to_openai_messages(items: list[ContextItem]) -> list[dict[str, Any]]:
     return messages
 
 
-# ---------------------------------------------------------------------------
-# Per-role decoders
-# ---------------------------------------------------------------------------
+# --- Per-role decoders ---
 
 
 def _from_system(msg: dict[str, Any], idx: int) -> ContextItem:
-    content = _string_content(msg, idx, "system")
-    return ContextItem(
-        id=f"{_PREFIX_SYSTEM}{idx}",
-        kind=ItemKind.policy,
-        text=content,
-        metadata={"role": "system"},
-    )
+    return _make_turn(msg, idx, role="system", kind=ItemKind.policy, prefix=_PREFIX_SYSTEM)
 
 
 def _from_user(msg: dict[str, Any], idx: int) -> ContextItem:
-    content = _string_content(msg, idx, "user")
+    return _make_turn(msg, idx, role="user", kind=ItemKind.user_turn, prefix=_PREFIX_USER)
+
+
+def _make_turn(
+    msg: dict[str, Any], idx: int, *, role: str, kind: ItemKind, prefix: str
+) -> ContextItem:
     return ContextItem(
-        id=f"{_PREFIX_USER}{idx}",
-        kind=ItemKind.user_turn,
-        text=content,
-        metadata={"role": "user"},
+        id=f"{prefix}{idx}",
+        kind=kind,
+        text=_string_content(msg, idx, role),
+        metadata={"role": role},
     )
 
 
 def _from_assistant(
     msg: dict[str, Any], idx: int, seen_tool_call_ids: set[str]
 ) -> list[ContextItem]:
-    """Expand an assistant message into agent_msg + N tool_call items."""
+    """Expand an assistant message into agent_msg + N tool_call items.
+
+    Metadata keys ``content_is_null`` and ``original_content`` preserve
+    the three input shapes (``None`` / ``""`` / list-of-parts) so the
+    inverse adapter can re-emit them exactly (PR #230 review).
+    """
     out: list[ContextItem] = []
     raw_content = msg.get("content")
-    # Capture whether `content` was a list-of-parts (multimodal input).
-    # When it is, _string_content collapses it to text; we keep the original
-    # so to_openai_messages can re-emit the same list and avoid a lossy
-    # str round-trip (PR #230 review).
-    original_content: Any = raw_content
     text = "" if raw_content is None else _string_content(msg, idx, "assistant")
     out.append(
         ContextItem(
@@ -245,12 +235,8 @@ def _from_assistant(
             text=text,
             metadata={
                 "role": "assistant",
-                # Preserve None vs "" so to_openai_messages can re-emit None.
                 "content_is_null": raw_content is None,
-                # Preserve list-of-parts content for lossless round-trip.
-                "original_content": original_content,
-                # Tag both agent_msg and its child tool_calls with the same
-                # input index so to_openai_messages can re-associate them.
+                "original_content": raw_content,
                 "assistant_idx": idx,
             },
         )
@@ -261,20 +247,17 @@ def _from_assistant(
         raise CatalogError(f"OpenAI assistant message at index {idx} has non-list tool_calls")
 
     for tc_idx, tc in enumerate(tool_calls):
-        if not isinstance(tc, dict):
-            raise CatalogError(
-                f"OpenAI tool_call at index [{idx}].tool_calls[{tc_idx}] is not a dict"
-            )
+        loc = f"OpenAI tool_call at index [{idx}].tool_calls[{tc_idx}]"
+        expect_dict(tc, label=loc)
         tc_id = tc.get("id")
         if not tc_id:
-            raise CatalogError(f"OpenAI tool_call at index [{idx}].tool_calls[{tc_idx}] missing id")
+            raise CatalogError(f"{loc} missing id")
         fn = tc.get("function") or {}
-        if not isinstance(fn, dict):
-            raise CatalogError(f"OpenAI tool_call {tc_id!r} has non-dict function payload")
+        expect_dict(fn, label=f"OpenAI tool_call {tc_id!r} function payload")
         fn_name = fn.get("name", "")
-        # Arguments are a JSON-encoded string in OpenAI's schema. Preserve
-        # the raw string in text for inspection AND store the parsed args
-        # in metadata so to_openai_messages can re-emit the canonical shape.
+        # Arguments are a JSON-encoded string in OpenAI's schema; preserve
+        # raw text + parsed args in metadata so to_openai_messages can
+        # re-emit the canonical shape.
         args_str = fn.get("arguments", "")
         if not isinstance(args_str, str):
             args_str = json.dumps(args_str)
@@ -318,9 +301,7 @@ def _from_tool(msg: dict[str, Any], idx: int, seen_tool_call_ids: set[str]) -> C
     )
 
 
-# ---------------------------------------------------------------------------
-# to_openai_messages helpers
-# ---------------------------------------------------------------------------
+# --- to_openai_messages helpers ---
 
 
 def _collect_assistant_tool_calls(items: list[ContextItem], start: int) -> list[dict[str, Any]]:
@@ -357,7 +338,7 @@ def _tool_call_payload(item: ContextItem) -> dict[str, Any]:
     if not tool_call_id:
         # Fall back to stripping the prefix; rejects items that weren't
         # produced by this adapter.
-        tool_call_id = _strip_prefix(item.id, _PREFIX_TOOL_CALL)
+        tool_call_id = strip_prefix(item.id, _PREFIX_TOOL_CALL)
     if not tool_call_id:
         raise CatalogError(
             f"tool_call item {item.id!r} cannot round-trip: missing "
@@ -374,57 +355,42 @@ def _tool_call_payload(item: ContextItem) -> dict[str, Any]:
     }
 
 
-# ---------------------------------------------------------------------------
-# Shared helpers
-# ---------------------------------------------------------------------------
+# --- Shared helpers ---
 
 
-def _restore_assistant_content(item: ContextItem, meta: dict[str, Any]) -> Any:  # noqa: ANN401 — provider-shaped JSON
-    """Reconstruct the OpenAI assistant ``content`` field for round-trip.
-
-    Three distinct decoder inputs map to distinct outputs here:
-
-    - ``content`` originally ``None`` → emit ``None`` (uses ``content_is_null``).
-    - ``content`` originally a list of parts → emit the original list
-      (uses ``original_content``).
-    - ``content`` originally a string (including ``""``) → emit ``item.text``.
-
-    Without this restoration, all three would collapse via ``item.text or
-    None`` (PR #230 review).
-    """
+def _restore_assistant_content(
+    item: ContextItem, meta: dict[str, Any]
+) -> Any:  # noqa: ANN401 — provider-shaped JSON
+    """Reconstruct assistant ``content``: None / list / string (PR #230)."""
     if meta.get("content_is_null"):
         return None
     original = meta.get("original_content")
     if isinstance(original, list):
         return original
-    # Strings (including empty) and any non-list originals fall through to
-    # the canonical text the decoder stored.
     return item.text
 
 
 def _string_content(msg: dict[str, Any], idx: int, role: str) -> str:
-    """Coerce the ``content`` field to a string with a clear error on misuse."""
+    """Coerce ``content`` to a string; collapse list-of-parts to joined text.
+
+    The list path supports OpenAI's multimodal `content` shape. The original
+    list payload is preserved separately in metadata so the round-trip is
+    lossless (see :func:`_from_assistant`).
+    """
     content = msg.get("content")
     if content is None:
         return ""
     if isinstance(content, str):
         return content
-    # OpenAI also supports `content` as a list of content parts (vision /
-    # multimodal); we collapse the text parts and preserve unknown blocks
-    # via JSON so callers see *something* rather than silently losing data.
     if isinstance(content, list):
-        text_parts: list[str] = []
-        for part in content:
-            if isinstance(part, dict) and part.get("type") == "text":
-                text_parts.append(str(part.get("text", "")))
-            else:
-                text_parts.append(json.dumps(part, sort_keys=True))
-        return "\n".join(text_parts)
+        parts = [
+            str(p.get("text", ""))
+            if isinstance(p, dict) and p.get("type") == "text"
+            else json.dumps(p, sort_keys=True)
+            for p in content
+        ]
+        return "\n".join(parts)
     raise CatalogError(
         f"OpenAI {role} message at index {idx} has unsupported content type: "
         f"{type(content).__name__}"
     )
-
-
-def _strip_prefix(value: str, prefix: str) -> str:
-    return value[len(prefix) :] if value.startswith(prefix) else ""

--- a/src/contextweaver/adapters/openai_messages.py
+++ b/src/contextweaver/adapters/openai_messages.py
@@ -30,12 +30,15 @@ Mapping rules:
 :func:`to_openai_messages` is the inverse of :func:`from_openai_messages`
 for any well-formed input.
 
+The decoder helpers live in :mod:`._openai_decode` and the encoder
+helpers in :mod:`._openai_encode` to keep this public surface focused
+and within the repo's ≤300-line module guideline.
+
 Issue #219 (slice of #194).
 """
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -45,6 +48,18 @@ from contextweaver.adapters._messages_common import (
     ingest_into_manager,
     strip_prefix,
 )
+from contextweaver.adapters._openai_decode import (
+    _PREFIX_TOOL_RESULT,
+    _from_assistant,
+    _from_system,
+    _from_tool,
+    _from_user,
+)
+from contextweaver.adapters._openai_encode import (
+    _collect_assistant_tool_calls,
+    _restore_assistant_content,
+    _tool_call_payload,
+)
 from contextweaver.exceptions import CatalogError
 from contextweaver.types import ContextItem, ItemKind
 
@@ -52,19 +67,6 @@ if TYPE_CHECKING:
     from contextweaver.context.manager import ContextManager
 
 logger = logging.getLogger("contextweaver.adapters")
-
-# ID prefix carries enough information to round-trip the OpenAI message:
-# - "openai:tool_call:<tool_call_id>"   → the assistant's tool-call entry
-# - "openai:tool_result:<tool_call_id>" → the matching role="tool" response
-# - "openai:{user,assistant,system}:<idx>" → turn entries
-_PREFIX_TOOL_CALL = "openai:tool_call:"
-_PREFIX_TOOL_RESULT = "openai:tool_result:"
-_PREFIX_USER = "openai:user:"
-_PREFIX_ASSISTANT = "openai:assistant:"
-_PREFIX_SYSTEM = "openai:system:"
-
-
-# --- Public: from_openai_messages ---
 
 
 def from_openai_messages(
@@ -116,9 +118,6 @@ def from_openai_messages(
     ingest_into_manager(items, into)
     logger.debug("from_openai_messages: messages_in=%d, items_out=%d", len(messages), len(items))
     return items
-
-
-# --- Public: to_openai_messages ---
 
 
 def to_openai_messages(items: list[ContextItem]) -> list[dict[str, Any]]:
@@ -192,203 +191,3 @@ def to_openai_messages(items: list[ContextItem]) -> list[dict[str, Any]]:
             )
         i += 1
     return messages
-
-
-# --- Per-role decoders ---
-
-
-def _from_system(msg: dict[str, Any], idx: int) -> ContextItem:
-    return _make_turn(msg, idx, role="system", kind=ItemKind.policy, prefix=_PREFIX_SYSTEM)
-
-
-def _from_user(msg: dict[str, Any], idx: int) -> ContextItem:
-    return _make_turn(msg, idx, role="user", kind=ItemKind.user_turn, prefix=_PREFIX_USER)
-
-
-def _make_turn(
-    msg: dict[str, Any], idx: int, *, role: str, kind: ItemKind, prefix: str
-) -> ContextItem:
-    return ContextItem(
-        id=f"{prefix}{idx}",
-        kind=kind,
-        text=_string_content(msg, idx, role),
-        metadata={"role": role},
-    )
-
-
-def _from_assistant(
-    msg: dict[str, Any], idx: int, seen_tool_call_ids: set[str]
-) -> list[ContextItem]:
-    """Expand an assistant message into agent_msg + N tool_call items.
-
-    Metadata keys ``content_is_null`` and ``original_content`` preserve
-    the three input shapes (``None`` / ``""`` / list-of-parts) so the
-    inverse adapter can re-emit them exactly (PR #230 review).
-    """
-    out: list[ContextItem] = []
-    raw_content = msg.get("content")
-    text = "" if raw_content is None else _string_content(msg, idx, "assistant")
-    out.append(
-        ContextItem(
-            id=f"{_PREFIX_ASSISTANT}{idx}",
-            kind=ItemKind.agent_msg,
-            text=text,
-            metadata={
-                "role": "assistant",
-                "content_is_null": raw_content is None,
-                "original_content": raw_content,
-                "assistant_idx": idx,
-            },
-        )
-    )
-
-    tool_calls = msg.get("tool_calls") or []
-    if not isinstance(tool_calls, list):
-        raise CatalogError(f"OpenAI assistant message at index {idx} has non-list tool_calls")
-
-    for tc_idx, tc in enumerate(tool_calls):
-        loc = f"OpenAI tool_call at index [{idx}].tool_calls[{tc_idx}]"
-        expect_dict(tc, label=loc)
-        tc_id = tc.get("id")
-        if not tc_id:
-            raise CatalogError(f"{loc} missing id")
-        fn = tc.get("function") or {}
-        expect_dict(fn, label=f"OpenAI tool_call {tc_id!r} function payload")
-        fn_name = fn.get("name", "")
-        # Arguments are a JSON-encoded string in OpenAI's schema; preserve
-        # raw text + parsed args in metadata so to_openai_messages can
-        # re-emit the canonical shape.
-        args_str = fn.get("arguments", "")
-        if not isinstance(args_str, str):
-            args_str = json.dumps(args_str)
-        out.append(
-            ContextItem(
-                id=f"{_PREFIX_TOOL_CALL}{tc_id}",
-                kind=ItemKind.tool_call,
-                text=args_str,
-                metadata={
-                    "tool_call_id": tc_id,
-                    "tool_call_type": tc.get("type", "function"),
-                    "function_name": fn_name,
-                    "arguments": args_str,
-                    "assistant_idx": idx,
-                },
-            )
-        )
-        seen_tool_call_ids.add(tc_id)
-    return out
-
-
-def _from_tool(msg: dict[str, Any], idx: int, seen_tool_call_ids: set[str]) -> ContextItem:
-    tool_call_id = msg.get("tool_call_id")
-    if not tool_call_id:
-        raise CatalogError(f"OpenAI tool message at index {idx} missing tool_call_id")
-    if tool_call_id not in seen_tool_call_ids:
-        # The tool_call_id must reference a prior assistant tool_calls entry
-        # so the resulting ContextItem.parent_id points at a real item (PR
-        # #230 review). Mirrors the Gemini adapter's unmatched-response check.
-        raise CatalogError(
-            f"OpenAI tool message at index {idx} has tool_call_id={tool_call_id!r} "
-            "that does not match any prior assistant tool_calls entry"
-        )
-    content = _string_content(msg, idx, "tool")
-    return ContextItem(
-        id=f"{_PREFIX_TOOL_RESULT}{tool_call_id}",
-        kind=ItemKind.tool_result,
-        text=content,
-        metadata={"role": "tool", "tool_call_id": tool_call_id},
-        parent_id=f"{_PREFIX_TOOL_CALL}{tool_call_id}",
-    )
-
-
-# --- to_openai_messages helpers ---
-
-
-def _collect_assistant_tool_calls(items: list[ContextItem], start: int) -> list[dict[str, Any]]:
-    """Collect tool_call items that follow an assistant agent_msg.
-
-    A tool_call belongs to the immediately-preceding agent_msg iff its
-    ``metadata["assistant_idx"]`` matches the agent_msg's input index. We
-    look at consecutive tool_call items and stop at the first non-match.
-    """
-    out: list[dict[str, Any]] = []
-    if start == 0:
-        return out
-    prev = items[start - 1]
-    if prev.kind is not ItemKind.agent_msg:
-        return out
-    expected_idx = prev.metadata.get("assistant_idx") if prev.metadata else None
-    cursor = start
-    while cursor < len(items):
-        candidate = items[cursor]
-        if candidate.kind is not ItemKind.tool_call:
-            break
-        # Only consume tool_calls that came from this assistant turn.
-        cand_idx = candidate.metadata.get("assistant_idx") if candidate.metadata else None
-        if cand_idx != expected_idx:
-            break
-        out.append({"payload": _tool_call_payload(candidate)})
-        cursor += 1
-    return out
-
-
-def _tool_call_payload(item: ContextItem) -> dict[str, Any]:
-    """Build an OpenAI ``tool_calls[]`` entry from a stored tool_call item."""
-    tool_call_id = item.metadata.get("tool_call_id") if item.metadata else None
-    if not tool_call_id:
-        # Fall back to stripping the prefix; rejects items that weren't
-        # produced by this adapter.
-        tool_call_id = strip_prefix(item.id, _PREFIX_TOOL_CALL)
-    if not tool_call_id:
-        raise CatalogError(
-            f"tool_call item {item.id!r} cannot round-trip: missing "
-            "tool_call_id metadata and id is not openai-prefixed"
-        )
-    fn_name = item.metadata.get("function_name", "") if item.metadata else ""
-    arguments = item.metadata.get("arguments") if item.metadata else None
-    if arguments is None:
-        arguments = item.text
-    return {
-        "id": tool_call_id,
-        "type": item.metadata.get("tool_call_type", "function") if item.metadata else "function",
-        "function": {"name": fn_name, "arguments": arguments},
-    }
-
-
-# --- Shared helpers ---
-
-
-def _restore_assistant_content(item: ContextItem, meta: dict[str, Any]) -> Any:  # noqa: ANN401 — provider-shaped JSON
-    """Reconstruct assistant ``content``: None / list / string (PR #230)."""
-    if meta.get("content_is_null"):
-        return None
-    original = meta.get("original_content")
-    if isinstance(original, list):
-        return original
-    return item.text
-
-
-def _string_content(msg: dict[str, Any], idx: int, role: str) -> str:
-    """Coerce ``content`` to a string; collapse list-of-parts to joined text.
-
-    The list path supports OpenAI's multimodal `content` shape. The original
-    list payload is preserved separately in metadata so the round-trip is
-    lossless (see :func:`_from_assistant`).
-    """
-    content = msg.get("content")
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts = [
-            str(p.get("text", ""))
-            if isinstance(p, dict) and p.get("type") == "text"
-            else json.dumps(p, sort_keys=True)
-            for p in content
-        ]
-        return "\n".join(parts)
-    raise CatalogError(
-        f"OpenAI {role} message at index {idx} has unsupported content type: "
-        f"{type(content).__name__}"
-    )

--- a/src/contextweaver/adapters/openai_messages.py
+++ b/src/contextweaver/adapters/openai_messages.py
@@ -358,9 +358,7 @@ def _tool_call_payload(item: ContextItem) -> dict[str, Any]:
 # --- Shared helpers ---
 
 
-def _restore_assistant_content(
-    item: ContextItem, meta: dict[str, Any]
-) -> Any:  # noqa: ANN401 — provider-shaped JSON
+def _restore_assistant_content(item: ContextItem, meta: dict[str, Any]) -> Any:  # noqa: ANN401 — provider-shaped JSON
     """Reconstruct assistant ``content``: None / list / string (PR #230)."""
     if meta.get("content_is_null"):
         return None

--- a/src/contextweaver/routing/cards.py
+++ b/src/contextweaver/routing/cards.py
@@ -289,6 +289,15 @@ def make_choice_cards(
     *target_tokens_per_card* (per §2.4).  Cards are then sorted per
     §2.5 (score desc, ``id`` asc) and capped to *max_cards*.
 
+    **Ordering guarantee (issue #218).** For identical *items*, *scores*,
+    and tuning parameters, the returned list is deterministic and
+    byte-identical across calls — ranked by descending ``score`` with
+    ties broken by ascending ``id``. Downstream prompt-cache assemblers
+    (Anthropic ``cache_control``, OpenAI / Google equivalents) can rely
+    on this invariant when placing a cache breakpoint after the last
+    rendered card. See ``docs/integration_mcp.md`` §"Prompt-caching
+    compatibility" for a worked example.
+
     Args:
         items: Source items.
         max_cards: Maximum number of cards to return.

--- a/tests/test_adapters_anthropic_messages.py
+++ b/tests/test_adapters_anthropic_messages.py
@@ -231,6 +231,75 @@ def test_tool_result_with_is_error_preserved() -> None:
     assert to_anthropic_messages(items) == msgs
 
 
+def test_from_anthropic_messages_rejects_orphan_tool_result() -> None:
+    """tool_result with tool_use_id not announced by a prior tool_use → CatalogError.
+
+    PR #230 review: mirrors the openai_messages orphan check.
+    """
+    msgs = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_orphan",
+                    "content": "result without a call",
+                }
+            ],
+        }
+    ]
+    with pytest.raises(CatalogError, match="does not match any prior assistant tool_use"):
+        from_anthropic_messages(msgs)
+
+
+def test_roundtrip_preserves_explicit_is_error_false() -> None:
+    """Explicit `is_error: False` survives the round-trip (PR #230 review)."""
+    msgs = [
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "toolu_e", "name": "f", "input": {}}],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_e",
+                    "content": "ok",
+                    "is_error": False,
+                }
+            ],
+        },
+    ]
+    rebuilt = to_anthropic_messages(from_anthropic_messages(msgs))
+    assert rebuilt == msgs
+    # Defensive: the False must appear explicitly, not be stripped.
+    assert rebuilt[1]["content"][0]["is_error"] is False
+
+
+def test_roundtrip_preserves_unknown_block_fields_like_cache_control() -> None:
+    """Unknown provider fields on text blocks survive the round-trip.
+
+    PR #230 review: `cache_control` (and any other future Anthropic block
+    attribute we don't explicitly decode) must not be dropped.
+    """
+    msgs = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Hello there.",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        }
+    ]
+    rebuilt = to_anthropic_messages(from_anthropic_messages(msgs))
+    assert rebuilt == msgs
+    assert rebuilt[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+
+
 def test_module_does_not_import_provider_sdk_at_load_time() -> None:
     """No provider SDK leaked into sys.modules through the adapter import."""
     assert "anthropic" not in sys.modules

--- a/tests/test_adapters_anthropic_messages.py
+++ b/tests/test_adapters_anthropic_messages.py
@@ -1,0 +1,238 @@
+"""Tests for the Anthropic Messages API adapter (issue #222)."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from contextweaver.adapters.anthropic_messages import (
+    from_anthropic_messages,
+    to_anthropic_messages,
+)
+from contextweaver.context.manager import ContextManager
+from contextweaver.exceptions import CatalogError
+from contextweaver.types import ItemKind, Phase
+
+# ---------------------------------------------------------------------------
+# Fixtures (representative Anthropic Messages API arrays)
+# ---------------------------------------------------------------------------
+
+
+SIMPLE_CHAT: list[dict] = [
+    {
+        "role": "user",
+        "content": [{"type": "text", "text": "Hello, who are you?"}],
+    },
+    {
+        "role": "assistant",
+        "content": [{"type": "text", "text": "I'm Claude, an AI assistant."}],
+    },
+]
+
+
+CHAT_WITH_TOOL_USE: list[dict] = [
+    {
+        "role": "user",
+        "content": [{"type": "text", "text": "What's the weather in Tokyo?"}],
+    },
+    {
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "I'll check the weather."},
+            {
+                "type": "tool_use",
+                "id": "toolu_01ABC",
+                "name": "get_weather",
+                "input": {"city": "Tokyo"},
+            },
+        ],
+    },
+    {
+        "role": "user",
+        "content": [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_01ABC",
+                "content": '{"temperature_c": 22}',
+            }
+        ],
+    },
+    {
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Tokyo is 22 °C."}],
+    },
+]
+
+
+STRING_SHORTHAND: list[dict] = [
+    # Anthropic accepts `content: "..."` as a shorthand for a single text block.
+    {"role": "user", "content": "Hi there!"},
+    {"role": "assistant", "content": "Hello! How can I help?"},
+]
+
+
+# ---------------------------------------------------------------------------
+# from_anthropic_messages: role + block mapping
+# ---------------------------------------------------------------------------
+
+
+def test_from_anthropic_messages_simple_chat() -> None:
+    items = from_anthropic_messages(SIMPLE_CHAT)
+    assert [item.kind for item in items] == [ItemKind.user_turn, ItemKind.agent_msg]
+    assert items[0].text == "Hello, who are you?"
+    assert items[1].text == "I'm Claude, an AI assistant."
+
+
+def test_from_anthropic_messages_tool_use_splits_into_text_and_tool_call() -> None:
+    items = from_anthropic_messages(CHAT_WITH_TOOL_USE)
+    kinds = [item.kind for item in items]
+    # user_turn, agent_msg (text), tool_call, tool_result, agent_msg
+    assert kinds == [
+        ItemKind.user_turn,
+        ItemKind.agent_msg,
+        ItemKind.tool_call,
+        ItemKind.tool_result,
+        ItemKind.agent_msg,
+    ]
+
+
+def test_from_anthropic_messages_tool_use_id_chain() -> None:
+    items = from_anthropic_messages(CHAT_WITH_TOOL_USE)
+    tool_call = next(it for it in items if it.kind is ItemKind.tool_call)
+    tool_result = next(it for it in items if it.kind is ItemKind.tool_result)
+    assert tool_call.metadata["tool_use_id"] == "toolu_01ABC"
+    assert tool_result.metadata["tool_use_id"] == "toolu_01ABC"
+    # parent_id chain back to the originating tool_use item.
+    assert tool_result.parent_id == tool_call.id
+
+
+def test_from_anthropic_messages_preserves_content_block_ordering() -> None:
+    """Anthropic models care about block order — round-trip must preserve it."""
+    items = from_anthropic_messages(CHAT_WITH_TOOL_USE)
+    # The assistant turn at msg_index=1 has 2 blocks: text then tool_use.
+    assistant_blocks = [it for it in items if it.metadata.get("msg_index") == 1]
+    assert [it.metadata["block_index"] for it in assistant_blocks] == [0, 1]
+    assert [it.metadata["block_type"] for it in assistant_blocks] == [
+        "text",
+        "tool_use",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Round-trip equality
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [SIMPLE_CHAT, CHAT_WITH_TOOL_USE, STRING_SHORTHAND],
+    ids=["simple_chat", "tool_use_chain", "string_shorthand"],
+)
+def test_roundtrip_preserves_structure(fixture: list[dict]) -> None:
+    items = from_anthropic_messages(fixture)
+    rebuilt = to_anthropic_messages(items)
+    assert rebuilt == fixture
+
+
+# ---------------------------------------------------------------------------
+# Drop-in path via into=
+# ---------------------------------------------------------------------------
+
+
+def test_from_anthropic_messages_into_manager_builds_pack() -> None:
+    mgr = ContextManager()
+    from_anthropic_messages(CHAT_WITH_TOOL_USE, into=mgr)
+    pack = mgr.build_sync(phase=Phase.answer, query="What was the temperature?")
+    assert pack.prompt
+    assert pack.stats.included_count > 0
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_from_anthropic_messages_rejects_non_list() -> None:
+    with pytest.raises(CatalogError, match="expects a list"):
+        from_anthropic_messages("nope")  # type: ignore[arg-type]
+
+
+def test_from_anthropic_messages_rejects_unknown_role() -> None:
+    with pytest.raises(CatalogError, match="unknown role"):
+        from_anthropic_messages([{"role": "robot", "content": "x"}])
+
+
+def test_from_anthropic_messages_rejects_tool_use_without_id() -> None:
+    msgs = [
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "name": "f", "input": {}}],
+        }
+    ]
+    with pytest.raises(CatalogError, match="missing 'id'"):
+        from_anthropic_messages(msgs)
+
+
+def test_from_anthropic_messages_rejects_tool_result_without_tool_use_id() -> None:
+    msgs = [{"role": "user", "content": [{"type": "tool_result", "content": "x"}]}]
+    with pytest.raises(CatalogError, match="missing 'tool_use_id'"):
+        from_anthropic_messages(msgs)
+
+
+def test_from_anthropic_messages_rejects_unknown_block_type() -> None:
+    msgs = [{"role": "user", "content": [{"type": "alien_block"}]}]
+    with pytest.raises(CatalogError, match="unsupported"):
+        from_anthropic_messages(msgs)
+
+
+def test_to_anthropic_messages_rejects_items_without_msg_index() -> None:
+    from contextweaver.types import ContextItem
+
+    items = [ContextItem(id="x", kind=ItemKind.user_turn, text="hi", metadata={"role": "user"})]
+    with pytest.raises(CatalogError, match="msg_index"):
+        to_anthropic_messages(items)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_tool_result_with_is_error_preserved() -> None:
+    """is_error flag survives the round-trip."""
+    msgs = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_X",
+                    "name": "fail",
+                    "input": {},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_X",
+                    "content": "something broke",
+                    "is_error": True,
+                }
+            ],
+        },
+    ]
+    items = from_anthropic_messages(msgs)
+    tool_result = next(it for it in items if it.kind is ItemKind.tool_result)
+    assert tool_result.metadata["is_error"] is True
+    assert to_anthropic_messages(items) == msgs
+
+
+def test_module_does_not_import_provider_sdk_at_load_time() -> None:
+    """No provider SDK leaked into sys.modules through the adapter import."""
+    assert "anthropic" not in sys.modules
+    assert "openai" not in sys.modules
+    assert "google.generativeai" not in sys.modules

--- a/tests/test_adapters_gemini_contents.py
+++ b/tests/test_adapters_gemini_contents.py
@@ -1,0 +1,218 @@
+"""Tests for the Google Gemini ``contents`` adapter (issue #222)."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from contextweaver.adapters.gemini_contents import (
+    from_gemini_contents,
+    to_gemini_contents,
+)
+from contextweaver.context.manager import ContextManager
+from contextweaver.exceptions import CatalogError
+from contextweaver.types import ItemKind, Phase
+
+# ---------------------------------------------------------------------------
+# Fixtures (representative Gemini contents arrays)
+# ---------------------------------------------------------------------------
+
+
+SIMPLE_CHAT: list[dict] = [
+    {"role": "user", "parts": [{"text": "What's 2 + 2?"}]},
+    {"role": "model", "parts": [{"text": "4."}]},
+]
+
+
+CHAT_WITH_FUNCTION_CALL: list[dict] = [
+    {"role": "user", "parts": [{"text": "What's the time in Berlin?"}]},
+    {
+        "role": "model",
+        "parts": [
+            {"text": "Let me check the time."},
+            {
+                "functionCall": {
+                    "name": "get_time",
+                    "args": {"city": "Berlin"},
+                }
+            },
+        ],
+    },
+    {
+        "role": "function",
+        "parts": [
+            {
+                "functionResponse": {
+                    "name": "get_time",
+                    "response": {"time": "15:30"},
+                }
+            }
+        ],
+    },
+    {"role": "model", "parts": [{"text": "It's 15:30 in Berlin."}]},
+]
+
+
+# ---------------------------------------------------------------------------
+# from_gemini_contents: role + part mapping
+# ---------------------------------------------------------------------------
+
+
+def test_from_gemini_contents_simple_chat() -> None:
+    items = from_gemini_contents(SIMPLE_CHAT)
+    assert [item.kind for item in items] == [ItemKind.user_turn, ItemKind.agent_msg]
+    assert items[0].text == "What's 2 + 2?"
+    assert items[1].text == "4."
+
+
+def test_from_gemini_contents_function_call_chain() -> None:
+    items = from_gemini_contents(CHAT_WITH_FUNCTION_CALL)
+    kinds = [item.kind for item in items]
+    assert kinds == [
+        ItemKind.user_turn,
+        ItemKind.agent_msg,
+        ItemKind.tool_call,
+        ItemKind.tool_result,
+        ItemKind.agent_msg,
+    ]
+
+
+def test_from_gemini_contents_synthesised_id_is_deterministic() -> None:
+    """Issue #222 design constraint: synthesise ID from name + position."""
+    items1 = from_gemini_contents(CHAT_WITH_FUNCTION_CALL)
+    items2 = from_gemini_contents(CHAT_WITH_FUNCTION_CALL)
+    ids1 = [it.id for it in items1]
+    ids2 = [it.id for it in items2]
+    assert ids1 == ids2
+    # The synthesised ID format is "<name>:<msg_idx>:<part_idx>" for the call,
+    # and the response is linked back via parent_id.
+    tool_call = next(it for it in items1 if it.kind is ItemKind.tool_call)
+    assert "get_time:1:1" in tool_call.id
+
+
+def test_from_gemini_contents_parent_id_chain() -> None:
+    items = from_gemini_contents(CHAT_WITH_FUNCTION_CALL)
+    tool_call = next(it for it in items if it.kind is ItemKind.tool_call)
+    tool_result = next(it for it in items if it.kind is ItemKind.tool_result)
+    assert tool_result.parent_id == tool_call.id
+
+
+def test_from_gemini_contents_preserves_part_ordering() -> None:
+    """Multi-part messages must preserve original part_index order."""
+    items = from_gemini_contents(CHAT_WITH_FUNCTION_CALL)
+    model_turn_parts = [it for it in items if it.metadata.get("msg_index") == 1]
+    assert [it.metadata["part_index"] for it in model_turn_parts] == [0, 1]
+
+
+# ---------------------------------------------------------------------------
+# Round-trip equality
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [SIMPLE_CHAT, CHAT_WITH_FUNCTION_CALL],
+    ids=["simple_chat", "function_call_chain"],
+)
+def test_roundtrip_preserves_structure(fixture: list[dict]) -> None:
+    items = from_gemini_contents(fixture)
+    rebuilt = to_gemini_contents(items)
+    assert rebuilt == fixture
+
+
+# ---------------------------------------------------------------------------
+# Drop-in path via into=
+# ---------------------------------------------------------------------------
+
+
+def test_from_gemini_contents_into_manager_builds_pack() -> None:
+    mgr = ContextManager()
+    from_gemini_contents(CHAT_WITH_FUNCTION_CALL, into=mgr)
+    pack = mgr.build_sync(phase=Phase.answer, query="What time was it?")
+    assert pack.prompt
+    assert pack.stats.included_count > 0
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_from_gemini_contents_rejects_non_list() -> None:
+    with pytest.raises(CatalogError, match="expects a list"):
+        from_gemini_contents("nope")  # type: ignore[arg-type]
+
+
+def test_from_gemini_contents_rejects_unknown_role() -> None:
+    with pytest.raises(CatalogError, match="unknown role"):
+        from_gemini_contents([{"role": "system", "parts": [{"text": "x"}]}])
+
+
+def test_from_gemini_contents_rejects_missing_parts_list() -> None:
+    with pytest.raises(CatalogError, match="non-list parts"):
+        from_gemini_contents([{"role": "user", "parts": "nope"}])
+
+
+def test_from_gemini_contents_rejects_response_without_matching_call() -> None:
+    msgs = [
+        {
+            "role": "function",
+            "parts": [
+                {
+                    "functionResponse": {
+                        "name": "orphan_function",
+                        "response": {"x": 1},
+                    }
+                }
+            ],
+        }
+    ]
+    with pytest.raises(CatalogError, match="no matching prior functionCall"):
+        from_gemini_contents(msgs)
+
+
+def test_from_gemini_contents_rejects_unknown_part_type() -> None:
+    msgs = [{"role": "user", "parts": [{"alien": "x"}]}]
+    with pytest.raises(CatalogError, match="no recognised content"):
+        from_gemini_contents(msgs)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_two_function_calls_with_same_name_get_distinct_ids() -> None:
+    """FIFO matching: two calls with the same name pair with two responses."""
+    msgs = [
+        {
+            "role": "model",
+            "parts": [
+                {"functionCall": {"name": "fetch", "args": {"q": "a"}}},
+                {"functionCall": {"name": "fetch", "args": {"q": "b"}}},
+            ],
+        },
+        {
+            "role": "function",
+            "parts": [
+                {"functionResponse": {"name": "fetch", "response": {"r": "a"}}},
+                {"functionResponse": {"name": "fetch", "response": {"r": "b"}}},
+            ],
+        },
+    ]
+    items = from_gemini_contents(msgs)
+    tool_calls = [it for it in items if it.kind is ItemKind.tool_call]
+    tool_results = [it for it in items if it.kind is ItemKind.tool_result]
+    assert len({it.id for it in tool_calls}) == 2  # distinct IDs
+    # Responses pair with calls FIFO by name.
+    assert tool_results[0].parent_id == tool_calls[0].id
+    assert tool_results[1].parent_id == tool_calls[1].id
+    # And the round-trip preserves the shape.
+    assert to_gemini_contents(items) == msgs
+
+
+def test_module_does_not_import_provider_sdk_at_load_time() -> None:
+    assert "google.generativeai" not in sys.modules
+    assert "openai" not in sys.modules
+    assert "anthropic" not in sys.modules

--- a/tests/test_adapters_openai_messages.py
+++ b/tests/test_adapters_openai_messages.py
@@ -243,6 +243,55 @@ def test_from_openai_messages_handles_multimodal_user_content_list() -> None:
     assert "Describe this:" in items[0].text
 
 
+def test_from_openai_messages_rejects_orphan_tool_call_id() -> None:
+    """role="tool" with a tool_call_id no prior assistant announced → CatalogError.
+
+    PR #230 review: dangling parent_id would break the event-log
+    dependency chain the adapter is meant to reconstruct.
+    """
+    msgs = [
+        {
+            "role": "tool",
+            "tool_call_id": "call_orphan",
+            "content": "result without a call",
+        }
+    ]
+    with pytest.raises(CatalogError, match="does not match any prior assistant tool_calls"):
+        from_openai_messages(msgs)
+
+
+def test_roundtrip_preserves_empty_string_assistant_content() -> None:
+    """content="" must NOT collapse to None on round-trip (PR #230 review)."""
+    msgs = [{"role": "assistant", "content": ""}]
+    rebuilt = to_openai_messages(from_openai_messages(msgs))
+    assert rebuilt == msgs
+    assert rebuilt[0]["content"] == ""  # specifically not None
+
+
+def test_roundtrip_preserves_multimodal_assistant_content_list() -> None:
+    """Assistant `content` as a list of parts must round-trip unchanged.
+
+    PR #230 review: previously the decoder collapsed the list to a text
+    string and the encoder re-emitted a string, losing image / unknown
+    parts. The decoder now stashes the original payload so the encoder
+    can re-emit it verbatim.
+    """
+    msgs = [
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "Here's what I see:"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/x.jpg"},
+                },
+            ],
+        }
+    ]
+    rebuilt = to_openai_messages(from_openai_messages(msgs))
+    assert rebuilt == msgs
+
+
 def test_module_does_not_import_provider_sdk_at_load_time() -> None:
     """Issue #219 design constraint: no provider SDK import at module level."""
     # The openai_messages module is already imported by these tests; assert

--- a/tests/test_adapters_openai_messages.py
+++ b/tests/test_adapters_openai_messages.py
@@ -1,0 +1,253 @@
+"""Tests for the OpenAI Chat Completions message-array adapter (issue #219)."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from contextweaver.adapters.openai_messages import (
+    from_openai_messages,
+    to_openai_messages,
+)
+from contextweaver.context.manager import ContextManager
+from contextweaver.exceptions import CatalogError
+from contextweaver.types import ItemKind, Phase
+
+# ---------------------------------------------------------------------------
+# Fixtures (representative OpenAI message arrays)
+# ---------------------------------------------------------------------------
+
+
+SIMPLE_CHAT: list[dict] = [
+    {"role": "system", "content": "You are a concise assistant."},
+    {"role": "user", "content": "What is the capital of France?"},
+    {"role": "assistant", "content": "Paris."},
+]
+
+
+CHAT_WITH_TOOL_CALL: list[dict] = [
+    {"role": "user", "content": "What's the weather in Paris?"},
+    {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_abc123",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"city": "Paris"}',
+                },
+            }
+        ],
+    },
+    {
+        "role": "tool",
+        "tool_call_id": "call_abc123",
+        "content": '{"temperature_c": 18, "condition": "cloudy"}',
+    },
+    {"role": "assistant", "content": "It's 18 °C and cloudy in Paris."},
+]
+
+
+MULTI_TOOL_CALL: list[dict] = [
+    {"role": "user", "content": "Compare weather in Paris and London."},
+    {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_p",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"city": "Paris"}',
+                },
+            },
+            {
+                "id": "call_l",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"city": "London"}',
+                },
+            },
+        ],
+    },
+    {
+        "role": "tool",
+        "tool_call_id": "call_p",
+        "content": '{"temperature_c": 18}',
+    },
+    {
+        "role": "tool",
+        "tool_call_id": "call_l",
+        "content": '{"temperature_c": 14}',
+    },
+    {"role": "assistant", "content": "Paris is warmer (18 °C vs 14 °C)."},
+]
+
+
+# ---------------------------------------------------------------------------
+# from_openai_messages: role mapping
+# ---------------------------------------------------------------------------
+
+
+def test_from_openai_messages_simple_chat_role_mapping() -> None:
+    items = from_openai_messages(SIMPLE_CHAT)
+    assert [item.kind for item in items] == [
+        ItemKind.policy,
+        ItemKind.user_turn,
+        ItemKind.agent_msg,
+    ]
+    assert items[0].text == "You are a concise assistant."
+    assert items[1].text == "What is the capital of France?"
+    assert items[2].text == "Paris."
+
+
+def test_from_openai_messages_assistant_tool_call_splits() -> None:
+    """Assistant message with tool_calls expands to agent_msg + tool_call items."""
+    items = from_openai_messages(CHAT_WITH_TOOL_CALL)
+    # user, assistant (agent_msg), tool_call, tool_result, assistant
+    kinds = [item.kind for item in items]
+    assert kinds == [
+        ItemKind.user_turn,
+        ItemKind.agent_msg,
+        ItemKind.tool_call,
+        ItemKind.tool_result,
+        ItemKind.agent_msg,
+    ]
+
+
+def test_from_openai_messages_tool_result_parent_id_chain() -> None:
+    """tool_result.parent_id must reference the originating tool_call item."""
+    items = from_openai_messages(CHAT_WITH_TOOL_CALL)
+    tool_call_item = next(it for it in items if it.kind is ItemKind.tool_call)
+    tool_result_item = next(it for it in items if it.kind is ItemKind.tool_result)
+    assert tool_result_item.parent_id == tool_call_item.id
+    assert tool_result_item.metadata["tool_call_id"] == "call_abc123"
+
+
+def test_from_openai_messages_tool_call_id_roundtrips_to_item_id() -> None:
+    items = from_openai_messages(CHAT_WITH_TOOL_CALL)
+    tool_call_item = next(it for it in items if it.kind is ItemKind.tool_call)
+    # tool_call_id is recoverable from the ContextItem.id (the round-trip
+    # invariant required by issue #219).
+    assert tool_call_item.id.endswith("call_abc123")
+    assert tool_call_item.metadata["function_name"] == "get_weather"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip equality (the issue's hard requirement)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    [SIMPLE_CHAT, CHAT_WITH_TOOL_CALL, MULTI_TOOL_CALL],
+    ids=["simple_chat", "single_tool_call", "multi_tool_call"],
+)
+def test_roundtrip_preserves_structure(fixture: list[dict]) -> None:
+    """to_openai_messages(from_openai_messages(x)) == x (structural)."""
+    items = from_openai_messages(fixture)
+    rebuilt = to_openai_messages(items)
+    assert rebuilt == fixture
+
+
+# ---------------------------------------------------------------------------
+# into=ContextManager: 5-line drop-in path
+# ---------------------------------------------------------------------------
+
+
+def test_from_openai_messages_into_manager_appends_to_event_log() -> None:
+    mgr = ContextManager()
+    items = from_openai_messages(CHAT_WITH_TOOL_CALL, into=mgr)
+    # Every returned item must also be in the manager's event log in order.
+    logged = list(mgr.event_log.all())
+    assert [it.id for it in logged] == [it.id for it in items]
+
+
+def test_from_openai_messages_5_line_drop_in_builds_pack() -> None:
+    """Issue #219 success metric: ≤5-line drop-in produces a working pack."""
+    mgr = ContextManager()
+    from_openai_messages(CHAT_WITH_TOOL_CALL, into=mgr)
+    pack = mgr.build_sync(phase=Phase.answer, query="What was the weather?")
+    assert pack.prompt
+    assert pack.stats.included_count > 0
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_from_openai_messages_rejects_non_list() -> None:
+    with pytest.raises(CatalogError, match="expects a list"):
+        from_openai_messages("not a list")  # type: ignore[arg-type]
+
+
+def test_from_openai_messages_rejects_unknown_role() -> None:
+    with pytest.raises(CatalogError, match="unknown role"):
+        from_openai_messages([{"role": "spaceship", "content": "x"}])
+
+
+def test_from_openai_messages_rejects_tool_without_call_id() -> None:
+    with pytest.raises(CatalogError, match="missing tool_call_id"):
+        from_openai_messages([{"role": "tool", "content": "x"}])
+
+
+def test_from_openai_messages_rejects_tool_call_without_id() -> None:
+    msg = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [{"type": "function", "function": {"name": "x"}}],
+    }
+    with pytest.raises(CatalogError, match="missing id"):
+        from_openai_messages([msg])
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_from_openai_messages_handles_assistant_content_null() -> None:
+    """content=None on assistant tool-call message round-trips back to None."""
+    msg = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_x",
+                "type": "function",
+                "function": {"name": "f", "arguments": "{}"},
+            }
+        ],
+    }
+    items = from_openai_messages([msg])
+    rebuilt = to_openai_messages(items)
+    assert rebuilt[0]["content"] is None
+
+
+def test_from_openai_messages_handles_multimodal_user_content_list() -> None:
+    """User messages with content as a list of parts collapse to joined text."""
+    msg = {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe this:"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/x.jpg"}},
+        ],
+    }
+    items = from_openai_messages([msg])
+    assert "Describe this:" in items[0].text
+
+
+def test_module_does_not_import_provider_sdk_at_load_time() -> None:
+    """Issue #219 design constraint: no provider SDK import at module level."""
+    # The openai_messages module is already imported by these tests; assert
+    # that neither openai nor any openai_* package leaked into sys.modules
+    # as a transitive import of the adapter.
+    assert "openai" not in sys.modules
+    assert "anthropic" not in sys.modules
+    assert "google.generativeai" not in sys.modules

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -142,6 +142,53 @@ def test_make_choice_cards_score_desc_id_asc_ordering() -> None:
     assert [c.id for c in cards] == ["t_aaa", "t_mmm", "t_zzz"]
 
 
+def test_make_choice_cards_byte_identical_stable_order() -> None:
+    """Issue #218: identical inputs produce byte-identical JSON across calls.
+
+    Adopters using Anthropic / OpenAI / Google prompt-caching depend on the
+    tool-definition prefix being byte-stable across requests. This regression
+    test locks the ``make_choice_cards`` invariant: same input items + same
+    scores + same tuning ⇒ same serialised bytes.
+    """
+    import json
+
+    # Inputs are constructed in a non-trivial order to exercise the sort.
+    items = [
+        _item("z_tool", description="last alphabetical"),
+        _item("a_tool", description="first alphabetical"),
+        _item("m_tool", description="middle alphabetical"),
+        _item("tied_a", description="tied score, lower id"),
+        _item("tied_b", description="tied score, higher id"),
+    ]
+    scores = {
+        "z_tool": 0.7,
+        "a_tool": 0.9,
+        "m_tool": 0.5,
+        "tied_a": 0.3,
+        "tied_b": 0.3,
+    }
+
+    cards1 = make_choice_cards(items, scores=scores)
+    cards2 = make_choice_cards(items, scores=scores)
+
+    # Structural equality of the full list.
+    assert [c.to_dict() for c in cards1] == [c.to_dict() for c in cards2]
+
+    # Byte-identical serialisation — what prompt-cache prefix relies on.
+    bytes1 = json.dumps([c.to_dict() for c in cards1], sort_keys=True).encode("utf-8")
+    bytes2 = json.dumps([c.to_dict() for c in cards2], sort_keys=True).encode("utf-8")
+    assert bytes1 == bytes2
+
+    # Expected ordering: score desc, id asc (ties: tied_a before tied_b).
+    assert [c.id for c in cards1] == [
+        "a_tool",
+        "z_tool",
+        "m_tool",
+        "tied_a",
+        "tied_b",
+    ]
+
+
 def test_make_choice_cards_no_schemas_in_output() -> None:
     items = [_item("t1", args_schema={"type": "object", "properties": {"x": {"type": "int"}}})]
     cards = make_choice_cards(items)


### PR DESCRIPTION
## Summary

Lands the 6-issue adoption group selected by the triage pass — three new provider-message adapters, a 5-line quickstart drop-in, the `make_choice_cards` byte-stable ordering contract, and the docs "context engineering" positioning polish.

Fixes #194
Fixes #219
Fixes #222
Fixes #220
Fixes #217
Fixes #218

## Changes

**New source modules (3 adapters, all pure stateless converters — no provider SDK imports at module level):**

- `src/contextweaver/adapters/openai_messages.py` — `from_openai_messages` + `to_openai_messages`. Handles `system` / `user` / `assistant` (with optional `tool_calls`) / `tool` (with `tool_call_id`) roles. `tool_call_id` round-trips to/from `ContextItem.id`; `parent_id` chains reconstructed for `tool_result → tool_call`. (closes #219)
- `src/contextweaver/adapters/anthropic_messages.py` — `from_anthropic_messages` + `to_anthropic_messages`. Three block types (`text`, `tool_use`, `tool_result`). Content-block ordering preserved via `metadata.block_index`; string-shorthand `content: "..."` round-trips back to a string. (closes #222 in part)
- `src/contextweaver/adapters/gemini_contents.py` — `from_gemini_contents` + `to_gemini_contents`. Three part types (`text`, `functionCall`, `functionResponse`). Deterministic ID synthesis (`<name>:<msg_idx>:<part_idx>`) since Gemini's `functionCall` has no native ID; FIFO pairing of duplicate-name `functionCall`/`functionResponse` pairs. (closes #222 in full and therefore #194)

**Test files (3 new):**

- `tests/test_adapters_openai_messages.py` — 16 tests, 3 round-trip fixtures (simple chat, single tool call, multi-tool-call).
- `tests/test_adapters_anthropic_messages.py` — 16 tests, 3 round-trip fixtures (simple chat, tool_use chain, string shorthand).
- `tests/test_adapters_gemini_contents.py` — 15 tests, 2 round-trip fixtures + a "two functions with the same name get distinct IDs" edge case.

Every test module asserts `sys.modules` cleanliness — no provider SDK leaks into the import graph at adapter load time.

**Docs (5 files):**

- `docs/quickstart.md` — new "Adopting from an existing chat history (5-line drop-in)" section near the top with OpenAI / Anthropic / Gemini variants. (closes #220)
- `README.md` — 3-line "Adopting in 5 lines from an existing OpenAI / Anthropic / Gemini agent" teaser in the Quickstart section. (closes #220)
- `docs/which_pattern.md` — new "I already have an OpenAI / Anthropic / Gemini agent" branch cross-linking to the quickstart section. (closes #220)
- `docs/index.md` — tagline switched to "phase-specific, budget-aware **context engineering**" with a one-line callout linking the canonical framing. (closes #217)
- `docs/architecture.md` — new "Why context engineering matters" callout (≤2 ¶, 1 citation). (closes #217)
- `docs/integration_mcp.md` — new "Prompt-caching compatibility" section with worked Anthropic `cache_control` example. (closes #218)

**Touched source / tests:**

- `src/contextweaver/routing/cards.py` — docstring guarantee on `make_choice_cards` stating the `(-score, +id)` determinism invariant. **No behavior change.** (closes #218)
- `tests/test_cards.py` — new `test_make_choice_cards_byte_identical_stable_order` regression test asserting byte-identical JSON across two consecutive calls. (closes #218)
- `src/contextweaver/adapters/__init__.py` — re-exports + `__all__` updated for the 6 new public symbols.

**Bookkeeping:**

- `CHANGELOG.md` — `## [Unreleased]` populated with one bullet per issue.
- `llms-full.txt` — regenerated via `make llms`.

## Checklist

- [x] Tests added or updated for every new/changed public function (47 new tests across 4 test files)
- [x] `make ci` passes locally (fmt + lint + type + test + example + demo) — see "How verified" below
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docstrings added for all new public APIs (Google-style)
- [ ] Every modified module stays ≤ 300 lines — **see "Tradeoffs / risks" below**: the three new adapter modules are 327 / 380 / 382 lines, in line with the existing peer pattern (`adapters/mcp.py` 401, `adapters/proxy_runtime.py` 462). Splitting each provider into `_decode.py` / `_encode.py` halves was considered and rejected as it would double the file count without reducing cognitive load. Per Mode B authority, accepting the modest overrun in this PR.
- [x] Related issue linked in the summary above
- [x] Agent-facing docs updated if pipeline, API, or conventions changed — none of those changed; adapters are additive and `make_choice_cards` is behavior-preserving

## Why

Each issue's "still relevant" judgment plus the triage report's grouping rationale: every issue here targets the same adopter persona — *"I already have an OpenAI / Anthropic / Gemini agent; how do I drop contextweaver in?"* — and the same docs surface (`README.md`, `docs/quickstart.md`, `docs/integration_mcp.md`, `docs/architecture.md`, `docs/index.md`). The cross-references between issues (`#220` "depends on `#219`", `#222` closes `#194`, `#218` composes with the adapter trio) were authored by the maintainer and naturally sequence the work into one coherent PR.

## How verified

```bash
ruff format --check src/ tests/ examples/ scripts/   # 143 files already formatted
ruff check src/ tests/ examples/ scripts/            # All checks passed!
mypy src/                                            # Success: no issues found in 67 source files
python -m pytest --cov=contextweaver -q              # 996 passed, 8 skipped in 5.92s
make example                                         # 13 example scripts ran clean
make demo                                            # Demo complete.
make scorecard-check                                 # exit=0 (no benchmark drift)
make llms-check                                      # llms.txt and llms-full.txt are up to date
make docs                                            # mkdocs built in 10s; no new link warnings
```

Targeted new-tests run:

```bash
python -m pytest \
  tests/test_adapters_openai_messages.py \
  tests/test_adapters_anthropic_messages.py \
  tests/test_adapters_gemini_contents.py \
  tests/test_cards.py -q
# → 70 passed in 0.13s
```

## Tradeoffs / risks

- **Module-size guideline overrun.** Three new adapter modules sit at 327 / 380 / 382 lines, modestly above the 300-line target. Docstrings carry most of the weight (the largest, `anthropic_messages.py`, has ~310 effective code lines after stripping blanks/comments). Splitting into `_decode.py` / `_encode.py` halves was rejected as splitting-for-splitting's-sake; existing peers `adapters/mcp.py` (401) and `adapters/proxy_runtime.py` (462) set precedent. Decomposition can land as a follow-up if reviewers prefer.
- **Issue body typo — `Sensitivity.normal`.** Issues `#219` / `#222` reference `Sensitivity.normal` as the default, but the type system only has `public` / `internal` / `confidential` / `restricted`. The adapters use `Sensitivity.public` (the actual `ContextItem` default). The behaviour matches the issue intent ("don't escalate sensitivity at ingestion").
- **Issue body typo — `ItemKind.agent_message`.** The actual enum value is `agent_msg`. The adapters use the correct name.
- **Anthropic `system` parameter.** Anthropic's system prompt is a top-level API parameter, not a message; it's intentionally out of scope per `#222`. Users with a system prompt should append it as an `ItemKind.policy` item manually.
- **Multimodal content.** OpenAI's `content` can be a list of parts (text + image). The adapter collapses text parts and JSON-encodes unknown blocks rather than silently dropping them. Anthropic / Gemini multimodal (`image`, `inlineData`, `fileData`) blocks are out of scope and would need a follow-up issue.
- **Token discounts referenced in the cache-control docs section** (90% / 50% / 75%) are provider-published figures, cited via the linked references in the prose; not benchmarked here.

## Scope notes (Mode B authorised)

- Mode B + single combined PR was selected for this change set (~2.2K LOC added, 17 files). All changes are strictly within the union of the 6 issues' acceptance criteria.
- **Not touched in this PR (each is its own follow-up):** `ProxyRuntime.cache_stable` flag (#227 — composes with #218), `RouteResult.explanation()` (#226), JSON-Schema generator (#225), OTel GenAI SemConv (#224), SQLite stores (#174/#223), Typer migration (#221), prompt file (#216), `BuildStats.report()` (#106), `ContextManager` decomposition (#101), framework adapter coverage (#193), external memory backends (#195), `JsonFileArtifactStore` (#42), dynamic per-step retrieval (#27), LLM summarizer Phase 2 (#26), embedding retrieval backend (#8), and the eval-harness package (#12).
- The triage report identified these as the next coherent groups; ready to follow up after this lands.

## Notes for reviewers

- The adapter test suite uses real `ContextManager` / `InMemoryEventLog` instances per the CONTRIBUTING.md guidance (no internal mocking).
- The `make_choice_cards` regression test (`test_make_choice_cards_byte_identical_stable_order`) intentionally uses `json.dumps(..., sort_keys=True)` so the byte comparison is robust to dict-key ordering changes in upstream Python — what we lock is the *card order* and *card content*, not the JSON serialiser's behaviour.
- The integration_mcp.md cache-control example uses `model="claude-3-5-sonnet-latest"`; if reviewers prefer a pinned model id, please flag and I'll update.

## Reproducibility (scoring / context-pipeline changes)

N/A — this PR does not touch the scoring / routing / context pipeline. `make scorecard-check` is green (no benchmark drift); only `make_choice_cards`' docstring (not its behaviour) is touched in the routing layer.

https://claude.ai/code/session_01JD32VsJUmYbUmmbgnDJ8gv

---
_Generated by [Claude Code](https://claude.ai/code/session_01JD32VsJUmYbUmmbgnDJ8gv)_