### PR TITLE
feat(cli,context,routing,observability,contracts): adopter-inspection surfaces (#106, #221, #224, #225, #226)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,13 @@ jobs:
         # numbers, which would otherwise make the check non-portable.
         run: python scripts/render_scorecard.py --check
 
+      - name: Schema drift check (gating, issue #225)
+        # Regenerates schemas from dataclasses and fails the build if the
+        # committed files differ.  This is the contract gate that catches
+        # dataclass-field changes that forget to update schemas/ and
+        # docs/schemas/v0/.
+        run: python scripts/gen_schemas.py --check
+
       - name: Weaver-spec conformance
         # Round-trip + JSON-Schema validation against the canonical contracts
         # published at https://weaver-spec.dev/contracts/v0/. Gating because

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ It prepares context and routes tools but never calls models or executes tools.
 | `routing/normalizer.py` | `CatalogNormalizer` + `NormalizationReport` for catalog metadata hygiene (issue #44) |
 | `routing/registry.py` | `EngineRegistry` and bundled `TfIdfRetriever` / `NoOpReranker` / `JaccardClusteringEngine` defaults (issue #47) |
 | `routing/trace.py` | `RouteTrace` + `TraceStep` structured routing audit (issue #51) |
+| `routing/explanation.py` | `RouteResult.explanation()` Markdown / dict rendering (issue #226) |
+| `_schema_gen.py` | Dataclass → JSON Schema (Draft 2020-12) generator + `make schemas-check` engine (issue #225) |
 | `routing/tool_id.py` | Canonical `tool_id` grammar (`parse_tool_id` / `format_tool_id` / `compute_hash8`) per `docs/gateway_spec.md` §1 |
 | `routing/path.py` | `tool_browse` path-navigation grammar (`parse_path` / `resolve_path`) per `docs/gateway_spec.md` §3 |
 | `adapters/` | MCP, FastMCP, A2A, and weaver-spec protocol adapters + MCP proxy / gateway runtime (issues #13, #28, #29, #34) |
@@ -48,7 +50,7 @@ It prepares context and routes tools but never calls models or executes tools.
 | `adapters/mcp_gateway_server.py` | Bind `mcp_gateway` onto `mcp.server.Server` over stdio (issue #28) |
 | `adapters/mcp_proxy_server.py` | Bind `mcp_proxy` onto `mcp.server.Server` over stdio (issue #13) |
 | `adapters/gateway_error.py` | Structured `GatewayError` (codes + §3.4 wire shape) |
-| `__main__.py` | CLI: 7 subcommands (`demo`, `build`, `route`, `print-tree`, `init`, `ingest`, `replay`) |
+| `__main__.py` | CLI: 8 subcommands (`demo`, `build`, `route`, `print-tree`, `init`, `ingest`, `replay`, `stats`). Typer + Rich (both core deps as of v0.5, issue #221). |
 
 ## Pipelines (summary)
 
@@ -111,6 +113,8 @@ make benchmark        # run benchmark harness (non-gating; writes benchmarks/res
 make benchmark-matrix # benchmark + per-backend × per-size matrix (#208) and per-namespace breakdown (#209)
 make scorecard        # render benchmarks/scorecard.md from benchmarks/results/latest.json
 make scorecard-check  # verify scorecard.md is up to date (exits non-zero on drift)
+make schemas         # regenerate schemas/ + docs/schemas/v0/ (issue #225)
+make schemas-check    # verify published schemas match dataclasses (gating, in `make ci`)
 make sweep-scoring    # weight sweep for ScoringConfig (#214); writes benchmarks/sweep_scoring.md
 make llms        # regenerate llms.txt and llms-full.txt from canonical docs
 make llms-check  # verify llms.txt and llms-full.txt are up to date (exits non-zero on drift)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,107 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`BuildStats.report()` and `BuildStats.report_dict()`** (#106). New
+  diagnostic-report surface on `BuildStats`: pure-data string rendering
+  (`"text"` or `"rich"` Rich-markup format) plus a versioned dict for
+  programmatic consumers. Includes phase, budget, candidate counts,
+  per-section token breakdown, drop reasons, and budget-utilisation
+  recommendations. Output is deterministic (sorted keys, stable
+  spacing).
+- **`BuildStats.prompt_tokens` property** (#106). Single source of
+  truth for `sum(tokens_per_section.values()) + header_footer_tokens`
+  — replaces six inline computations across `extras/otel.py`,
+  `__main__.py`, `metrics.py`, and example scripts.
+- **`contextweaver stats` CLI subcommand** (#106). Renders the
+  `BuildStats` report from an ingested session JSON. Supports
+  `--phase` / `--budget` / `--format {rich,text}`.
+- **`RouteResult.explanation()`** (#226). New pure-data method on
+  `RouteResult` that renders a paste-friendly Markdown rationale of
+  the routing decision — top-k table, confidence gap, ambiguity flag,
+  applied context hints, excluded/gated filter counts. `format="dict"`
+  returns a versioned (`{"version": 1, ...}`) structured payload for
+  programmatic consumers. Logic lives in the new
+  `src/contextweaver/routing/explanation.py` module to keep `router.py`
+  under the soft 300-line cap. `docs/troubleshooting.md` gains a
+  paste-ready example.
+- **JSON Schemas + drift gate** (#225, closes #196). Six committed
+  schemas under `schemas/` and `docs/schemas/v0/`:
+  `catalog.schema.json`, `choice_card.schema.json`,
+  `result_envelope.schema.json`, `route_trace.schema.json`,
+  `build_stats.schema.json`, `graph_manifest.schema.json`. Stable `$id`
+  URLs (`https://dgenio.github.io/contextweaver/schemas/v0/...`).
+  Generator (`src/contextweaver/_schema_gen.py`, stdlib-only) is
+  deterministic; `make schemas` regenerates; `make schemas-check`
+  fails on drift and is wired into `make ci` and
+  `.github/workflows/ci.yml`. `ChoiceCard` size bounds from
+  `docs/gateway_spec.md` §2 round-trip into the schema as `maxLength`
+  / `maxItems` and are also enforced at construction time via
+  `__post_init__`. `examples/sample_catalog.yaml` gains a
+  `# yaml-language-server: $schema=...` header. New
+  `docs/contracts.md`.
+- **OpenTelemetry GenAI semantic conventions** (#224). Rewrite of
+  `extras/otel.py` to emit `invoke_agent`-shaped spans for
+  `ContextManager.build()` and `execute_tool`-shaped spans for
+  `Router.route()`, populating the stable subset of `gen_ai.*`
+  attributes (`gen_ai.system="contextweaver"`,
+  `gen_ai.operation.name`, `gen_ai.usage.input_tokens`,
+  `gen_ai.tool.name`) plus an engine-specific `contextweaver.*`
+  namespace for routing-candidate detail. Token-usage histogram now
+  uses the canonical `gen_ai.client.token.usage` metric name. New
+  `docs/integration_otel.md` with Laminar + Phoenix worked examples
+  and PII-safety guidance. Default emission is PII-safe; experimental
+  attributes gated behind `otel_emit_experimental=False`. Tests use
+  `InMemorySpanExporter` for deterministic SemConv-name assertions.
+
+### Changed
+
+- **CLI: argparse → Typer + Rich** (#221).
+  `src/contextweaver/__main__.py` rewritten on top of
+  [Typer](https://typer.tiangolo.com) with Rich-formatted help,
+  panels, and tables. All seven existing subcommands (`demo`,
+  `build`, `route`, `print-tree`, `init`, `ingest`, `replay`) keep
+  their flag names — `tests/test_cli.py` still exercises every one.
+  New `stats` subcommand from #106 is wired on the same host.
+  Running `python -m contextweaver` without a subcommand now exits
+  with code 2 (Typer/Click convention) instead of 0; the no-args
+  smoke test was updated to accept either.
+- **Core dependencies**: `typer>=0.9` and `rich>=13.0` move from the
+  `[cli]` extra into core. The `[cli]` extra is kept as an empty alias
+  for one cycle (scheduled for removal in v0.6). The `_HAS_RICH`
+  guarded-import dance in `__main__.py` is gone.
+- **`ChoiceCard.kind`** tightened from `str` to
+  `Literal["tool", "agent", "skill", "internal"]` so the published
+  `choice_card.schema.json` carries the kind enumeration directly.
+  Construction-time validation (`__post_init__`) enforces the
+  gateway-spec §2 size bounds (`name` ≤ 64 chars, ≤ 5 tags each
+  ≤ 24 chars) on every path including `ChoiceCard.from_dict`.
+- **`opentelemetry-api`/`-sdk` floor bumped** from `>=1.20` to `>=1.27`
+  in the `[otel]` extra so the
+  `opentelemetry.semconv._incubating.attributes.gen_ai_attributes`
+  module is available; `opentelemetry-semantic-conventions>=0.48b0`
+  added as a direct extra dep.
+
+### Removed
+
+- **Old OTel span names**: `contextweaver.context.build` and
+  `contextweaver.routing.route` no longer emit. Dashboards keyed on
+  those names need to be re-keyed to `invoke_agent` and
+  `execute_tool`. The engine-specific
+  `contextweaver.context.firewall` and `contextweaver.context.exclude`
+  spans are preserved (no SemConv equivalent yet).
+- **Old OTel metric name**: `contextweaver.tokens.used` histogram
+  renamed to the canonical `gen_ai.client.token.usage`. The
+  engine-specific counter / histogram names
+  (`contextweaver.firewall.interceptions`,
+  `contextweaver.items.excluded`, `contextweaver.budget.exceeded`,
+  `contextweaver.routing.candidates`) are preserved.
+- **`OTelEventHook` attribute-key prefix**: engine-specific span
+  attributes moved from bare names (`phase`, `tokens`, `reason`) to
+  the `contextweaver.*` namespace to avoid colliding with future
+  SemConv additions.
+
 ## [0.4.0] - 2026-05-16
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt lint type test example demo ci docs docs-serve benchmark benchmark-matrix scorecard scorecard-check sweep-scoring architectures llms llms-check weaver-conformance
+.PHONY: fmt lint type test example demo ci docs docs-serve benchmark benchmark-matrix scorecard scorecard-check sweep-scoring architectures llms llms-check weaver-conformance schemas schemas-check
 
 fmt:
 	ruff format src/ tests/ examples/ scripts/
@@ -55,13 +55,19 @@ scorecard-check:
 sweep-scoring:
 	python scripts/sweep_scoring.py
 
-ci: fmt lint type test example demo
+ci: fmt lint type test schemas-check example demo
 
 llms:
 	python scripts/gen_llms.py
 
 llms-check:
 	python scripts/gen_llms.py --check
+
+schemas:
+	python scripts/gen_schemas.py
+
+schemas-check:
+	python scripts/gen_schemas.py --check
 
 weaver-conformance:
 	@mkdir -p .weaver-schemas

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1,0 +1,114 @@
+# Contracts — JSON Schemas for contextweaver public types
+
+> **Status:** stable as of v0.5 ([#225][i225])
+> **Closes:** [#196][i196]
+
+contextweaver publishes JSON Schemas (Draft 2020-12) for every public
+on-the-wire type so downstream tools — IDEs, catalog linters, language
+ports, evaluators, observability platforms — can program against a
+machine-readable contract instead of reverse-engineering the dataclasses.
+
+Schemas are **generated from the dataclasses** by
+`scripts/gen_schemas.py` (engine: `src/contextweaver/_schema_gen.py`)
+and committed under `schemas/`. A CI gate (`make schemas-check`, wired
+into `make ci` and `.github/workflows/ci.yml`) fails the build if a
+dataclass field is renamed without regenerating the schemas.
+
+## Published schemas
+
+| Schema file | Dataclass | Purpose |
+|---|---|---|
+| `schemas/catalog.schema.json` | `SelectableItem[]` (`src/contextweaver/types.py`) | Validates catalog JSON / YAML files (`examples/sample_catalog.yaml`). |
+| `schemas/choice_card.schema.json` | `ChoiceCard` (`src/contextweaver/envelope.py`) | Validates rendered choice cards. Carries the gateway-spec §2 size bounds (`name` ≤ 64 chars, ≤ 5 tags each ≤ 24 chars, `kind` ∈ `tool` / `agent` / `skill` / `internal`). |
+| `schemas/result_envelope.schema.json` | `ResultEnvelope` (`src/contextweaver/envelope.py`) | Validates tool-result envelopes (summary, facts, artifacts, views, provenance). |
+| `schemas/route_trace.schema.json` | `RouteTrace` (`src/contextweaver/routing/trace.py`) | Validates structured routing audit records (issue #51). |
+| `schemas/build_stats.schema.json` | `BuildStats` (`src/contextweaver/envelope.py`) | Validates diagnostic build statistics (issue #106). |
+| `schemas/graph_manifest.schema.json` | `GraphManifest` (`src/contextweaver/routing/manifest.py`) | Validates routing-graph build manifests (issues #15, #48). |
+
+Each schema is also published at a stable `$id` URL under the docs site:
+
+```
+https://dgenio.github.io/contextweaver/schemas/v0/<name>.schema.json
+```
+
+## Versioning policy
+
+Schemas are versioned independently of the library:
+
+- All current schemas live under `/v0/`.
+- Backwards-incompatible changes to any schema bump that schema to `/v1/`
+  in its own deliberate PR (and `/v0/` stays published for at least one
+  minor cycle).
+- Additive changes (new optional fields, new enum values) stay under the
+  current version.
+
+The library `version` (`pyproject.toml`) and the schema `/vN/` path
+move independently — a library minor bump does **not** automatically
+imply a schema major bump.
+
+## Regenerating
+
+```bash
+make schemas        # regenerate all 6 schemas + copy to docs/schemas/v0/
+make schemas-check  # exit non-zero on drift (gating CI step)
+```
+
+`make schemas-check` is part of `make ci` and runs in
+`.github/workflows/ci.yml`, so any PR that renames a dataclass field
+without regenerating the schemas will fail CI.
+
+## Using the schemas — VS Code YAML autocomplete
+
+The `examples/sample_catalog.yaml` file carries a top-of-file
+`# yaml-language-server: $schema=...` header:
+
+```yaml
+# yaml-language-server: $schema=https://dgenio.github.io/contextweaver/schemas/v0/catalog.schema.json
+- args_schema: {}
+  cost_hint: 0.29
+  description: Export audit log entries
+  id: admin.audit.export
+  kind: tool
+  ...
+```
+
+With the [Red Hat YAML extension][redhat-yaml] installed, VS Code now
+tab-completes `SelectableItem` fields, flags typos, and surfaces the
+size bounds (e.g. `tags` ≤ 5 entries) inline.
+
+## Using the schemas — programmatic validation
+
+```python
+import json
+import jsonschema
+
+with open("schemas/choice_card.schema.json") as f:
+    schema = json.load(f)
+
+with open("some_card.json") as f:
+    instance = json.load(f)
+
+jsonschema.validate(instance, schema)  # raises on contract violation
+```
+
+contextweaver ships `jsonschema>=4.0` as a core dependency
+(`pyproject.toml`), so no extra install is needed in downstream Python
+code that already depends on contextweaver.
+
+## Round-trip guarantee
+
+For every published schema, the following round-trip holds:
+
+```python
+instance = TheDataclass(...)               # construct
+payload = instance.to_dict()               # serialise
+jsonschema.validate(payload, the_schema)   # validates clean
+restored = TheDataclass.from_dict(payload) # deserialise
+assert restored == instance                # equal
+```
+
+`tests/test_schema_gen.py` enforces this for all 6 schemas.
+
+[i225]: https://github.com/dgenio/contextweaver/issues/225
+[i196]: https://github.com/dgenio/contextweaver/issues/196
+[redhat-yaml]: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml

--- a/docs/integration_otel.md
+++ b/docs/integration_otel.md
@@ -1,0 +1,147 @@
+# OpenTelemetry GenAI integration
+
+> **Status:** stable as of v0.5 ([#224][i224])
+> **Extra:** `pip install 'contextweaver[otel]'`
+
+contextweaver emits OpenTelemetry spans and metrics that conform to the
+official [OpenTelemetry GenAI Semantic Conventions][gen-ai-spans]. Modern
+agent-observability platforms — [Laminar], [Phoenix], [Langfuse],
+[LangSmith] — speak `gen_ai.*` natively, so contextweaver activity renders
+as agent / tool spans rather than generic ones.
+
+## Install
+
+```bash
+pip install 'contextweaver[otel]'
+```
+
+The extra pulls `opentelemetry-api>=1.27`, `opentelemetry-sdk>=1.27`, and
+`opentelemetry-semantic-conventions>=0.48b0`. The core install
+(`pip install contextweaver`) does not pull these — the integration is
+strictly opt-in.
+
+## Wire the hook
+
+```python
+from contextweaver.context.manager import ContextManager
+from contextweaver.extras.otel import OTelEventHook
+
+hook = OTelEventHook(service_name="my-agent")
+mgr = ContextManager(hook=hook)
+```
+
+Every `mgr.build_sync(...)` and `Router.route(...)` call now emits the
+appropriate GenAI span automatically. See
+[contextweaver/extras/otel.py][otel-source] for the full method set.
+
+## Span shapes
+
+| Span name | When emitted | Attributes |
+|---|---|---|
+| `invoke_agent` | One per `ContextManager.build()` | `gen_ai.system="contextweaver"`, `gen_ai.operation.name="invoke_agent"`, `gen_ai.usage.input_tokens` (= `BuildStats.prompt_tokens`), plus `contextweaver.phase`, `contextweaver.candidates.*` (engine-specific). |
+| `execute_tool` | One per `Router.route()` | `gen_ai.system="contextweaver"`, `gen_ai.operation.name="execute_tool"`, `gen_ai.tool.name` (the rank-1 candidate), plus `contextweaver.routing.candidate_count` and `contextweaver.routing.candidate_ids` (full ranked list). |
+| `contextweaver.context.firewall` | One per firewall interception | `contextweaver.firewall.reason`, `contextweaver.item.kind`. |
+| `contextweaver.context.exclude` | One per exclusion batch | `contextweaver.exclude.reason`, `contextweaver.exclude.count`. |
+
+The two `gen_ai.*` spans are the load-bearing ones for downstream
+platforms; the `contextweaver.*` spans are engine-specific audit detail
+that is not yet covered by upstream SemConv.
+
+## Metric shapes
+
+| Metric name | Type | Attributes |
+|---|---|---|
+| `gen_ai.client.token.usage` | histogram | `gen_ai.operation.name`, `gen_ai.token.type="input"`, `gen_ai.system="contextweaver"` |
+| `contextweaver.firewall.interceptions` | counter | `contextweaver.firewall.reason` |
+| `contextweaver.items.excluded` | counter | `contextweaver.exclude.reason` |
+| `contextweaver.budget.exceeded` | counter | `contextweaver.budget.requested`, `contextweaver.budget.limit` |
+| `contextweaver.routing.candidates` | histogram | `gen_ai.operation.name`, `gen_ai.system` |
+
+## Worked example — Phoenix
+
+[Phoenix] consumes OTLP and renders `invoke_agent` / `execute_tool` spans
+as collapsible agent traces. A minimal wiring:
+
+```python
+from phoenix.otel import register
+from contextweaver.context.manager import ContextManager
+from contextweaver.extras.otel import OTelEventHook
+from contextweaver.types import ContextItem, ItemKind, Phase
+
+register(project_name="my-agent", endpoint="http://localhost:6006/v1/traces")
+hook = OTelEventHook(service_name="my-agent")
+mgr = ContextManager(hook=hook)
+
+mgr.ingest(
+    ContextItem(id="u1", kind=ItemKind.user_turn, text="find open invoices")
+)
+pack = mgr.build_sync(phase=Phase.answer, query="open invoices")
+# Phoenix UI now shows a single `invoke_agent` span with prompt_tokens
+# under `gen_ai.usage.input_tokens` and `contextweaver.phase=answer`.
+```
+
+## Worked example — Laminar
+
+[Laminar] auto-imports `gen_ai.*` spans and renders them in its agent
+timeline. Wire OTLP the same way:
+
+```python
+import os
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+provider = TracerProvider()
+provider.add_span_processor(
+    BatchSpanProcessor(
+        OTLPSpanExporter(
+            endpoint="https://api.lmnr.ai/v1/traces",
+            headers={"Authorization": f"Bearer {os.environ['LMNR_PROJECT_API_KEY']}"},
+        )
+    )
+)
+trace.set_tracer_provider(provider)
+
+# Now any contextweaver build / route call emits via the configured
+# exporter under the `contextweaver` service name.
+```
+
+## Privacy guidance
+
+The default emission does **not** include raw query strings, full tool
+descriptions, or any `args_schema` content — those can carry sensitive
+payloads in some tool catalogs. Reference: [OpenTelemetry GenAI Tracing
+AI Agents Without Leaking PII][maketocreate-pii].
+
+To opt into experimental attributes (e.g. raw-prompt content under
+`gen_ai.prompt`), pass `otel_emit_experimental=True` at construction
+time. Only enable it when the observability backend is trusted to
+handle PII appropriately.
+
+```python
+# Off by default — PII-safe:
+hook = OTelEventHook(service_name="my-agent")
+
+# Opt-in when running on a trusted backend with redaction in place:
+hook = OTelEventHook(service_name="my-agent", otel_emit_experimental=True)
+```
+
+## SemConv version note
+
+The GenAI Semantic Conventions are still flagged **Development** status
+upstream. contextweaver imports them via the
+`opentelemetry.semconv._incubating.attributes.gen_ai_attributes` path,
+which is the OTel project's convention for unstable surfaces. When
+upstream graduates the conventions, the import path will change but the
+emitted attribute *names* are spec-stable (e.g. `gen_ai.system`,
+`gen_ai.operation.name`) — your dashboards will keep working.
+
+[i224]: https://github.com/dgenio/contextweaver/issues/224
+[gen-ai-spans]: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/
+[Laminar]: https://laminar.sh/
+[Phoenix]: https://phoenix.arize.com/
+[Langfuse]: https://langfuse.com/
+[LangSmith]: https://www.langchain.com/langsmith
+[otel-source]: https://github.com/dgenio/contextweaver/blob/main/src/contextweaver/extras/otel.py
+[maketocreate-pii]: https://maketocreate.com/opentelemetry-genai-tracing-ai-agents-without-leaking-pii/

--- a/docs/schemas/v0/build_stats.schema.json
+++ b/docs/schemas/v0/build_stats.schema.json
@@ -1,0 +1,40 @@
+{
+  "$id": "https://dgenio.github.io/contextweaver/schemas/v0/build_stats.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Diagnostic statistics produced by a context build pass.",
+  "properties": {
+    "dedup_removed": {
+      "type": "integer"
+    },
+    "dependency_closures": {
+      "type": "integer"
+    },
+    "dropped_count": {
+      "type": "integer"
+    },
+    "dropped_reasons": {
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "header_footer_tokens": {
+      "type": "integer"
+    },
+    "included_count": {
+      "type": "integer"
+    },
+    "tokens_per_section": {
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "total_candidates": {
+      "type": "integer"
+    }
+  },
+  "title": "BuildStats",
+  "type": "object"
+}

--- a/docs/schemas/v0/catalog.schema.json
+++ b/docs/schemas/v0/catalog.schema.json
@@ -1,0 +1,80 @@
+{
+  "$id": "https://dgenio.github.io/contextweaver/schemas/v0/catalog.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "items": {
+    "additionalProperties": false,
+    "description": "A unified representation of a tool, agent, skill, or internal function.",
+    "properties": {
+      "args_schema": {
+        "additionalProperties": {},
+        "type": "object"
+      },
+      "constraints": {
+        "additionalProperties": {},
+        "type": "object"
+      },
+      "cost_hint": {
+        "type": "number"
+      },
+      "description": {
+        "type": "string"
+      },
+      "examples": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "id": {
+        "type": "string"
+      },
+      "kind": {
+        "enum": [
+          "tool",
+          "agent",
+          "skill",
+          "internal"
+        ]
+      },
+      "metadata": {
+        "additionalProperties": {},
+        "type": "object"
+      },
+      "name": {
+        "type": "string"
+      },
+      "namespace": {
+        "type": "string"
+      },
+      "output_schema": {
+        "anyOf": [
+          {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "side_effects": {
+        "type": "boolean"
+      },
+      "tags": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "description",
+      "id",
+      "kind",
+      "name"
+    ],
+    "type": "object"
+  },
+  "title": "contextweaver catalog (SelectableItem[])",
+  "type": "array"
+}

--- a/docs/schemas/v0/choice_card.schema.json
+++ b/docs/schemas/v0/choice_card.schema.json
@@ -1,0 +1,63 @@
+{
+  "$id": "https://dgenio.github.io/contextweaver/schemas/v0/choice_card.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "A compact, LLM-friendly representation of a :class:`SelectableItem`.",
+  "properties": {
+    "cost_hint": {
+      "type": "number"
+    },
+    "description": {
+      "type": "string"
+    },
+    "has_schema": {
+      "type": "boolean"
+    },
+    "id": {
+      "type": "string"
+    },
+    "kind": {
+      "enum": [
+        "tool",
+        "agent",
+        "skill",
+        "internal"
+      ]
+    },
+    "name": {
+      "maxLength": 64,
+      "type": "string"
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "score": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "side_effects": {
+      "type": "boolean"
+    },
+    "tags": {
+      "items": {
+        "maxLength": 24,
+        "type": "string"
+      },
+      "maxItems": 5,
+      "type": "array"
+    }
+  },
+  "required": [
+    "description",
+    "id",
+    "name"
+  ],
+  "title": "ChoiceCard",
+  "type": "object"
+}

--- a/docs/schemas/v0/graph_manifest.schema.json
+++ b/docs/schemas/v0/graph_manifest.schema.json
@@ -1,0 +1,48 @@
+{
+  "$id": "https://dgenio.github.io/contextweaver/schemas/v0/graph_manifest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Formal build metadata for a :class:`ChoiceGraph`.",
+  "properties": {
+    "build_hash": {
+      "type": "string"
+    },
+    "engine_versions": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "extra": {
+      "additionalProperties": {},
+      "type": "object"
+    },
+    "item_count": {
+      "type": "integer"
+    },
+    "manifest_version": {
+      "type": "integer"
+    },
+    "max_depth": {
+      "type": "integer"
+    },
+    "seed": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "strategy": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "number"
+    }
+  },
+  "title": "GraphManifest",
+  "type": "object"
+}

--- a/docs/schemas/v0/result_envelope.schema.json
+++ b/docs/schemas/v0/result_envelope.schema.json
@@ -1,0 +1,106 @@
+{
+  "$defs": {
+    "ArtifactRef": {
+      "additionalProperties": false,
+      "description": "A lightweight reference to an out-of-band artifact stored in an ArtifactStore.",
+      "properties": {
+        "content_hash": {
+          "type": "string"
+        },
+        "handle": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "media_type": {
+          "type": "string"
+        },
+        "size_bytes": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "handle",
+        "media_type",
+        "size_bytes"
+      ],
+      "type": "object"
+    },
+    "ViewSpec": {
+      "additionalProperties": false,
+      "description": "Specifies a named view (a filtered/projected representation) of an artifact.",
+      "properties": {
+        "artifact_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ArtifactRef"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
+          "type": "string"
+        },
+        "selector": {
+          "additionalProperties": {},
+          "type": "object"
+        },
+        "view_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "label",
+        "view_id"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://dgenio.github.io/contextweaver/schemas/v0/result_envelope.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Wraps the output of a tool call with LLM-friendly summaries and structured data.",
+  "properties": {
+    "artifacts": {
+      "items": {
+        "$ref": "#/$defs/ArtifactRef"
+      },
+      "type": "array"
+    },
+    "facts": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "provenance": {
+      "additionalProperties": {},
+      "type": "object"
+    },
+    "status": {
+      "enum": [
+        "ok",
+        "partial",
+        "error"
+      ]
+    },
+    "summary": {
+      "type": "string"
+    },
+    "views": {
+      "items": {
+        "$ref": "#/$defs/ViewSpec"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "status",
+    "summary"
+  ],
+  "title": "ResultEnvelope",
+  "type": "object"
+}

--- a/docs/schemas/v0/route_trace.schema.json
+++ b/docs/schemas/v0/route_trace.schema.json
@@ -1,0 +1,108 @@
+{
+  "$defs": {
+    "TraceStep": {
+      "additionalProperties": false,
+      "description": "One beam-search expansion in a :class:`RouteTrace`.",
+      "properties": {
+        "depth": {
+          "type": "integer"
+        },
+        "kept": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "node": {
+          "type": "string"
+        },
+        "scored_children": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "score": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "score"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "depth",
+        "node"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://dgenio.github.io/contextweaver/schemas/v0/route_trace.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Structured audit record of a single routing call.",
+  "properties": {
+    "clarifying_question": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "confidence_gap": {
+      "type": "number"
+    },
+    "excluded_count": {
+      "type": "integer"
+    },
+    "extra": {
+      "additionalProperties": {},
+      "type": "object"
+    },
+    "gated_count": {
+      "type": "integer"
+    },
+    "is_ambiguous": {
+      "type": "boolean"
+    },
+    "query": {
+      "type": "string"
+    },
+    "retriever_engine": {
+      "type": "string"
+    },
+    "runner_up_score": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "steps": {
+      "items": {
+        "$ref": "#/$defs/TraceStep"
+      },
+      "type": "array"
+    },
+    "top_score": {
+      "type": "number"
+    },
+    "trace_version": {
+      "type": "integer"
+    }
+  },
+  "title": "RouteTrace",
+  "type": "object"
+}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -17,7 +17,8 @@ Three tools cover the majority of debugging scenarios:
   beam-search path taken for each query.
 
 If a problem is framework-specific, check the integration guides in `docs/`:
-[MCP](integration_mcp.md) · [A2A](integration_a2a.md).
+[MCP](integration_mcp.md) · [A2A](integration_a2a.md) ·
+[OpenTelemetry GenAI](integration_otel.md).
 
 ---
 
@@ -125,6 +126,46 @@ for step in result.debug_trace:
     print(step)
 # Shows each beam expansion, node scores, and why items were (de-)prioritised
 ```
+
+**Solution D — render an explanation of the decision surface (`RouteResult.explanation()`):**
+
+`RouteResult.explanation()` (issue #226) produces a paste-friendly Markdown
+rationale of why the router ranked the candidates the way it did — top-k
+table, confidence gap, ambiguity flag, applied context hints, filter counts.
+Useful in GitHub issues, Slack threads, and PR descriptions when reporting
+unexpected routing behaviour:
+
+```python
+result = router.route("send an email")
+print(result.explanation())                # default Markdown form
+payload = result.explanation(format="dict")  # versioned structured payload
+```
+
+Sample Markdown output:
+
+```markdown
+### Routing explanation for query `send an email`
+
+_Retriever engine: `tfidf`._
+
+**Top candidates**
+
+| Rank | Tool id | Score |
+|---:|:---|---:|
+| 1 | `comms.email.send` | 0.8421 |
+| 2 | `comms.sms.send` | 0.6105 |
+| 3 | `crm.tickets.create` | 0.4988 |
+
+**Confidence gap**: `comms.email.send` (0.8421) vs runner-up `comms.sms.send` (0.6105) = **+0.2316**.
+
+✅ Result is **not** ambiguous (gap above threshold).
+```
+
+The dict form (`format="dict"`) returns a versioned schema
+(`{"version": 1, ...}`) that is safe for programmatic consumers (observability
+spans, automated test assertions). Privacy: the explanation surfaces item ids,
+scores, and the original query — it never includes `args_schema` content or
+full item descriptions.
 
 ---
 

--- a/examples/sample_catalog.yaml
+++ b/examples/sample_catalog.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://dgenio.github.io/contextweaver/schemas/v0/catalog.schema.json
 - args_schema: {}
   cost_hint: 0.29
   description: Export audit log entries

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,12 +81,15 @@ nav:
       - Pipecat: integration_pipecat.md
   - Architecture: architecture.md
   - Benchmarks: benchmarks.md
+  - Contracts: contracts.md
+  - Observability: integration_otel.md
   - Troubleshooting: troubleshooting.md
   - API Reference: reference/
 
 exclude_docs: |
   agent-context/*
   gen_ref_pages.py
+  schemas/**/*
 
 not_in_nav: |
   agent-context/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "contextweaver"
-version = "0.4.0"
+version = "0.5.0"
 description = "Dynamic context management for tool-using AI agents"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -43,14 +43,19 @@ classifiers = [
 # gating them behind extras forced every caller through a guarded-import
 # dance.  ``tiktoken``, ``PyYAML``, ``rank-bm25`` are broadly used in GenAI
 # stacks (often already pulled in transitively) and unblock default behaviour
-# the library would otherwise have to approximate.  Other heavy or
-# runtime-specific packages remain under [project.optional-dependencies].
+# the library would otherwise have to approximate.  ``typer`` and ``rich``
+# moved into core in v0.5 alongside the Typer CLI rewrite (#221) — the CLI
+# is one of the project's primary user touchpoints and the ``_HAS_RICH``
+# guarded-import dance had become its own maintenance burden.  Other heavy
+# or runtime-specific packages remain under [project.optional-dependencies].
 dependencies = [
     "tiktoken>=0.5",
     "PyYAML>=6.0",
     "rank-bm25>=0.2",
     "mcp>=1.0",
     "jsonschema>=4.0",
+    "typer>=0.9",
+    "rich>=13.0",
 ]
 
 [project.urls]
@@ -100,12 +105,11 @@ docs = [
     "mkdocs-literate-nav>=0.6",
     "mkdocs-section-index>=0.3",
 ]
-# Enhanced CLI: rich-formatted output (tree, tables) for the existing argparse CLI.
-# A typer-based rewrite of __main__.py is tracked separately under the v0.6 milestone;
-# do not add typer here until that work lands so the extra reflects what users actually get.
-cli = [
-    "rich>=13.0",
-]
+# Deprecated empty alias.  Typer + Rich became core deps in v0.5 (#221), so
+# ``pip install 'contextweaver[cli]'`` is now equivalent to a plain install.
+# Kept as a no-op for one cycle so existing requirements pins do not break;
+# scheduled for removal in v0.6.
+cli = []
 # Fuzzy lexical retrieval backend (rapidfuzz) — supplements the default BM25
 # scorer for typo / abbreviation tolerance.
 retrieval = [
@@ -116,10 +120,14 @@ retrieval = [
 ann = [
     "hnswlib>=0.8",
 ]
-# OpenTelemetry tracing + metrics export.
+# OpenTelemetry tracing + metrics export with native GenAI semantic
+# conventions (#224).  Pinned at >=1.27 because the
+# ``opentelemetry.semconv.attributes.gen_ai_attributes`` module landed in
+# that release — older floors require hand-typing the attribute strings.
 otel = [
-    "opentelemetry-api>=1.20",
-    "opentelemetry-sdk>=1.20",
+    "opentelemetry-api>=1.27",
+    "opentelemetry-sdk>=1.27",
+    "opentelemetry-semantic-conventions>=0.48b0",
 ]
 # NetworkX-backed graph ops. Reserved; no functional code references these yet.
 graph = [
@@ -127,7 +135,6 @@ graph = [
 ]
 # Convenience: install every optional capability at once.
 all = [
-    "contextweaver[cli]",
     "contextweaver[retrieval]",
     "contextweaver[ann]",
     "contextweaver[otel]",
@@ -190,6 +197,14 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = "typer.*"
 ignore_missing_imports = true
+
+# Typer's ``@app.command()`` decorator is typed as a generic callable in 0.9-
+# 0.12, which trips ``disallow_untyped_decorators`` under strict mypy.
+# Carve out ``__main__`` (the only Typer consumer) rather than disable the
+# strictness globally.
+[[tool.mypy.overrides]]
+module = "contextweaver.__main__"
+disallow_untyped_decorators = false
 
 # weaver_contracts does not ship a py.typed marker; treat as untyped for mypy
 # while still being a real installed package the adapter can import.

--- a/schemas/build_stats.schema.json
+++ b/schemas/build_stats.schema.json
@@ -1,0 +1,40 @@
+{
+  "$id": "https://dgenio.github.io/contextweaver/schemas/v0/build_stats.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Diagnostic statistics produced by a context build pass.",
+  "properties": {
+    "dedup_removed": {
+      "type": "integer"
+    },
+    "dependency_closures": {
+      "type": "integer"
+    },
+    "dropped_count": {
+      "type": "integer"
+    },
+    "dropped_reasons": {
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "header_footer_tokens": {
+      "type": "integer"
+    },
+    "included_count": {
+      "type": "integer"
+    },
+    "tokens_per_section": {
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "type": "object"
+    },
+    "total_candidates": {
+      "type": "integer"
+    }
+  },
+  "title": "BuildStats",
+  "type": "object"
+}

--- a/schemas/catalog.schema.json
+++ b/schemas/catalog.schema.json
@@ -1,0 +1,80 @@
+{
+  "$id": "https://dgenio.github.io/contextweaver/schemas/v0/catalog.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "items": {
+    "additionalProperties": false,
+    "description": "A unified representation of a tool, agent, skill, or internal function.",
+    "properties": {
+      "args_schema": {
+        "additionalProperties": {},
+        "type": "object"
+      },
+      "constraints": {
+        "additionalProperties": {},
+        "type": "object"
+      },
+      "cost_hint": {
+        "type": "number"
+      },
+      "description": {
+        "type": "string"
+      },
+      "examples": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "id": {
+        "type": "string"
+      },
+      "kind": {
+        "enum": [
+          "tool",
+          "agent",
+          "skill",
+          "internal"
+        ]
+      },
+      "metadata": {
+        "additionalProperties": {},
+        "type": "object"
+      },
+      "name": {
+        "type": "string"
+      },
+      "namespace": {
+        "type": "string"
+      },
+      "output_schema": {
+        "anyOf": [
+          {
+            "additionalProperties": {},
+            "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "side_effects": {
+        "type": "boolean"
+      },
+      "tags": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      }
+    },
+    "required": [
+      "description",
+      "id",
+      "kind",
+      "name"
+    ],
+    "type": "object"
+  },
+  "title": "contextweaver catalog (SelectableItem[])",
+  "type": "array"
+}

--- a/schemas/choice_card.schema.json
+++ b/schemas/choice_card.schema.json
@@ -1,0 +1,63 @@
+{
+  "$id": "https://dgenio.github.io/contextweaver/schemas/v0/choice_card.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "A compact, LLM-friendly representation of a :class:`SelectableItem`.",
+  "properties": {
+    "cost_hint": {
+      "type": "number"
+    },
+    "description": {
+      "type": "string"
+    },
+    "has_schema": {
+      "type": "boolean"
+    },
+    "id": {
+      "type": "string"
+    },
+    "kind": {
+      "enum": [
+        "tool",
+        "agent",
+        "skill",
+        "internal"
+      ]
+    },
+    "name": {
+      "maxLength": 64,
+      "type": "string"
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "score": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "side_effects": {
+      "type": "boolean"
+    },
+    "tags": {
+      "items": {
+        "maxLength": 24,
+        "type": "string"
+      },
+      "maxItems": 5,
+      "type": "array"
+    }
+  },
+  "required": [
+    "description",
+    "id",
+    "name"
+  ],
+  "title": "ChoiceCard",
+  "type": "object"
+}

--- a/schemas/graph_manifest.schema.json
+++ b/schemas/graph_manifest.schema.json
@@ -1,0 +1,48 @@
+{
+  "$id": "https://dgenio.github.io/contextweaver/schemas/v0/graph_manifest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Formal build metadata for a :class:`ChoiceGraph`.",
+  "properties": {
+    "build_hash": {
+      "type": "string"
+    },
+    "engine_versions": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "type": "object"
+    },
+    "extra": {
+      "additionalProperties": {},
+      "type": "object"
+    },
+    "item_count": {
+      "type": "integer"
+    },
+    "manifest_version": {
+      "type": "integer"
+    },
+    "max_depth": {
+      "type": "integer"
+    },
+    "seed": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "strategy": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "number"
+    }
+  },
+  "title": "GraphManifest",
+  "type": "object"
+}

--- a/schemas/result_envelope.schema.json
+++ b/schemas/result_envelope.schema.json
@@ -1,0 +1,106 @@
+{
+  "$defs": {
+    "ArtifactRef": {
+      "additionalProperties": false,
+      "description": "A lightweight reference to an out-of-band artifact stored in an ArtifactStore.",
+      "properties": {
+        "content_hash": {
+          "type": "string"
+        },
+        "handle": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "media_type": {
+          "type": "string"
+        },
+        "size_bytes": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "handle",
+        "media_type",
+        "size_bytes"
+      ],
+      "type": "object"
+    },
+    "ViewSpec": {
+      "additionalProperties": false,
+      "description": "Specifies a named view (a filtered/projected representation) of an artifact.",
+      "properties": {
+        "artifact_ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ArtifactRef"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "label": {
+          "type": "string"
+        },
+        "selector": {
+          "additionalProperties": {},
+          "type": "object"
+        },
+        "view_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "label",
+        "view_id"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://dgenio.github.io/contextweaver/schemas/v0/result_envelope.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Wraps the output of a tool call with LLM-friendly summaries and structured data.",
+  "properties": {
+    "artifacts": {
+      "items": {
+        "$ref": "#/$defs/ArtifactRef"
+      },
+      "type": "array"
+    },
+    "facts": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "provenance": {
+      "additionalProperties": {},
+      "type": "object"
+    },
+    "status": {
+      "enum": [
+        "ok",
+        "partial",
+        "error"
+      ]
+    },
+    "summary": {
+      "type": "string"
+    },
+    "views": {
+      "items": {
+        "$ref": "#/$defs/ViewSpec"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "status",
+    "summary"
+  ],
+  "title": "ResultEnvelope",
+  "type": "object"
+}

--- a/schemas/route_trace.schema.json
+++ b/schemas/route_trace.schema.json
@@ -1,0 +1,108 @@
+{
+  "$defs": {
+    "TraceStep": {
+      "additionalProperties": false,
+      "description": "One beam-search expansion in a :class:`RouteTrace`.",
+      "properties": {
+        "depth": {
+          "type": "integer"
+        },
+        "kept": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "node": {
+          "type": "string"
+        },
+        "scored_children": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "score": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "score"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "depth",
+        "node"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://dgenio.github.io/contextweaver/schemas/v0/route_trace.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Structured audit record of a single routing call.",
+  "properties": {
+    "clarifying_question": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "confidence_gap": {
+      "type": "number"
+    },
+    "excluded_count": {
+      "type": "integer"
+    },
+    "extra": {
+      "additionalProperties": {},
+      "type": "object"
+    },
+    "gated_count": {
+      "type": "integer"
+    },
+    "is_ambiguous": {
+      "type": "boolean"
+    },
+    "query": {
+      "type": "string"
+    },
+    "retriever_engine": {
+      "type": "string"
+    },
+    "runner_up_score": {
+      "anyOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "steps": {
+      "items": {
+        "$ref": "#/$defs/TraceStep"
+      },
+      "type": "array"
+    },
+    "top_score": {
+      "type": "number"
+    },
+    "trace_version": {
+      "type": "integer"
+    }
+  },
+  "title": "RouteTrace",
+  "type": "object"
+}

--- a/scripts/gen_schemas.py
+++ b/scripts/gen_schemas.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Regenerate ``schemas/*.schema.json`` from contextweaver dataclasses (issue #225).
+
+Six published schemas:
+
+- ``catalog.schema.json`` — array of :class:`~contextweaver.types.SelectableItem`.
+- ``choice_card.schema.json`` — :class:`~contextweaver.envelope.ChoiceCard`
+  (carries the gateway-spec §2 size bounds as ``maxLength`` / ``maxItems``).
+- ``result_envelope.schema.json`` — :class:`~contextweaver.envelope.ResultEnvelope`.
+- ``route_trace.schema.json`` — :class:`~contextweaver.routing.trace.RouteTrace`.
+- ``build_stats.schema.json`` — :class:`~contextweaver.envelope.BuildStats`.
+- ``graph_manifest.schema.json`` — :class:`~contextweaver.routing.manifest.GraphManifest`.
+
+Usage::
+
+    python scripts/gen_schemas.py            # regenerate all 6 + copy to docs/
+    python scripts/gen_schemas.py --check    # exit non-zero on drift
+
+The ``--check`` mode is the engine of ``make schemas-check`` and is wired
+into ``make ci``.  CI re-runs it on every PR so dataclass-field drift cannot
+ship without the schema being regenerated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from contextweaver._schema_gen import (
+    SCHEMA_ID_BASE,
+    generate_array_schema,
+    generate_schema,
+    schema_to_json,
+)
+from contextweaver.envelope import BuildStats, ChoiceCard, ResultEnvelope
+from contextweaver.routing.manifest import GraphManifest
+from contextweaver.routing.trace import RouteTrace
+from contextweaver.types import SelectableItem
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMAS_DIR = REPO_ROOT / "schemas"
+DOCS_SCHEMAS_DIR = REPO_ROOT / "docs" / "schemas" / "v0"
+
+
+def _build_schemas() -> dict[str, str]:
+    """Return ``{relative_path: serialised_json}`` for every schema."""
+    schemas: dict[str, str] = {}
+    schemas["catalog.schema.json"] = schema_to_json(
+        generate_array_schema(
+            SelectableItem,
+            schema_id=f"{SCHEMA_ID_BASE}/catalog.schema.json",
+            title="contextweaver catalog (SelectableItem[])",
+        )
+    )
+    schemas["choice_card.schema.json"] = schema_to_json(
+        generate_schema(ChoiceCard, schema_id=f"{SCHEMA_ID_BASE}/choice_card.schema.json")
+    )
+    schemas["result_envelope.schema.json"] = schema_to_json(
+        generate_schema(ResultEnvelope, schema_id=f"{SCHEMA_ID_BASE}/result_envelope.schema.json")
+    )
+    schemas["route_trace.schema.json"] = schema_to_json(
+        generate_schema(RouteTrace, schema_id=f"{SCHEMA_ID_BASE}/route_trace.schema.json")
+    )
+    schemas["build_stats.schema.json"] = schema_to_json(
+        generate_schema(BuildStats, schema_id=f"{SCHEMA_ID_BASE}/build_stats.schema.json")
+    )
+    schemas["graph_manifest.schema.json"] = schema_to_json(
+        generate_schema(GraphManifest, schema_id=f"{SCHEMA_ID_BASE}/graph_manifest.schema.json")
+    )
+    return schemas
+
+
+def _write(schemas: dict[str, str]) -> None:
+    SCHEMAS_DIR.mkdir(parents=True, exist_ok=True)
+    DOCS_SCHEMAS_DIR.mkdir(parents=True, exist_ok=True)
+    for name, body in schemas.items():
+        (SCHEMAS_DIR / name).write_text(body, encoding="utf-8")
+    # Mirror under docs/ so mkdocs publishes them at the $id URL.
+    for name in schemas:
+        shutil.copyfile(SCHEMAS_DIR / name, DOCS_SCHEMAS_DIR / name)
+
+
+def _check(schemas: dict[str, str]) -> int:
+    drifted: list[str] = []
+    for name, expected in schemas.items():
+        on_disk = SCHEMAS_DIR / name
+        if not on_disk.exists() or on_disk.read_text(encoding="utf-8") != expected:
+            drifted.append(name)
+        mirror = DOCS_SCHEMAS_DIR / name
+        if not mirror.exists() or mirror.read_text(encoding="utf-8") != expected:
+            drifted.append(f"docs/schemas/v0/{name}")
+    if drifted:
+        print("schemas drifted — run `make schemas`:", file=sys.stderr)
+        for path in drifted:
+            print(f"  {path}", file=sys.stderr)
+        return 1
+    print("schemas up to date")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero on drift instead of writing schemas.",
+    )
+    args = parser.parse_args(argv)
+
+    schemas = _build_schemas()
+
+    if args.check:
+        return _check(schemas)
+
+    _write(schemas)
+    print(f"wrote {len(schemas)} schemas to {SCHEMAS_DIR.relative_to(REPO_ROOT)}/")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/contextweaver/__main__.py
+++ b/src/contextweaver/__main__.py
@@ -1,6 +1,6 @@
 """Command-line interface for contextweaver.
 
-Provides seven sub-commands:
+Provides eight sub-commands:
 
 demo        Run a built-in demonstration of both engines.
 build       Build a routing graph from a catalog JSON file.
@@ -9,28 +9,28 @@ print-tree  Pretty-print the routing tree for a graph.
 init        Scaffold contextweaver config + sample catalog in cwd.
 ingest      Ingest a JSONL session into a serialised session file.
 replay      Replay a session and build context for a given phase.
+stats       Render a human-readable :class:`BuildStats` diagnostic report
+            from an ingested session (issue #106).
 
 Invocable as ``python -m contextweaver`` or ``contextweaver`` (via
-``[project.scripts]``).  Exempt from 300-line module limit.
+``[project.scripts]``).  Exempt from the 300-line module limit.
+
+Built on `Typer <https://typer.tiangolo.com>`_ + `Rich <https://rich.readthedocs.io>`_
+(both core dependencies as of v0.5; the legacy ``[cli]`` extra is kept as an
+empty alias for one cycle).  Issue #221.
 """
 
 from __future__ import annotations
 
-import argparse
-
-# `[cli]` extra adds rich-formatted output. Guarded import keeps the CLI
-# fully functional with stdlib-only argparse when the extra is absent.
-try:
-    from rich.console import Console as _RichConsole
-    from rich.tree import Tree as _RichTree
-
-    _HAS_RICH = True
-except ImportError:  # pragma: no cover - exercised only when extra is missing
-    _HAS_RICH = False
 import json
 import sys
+from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
+
+import typer
+from rich.console import Console
+from rich.tree import Tree as RichTree
 
 from contextweaver.config import ContextBudget
 from contextweaver.context.manager import ContextManager
@@ -40,6 +40,37 @@ from contextweaver.routing.graph_io import load_graph, save_graph
 from contextweaver.routing.router import Router
 from contextweaver.routing.tree import TreeBuilder
 from contextweaver.types import ContextItem, ItemKind, Phase, SelectableItem
+
+# ---------------------------------------------------------------------------
+# Typer app + global console
+# ---------------------------------------------------------------------------
+
+app = typer.Typer(
+    name="contextweaver",
+    help="Dynamic context management for tool-using AI agents.",
+    no_args_is_help=True,
+    add_completion=False,
+    rich_markup_mode="rich",
+)
+
+_console = Console()
+
+
+# Typer prefers ``str`` Enums for ``--phase``-style choice flags over Click's
+# ``Choice`` because the Enum members produce typed values inside the handler
+# (and Typer auto-renders them as ``--phase [route|call|interpret|answer]``
+# in ``--help`` output).
+class _PhaseChoice(str, Enum):
+    route = "route"
+    call = "call"
+    interpret = "interpret"
+    answer = "answer"
+
+
+class _StatsFormatChoice(str, Enum):
+    rich = "rich"
+    text = "text"
+
 
 # ---------------------------------------------------------------------------
 # JSON-L session helpers
@@ -84,12 +115,34 @@ def _load_jsonl(path: str) -> list[ContextItem]:
     return items
 
 
+def _restore_manager_from_session(session_path: str, budget_tokens: int) -> ContextManager:
+    """Rebuild a :class:`ContextManager` from a session JSON written by ``ingest``."""
+    session: dict[str, Any] = json.loads(Path(session_path).read_text(encoding="utf-8"))
+    mgr = ContextManager(
+        budget=ContextBudget(
+            route=budget_tokens,
+            call=budget_tokens,
+            interpret=budget_tokens,
+            answer=budget_tokens,
+        )
+    )
+    for raw_event in session.get("events", []):
+        item = ContextItem.from_dict(raw_event)
+        mgr.ingest(item)
+    for key, value in session.get("facts", {}).items():
+        mgr.add_fact(key, value)
+    for ep in session.get("episodes", []):
+        mgr.add_episode(ep["episode_id"], ep["summary"])
+    return mgr
+
+
 # ---------------------------------------------------------------------------
-# Command handlers
+# Subcommands
 # ---------------------------------------------------------------------------
 
 
-def _cmd_demo(args: argparse.Namespace) -> int:  # noqa: ARG001
+@app.command()
+def demo() -> None:
     """Run a built-in demonstration of both engines."""
     print("=" * 60)
     print("contextweaver demo — end-to-end demonstration")
@@ -169,44 +222,42 @@ def _cmd_demo(args: argparse.Namespace) -> int:  # noqa: ARG001
 
     print("\n" + "=" * 60)
     print("Demo complete.")
-    return 0
 
 
-def _cmd_build(args: argparse.Namespace) -> int:
+@app.command()
+def build(
+    catalog: Annotated[Path, typer.Option(..., help="Path to the tool catalog JSON file.")],
+    out: Annotated[Path, typer.Option(..., help="Output path for the graph JSON file.")],
+    max_children: Annotated[
+        int, typer.Option("--max-children", help="Max children per node.")
+    ] = 20,
+) -> None:
     """Build a routing graph from a catalog JSON file."""
-    catalog_path: str = args.catalog
-    out_path: str = args.out
-    max_children: int = args.max_children
-
-    items = load_catalog_json(catalog_path)
-    print(f"Loaded {len(items)} items from {catalog_path}")
-
+    items = load_catalog_json(str(catalog))
+    print(f"Loaded {len(items)} items from {catalog}")
     builder = TreeBuilder(max_children=max_children)
     graph = builder.build(items)
-
-    save_graph(graph, out_path)
+    save_graph(graph, str(out))
     stats = graph.stats()
-    print(f"Graph saved to {out_path}")
+    print(f"Graph saved to {out}")
     print(f"Stats: {json.dumps(stats, indent=2)}")
-    return 0
 
 
-def _cmd_route(args: argparse.Namespace) -> int:
-    """Route a query over a pre-built graph."""
-    graph_path: str = args.graph
-    catalog_path: str = args.catalog
-    query: str = args.query
-    top_k: int = args.top_k
-    beam_width: int = args.beam_width
-
-    graph = load_graph(graph_path)
-    all_items = load_catalog_json(catalog_path)
-
-    # Keep only items present in the graph
-    graph_item_ids = set(graph.items())
+@app.command()
+def route(
+    graph: Annotated[Path, typer.Option(..., help="Path to the graph JSON file.")],
+    catalog: Annotated[Path, typer.Option(..., help="Path to the catalog JSON file.")],
+    query: Annotated[str, typer.Option(..., help="The user query to route.")],
+    top_k: Annotated[int, typer.Option("--top-k", help="Max results.")] = 10,
+    beam_width: Annotated[int, typer.Option("--beam-width", help="Beam width.")] = 3,
+) -> None:
+    """Route a query over a pre-built routing graph."""
+    graph_obj = load_graph(str(graph))
+    all_items = load_catalog_json(str(catalog))
+    graph_item_ids = set(graph_obj.items())
     items_list = [it for it in all_items if it.id in graph_item_ids]
 
-    router = Router(graph, items=items_list, beam_width=beam_width, top_k=top_k)
+    router = Router(graph_obj, items=items_list, beam_width=beam_width, top_k=top_k)
     result = router.route(query)
 
     print(f"Query: {query!r}")
@@ -216,79 +267,47 @@ def _cmd_route(args: argparse.Namespace) -> int:
         scores=dict(zip(result.candidate_ids, result.scores, strict=False)),
     )
     print(render_cards_text(cards))
-    return 0
 
 
-def _cmd_print_tree(args: argparse.Namespace) -> int:
-    """Pretty-print the routing tree for a graph.
+@app.command("print-tree")
+def print_tree(
+    graph: Annotated[Path, typer.Option(..., help="Path to the graph JSON file.")],
+    depth: Annotated[int, typer.Option(help="Max depth to display.")] = 3,
+) -> None:
+    """Pretty-print the routing tree for a graph (Rich-formatted)."""
+    graph_obj = load_graph(str(graph))
+    items_set = set(graph_obj.items())
 
-    Uses ``rich.tree`` for coloured output when the ``[cli]`` extra is
-    installed; falls back to plain ASCII otherwise.
-    """
-    graph_path: str = args.graph
-    max_depth: int = args.depth
-
-    graph = load_graph(graph_path)
-    items_set = set(graph.items())
-
-    if _HAS_RICH:
-        console = _RichConsole()
-
-        def _build_rich(node_id: str, depth: int) -> _RichTree:
-            node = graph.get_node(node_id)
-            is_item = node_id in items_set
-            label = node.label or node_id
-            if is_item:
-                rendered = f"[bold green]* {label}[/bold green]"
-            else:
-                hint = f"  [dim]({node.routing_hint})[/dim]" if node.routing_hint else ""
-                rendered = f"[bold cyan]> {label}[/bold cyan]{hint}"
-            tree = _RichTree(rendered)
-            if depth < max_depth:
-                for child in graph.successors(node_id):
-                    tree.add(_build_rich(child, depth + 1))
-            return tree
-
-        console.print(f"[bold]Routing tree (depth={max_depth}):[/bold]")
-        console.print(_build_rich(graph.root_id, 0))
-        stats = graph.stats()
-        console.print(
-            f"\n[dim]Stats: {stats['total_nodes']} nodes,"
-            f" {stats['total_items']} items,"
-            f" depth={stats['max_depth']}[/dim]"
-        )
-        return 0
-
-    # Stdlib fallback (existing behaviour, byte-for-byte compatible).
-    def _print_node(node_id: str, depth: int, prefix: str = "") -> None:
-        if depth > max_depth:
-            return
-        node = graph.get_node(node_id)
+    def _build(node_id: str, cur_depth: int) -> RichTree:
+        node = graph_obj.get_node(node_id)
         is_item = node_id in items_set
-        marker = "*" if is_item else ">"
         label = node.label or node_id
-        hint = f" - {node.routing_hint}" if node.routing_hint and not is_item else ""
-        print(f"{prefix}{marker} {label}{hint}")
-        children = graph.successors(node_id)
-        for i, child in enumerate(children):
-            last = i == len(children) - 1
-            child_prefix = prefix + ("    " if last else "|   ")
-            _print_node(child, depth + 1, child_prefix)
+        if is_item:
+            rendered = f"[bold green]* {label}[/bold green]"
+        else:
+            hint = f"  [dim]({node.routing_hint})[/dim]" if node.routing_hint else ""
+            rendered = f"[bold cyan]> {label}[/bold cyan]{hint}"
+        tree = RichTree(rendered)
+        if cur_depth < depth:
+            for child in graph_obj.successors(node_id):
+                tree.add(_build(child, cur_depth + 1))
+        return tree
 
-    print(f"Routing tree (depth={max_depth}):")
-    _print_node(graph.root_id, 0)
-    stats = graph.stats()
-    print(
-        f"\nStats: {stats['total_nodes']} nodes,"
+    _console.print(f"[bold]Routing tree (depth={depth}):[/bold]")
+    _console.print(_build(graph_obj.root_id, 0))
+    stats = graph_obj.stats()
+    _console.print(
+        f"\n[dim]Stats: {stats['total_nodes']} nodes,"
         f" {stats['total_items']} items,"
-        f" depth={stats['max_depth']}"
+        f" depth={stats['max_depth']}[/dim]"
     )
-    return 0
 
 
-def _cmd_init(args: argparse.Namespace) -> int:
+@app.command()
+def init(
+    force: Annotated[bool, typer.Option(help="Overwrite existing files.")] = False,
+) -> None:
     """Scaffold contextweaver config + sample catalog in cwd."""
-    force: bool = args.force
     config_path = Path("contextweaver.json")
     catalog_path = Path("sample_catalog.json")
 
@@ -296,7 +315,7 @@ def _cmd_init(args: argparse.Namespace) -> int:
     if existing and not force:
         names = ", ".join(str(p) for p in existing)
         print(f"Error: {names} already exist. Use --force to overwrite.", file=sys.stderr)
-        return 1
+        raise typer.Exit(1)
 
     config = {
         "version": "0.1.0",
@@ -316,15 +335,15 @@ def _cmd_init(args: argparse.Namespace) -> int:
     raw_items = generate_sample_catalog(n=40, seed=42)
     catalog_path.write_text(json.dumps(raw_items, indent=2) + "\n", encoding="utf-8")
     print(f"Created {catalog_path} ({len(raw_items)} items)")
-    return 0
 
 
-def _cmd_ingest(args: argparse.Namespace) -> int:
+@app.command()
+def ingest(
+    events: Annotated[Path, typer.Option(..., help="Path to the JSONL session file.")],
+    out: Annotated[Path, typer.Option(..., help="Output path for the session JSON file.")],
+) -> None:
     """Ingest a JSONL session into a serialised session file."""
-    events_path: str = args.events
-    out_path: str = args.out
-
-    items = _load_jsonl(events_path)
+    items = _load_jsonl(str(events))
     mgr = ContextManager()
 
     firewall_count = 0
@@ -343,7 +362,6 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
         else:
             mgr.ingest(item)
 
-    # Serialize session
     session: dict[str, Any] = {
         "event_count": len(items),
         "events": [it.to_dict() for it in mgr.event_log.all()],
@@ -360,50 +378,27 @@ def _cmd_ingest(args: argparse.Namespace) -> int:
             {"episode_id": ep.episode_id, "summary": ep.summary} for ep in mgr.episodic_store.all()
         ],
     }
-    Path(out_path).write_text(json.dumps(session, indent=2) + "\n", encoding="utf-8")
+    Path(out).write_text(json.dumps(session, indent=2) + "\n", encoding="utf-8")
 
-    print(f"Ingested {len(items)} events from {events_path}")
+    print(f"Ingested {len(items)} events from {events}")
     print(f"Event counts: {json.dumps(kind_counts)}")
     print(f"Firewall triggers: {firewall_count}")
     print(f"Artifacts stored: {len(session['artifacts'])}")
-    print(f"Session saved to {out_path}")
-    return 0
+    print(f"Session saved to {out}")
 
 
-def _cmd_replay(args: argparse.Namespace) -> int:
+@app.command()
+def replay(
+    session: Annotated[Path, typer.Option(..., help="Path to the session JSON file.")],
+    phase: Annotated[_PhaseChoice, typer.Option(help="Phase to render.")] = _PhaseChoice.answer,
+    budget: Annotated[int, typer.Option(help="Token budget.")] = 4000,
+    full: Annotated[bool, typer.Option(help="Show full prompt instead of preview.")] = False,
+) -> None:
     """Replay a session and build context for a given phase."""
-    session_path: str = args.session
-    phase_str: str = args.phase
-    budget_tokens: int = args.budget
-    preview: bool = not args.full
+    mgr = _restore_manager_from_session(str(session), budget)
+    pack = mgr.build_sync(phase=Phase(phase.value), query="replay", budget_tokens=budget)
 
-    session: dict[str, Any] = json.loads(Path(session_path).read_text(encoding="utf-8"))
-
-    # Re-ingest events
-    mgr = ContextManager(
-        budget=ContextBudget(
-            route=budget_tokens,
-            call=budget_tokens,
-            interpret=budget_tokens,
-            answer=budget_tokens,
-        )
-    )
-    for raw_event in session.get("events", []):
-        item = ContextItem.from_dict(raw_event)
-        mgr.ingest(item)
-
-    # Restore facts
-    for key, value in session.get("facts", {}).items():
-        mgr.add_fact(key, value)
-
-    # Restore episodes
-    for ep in session.get("episodes", []):
-        mgr.add_episode(ep["episode_id"], ep["summary"])
-
-    phase = Phase(phase_str)
-    pack = mgr.build_sync(phase=phase, query="replay", budget_tokens=budget_tokens)
-
-    print(f"=== Context Build: phase={phase.value}, budget={budget_tokens} ===")
+    print(f"=== Context Build: phase={phase.value}, budget={budget} ===")
     print(
         f"Stats: total_candidates={pack.stats.total_candidates}, "
         f"included={pack.stats.included_count}, "
@@ -412,114 +407,58 @@ def _cmd_replay(args: argparse.Namespace) -> int:
         f"closures={pack.stats.dependency_closures}"
     )
     print(f"Token breakdown: {pack.stats.tokens_per_section}")
-    total_tokens = sum(pack.stats.tokens_per_section.values()) + pack.stats.header_footer_tokens
-    print(f"Total tokens: {total_tokens} / {budget_tokens}")
+    print(f"Total tokens: {pack.stats.prompt_tokens} / {budget}")
 
-    artifacts = session.get("artifacts", {})
+    raw_session: dict[str, Any] = json.loads(Path(session).read_text(encoding="utf-8"))
+    artifacts = raw_session.get("artifacts", {})
     if artifacts:
         print(f"Artifacts available: {list(artifacts.keys())}")
-
-    facts = session.get("facts", {})
+    facts = raw_session.get("facts", {})
     if facts:
-        fact_strs = [f"{k}={v}" for k, v in facts.items()]
-        print(f"Facts: {fact_strs}")
+        print(f"Facts: {[f'{k}={v}' for k, v in facts.items()]}")
 
     print("--- Rendered prompt ---")
-    if preview:
+    if full:
+        print(pack.prompt)
+    else:
         print(pack.prompt[:500])
         if len(pack.prompt) > 500:
             print(f"... ({len(pack.prompt) - 500} more chars, use --full to see all)")
+
+
+@app.command()
+def stats(
+    session: Annotated[Path, typer.Option(..., help="Path to the session JSON file.")],
+    phase: Annotated[
+        _PhaseChoice, typer.Option(help="Phase to render the report for.")
+    ] = _PhaseChoice.answer,
+    budget: Annotated[int, typer.Option(help="Token budget for the build.")] = 4000,
+    format: Annotated[  # noqa: A002 — Typer CLI flag name
+        _StatsFormatChoice,
+        typer.Option(
+            "--format",
+            help="Output format: rich renders panels and tables; text is grep-friendly.",
+        ),
+    ] = _StatsFormatChoice.rich,
+) -> None:
+    """Render a human-readable :class:`BuildStats` diagnostic report (issue #106)."""
+    mgr = _restore_manager_from_session(str(session), budget)
+    pack = mgr.build_sync(phase=Phase(phase.value), query="stats", budget_tokens=budget)
+    if format == _StatsFormatChoice.rich:
+        _console.print(pack.stats.report(format="rich", phase=phase.value, budget=budget))
     else:
-        print(pack.prompt)
-    return 0
+        print(pack.stats.report(format="text", phase=phase.value, budget=budget))
 
 
 # ---------------------------------------------------------------------------
-# Parser
+# Entry point
 # ---------------------------------------------------------------------------
-
-
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="contextweaver",
-        description="Dynamic context management for tool-using AI agents.",
-    )
-    sub = parser.add_subparsers(dest="command", metavar="COMMAND")
-
-    # demo
-    sub.add_parser("demo", help="Run a built-in demonstration of both engines.")
-
-    # build
-    p_build = sub.add_parser("build", help="Build a routing graph from a catalog.")
-    p_build.add_argument("--catalog", required=True, help="Path to the tool catalog JSON file.")
-    p_build.add_argument("--out", required=True, help="Output path for the graph JSON file.")
-    p_build.add_argument(
-        "--max-children", type=int, default=20, help="Max children per node (default: 20)."
-    )
-
-    # route
-    p_route = sub.add_parser("route", help="Route a query over a pre-built graph.")
-    p_route.add_argument("--graph", required=True, help="Path to the graph JSON file.")
-    p_route.add_argument("--catalog", required=True, help="Path to the catalog JSON file.")
-    p_route.add_argument("--query", required=True, help="The user query to route.")
-    p_route.add_argument("--top-k", type=int, default=10, help="Max results (default: 10).")
-    p_route.add_argument("--beam-width", type=int, default=3, help="Beam width (default: 3).")
-
-    # print-tree
-    p_tree = sub.add_parser("print-tree", help="Pretty-print the routing tree.")
-    p_tree.add_argument("--graph", required=True, help="Path to the graph JSON file.")
-    p_tree.add_argument("--depth", type=int, default=3, help="Max depth to display (default: 3).")
-
-    # init
-    p_init = sub.add_parser("init", help="Scaffold contextweaver config + sample catalog in cwd.")
-    p_init.add_argument(
-        "--force", action="store_true", default=False, help="Overwrite existing files."
-    )
-
-    # ingest
-    p_ingest = sub.add_parser("ingest", help="Ingest a JSONL session file.")
-    p_ingest.add_argument("--events", required=True, help="Path to the JSONL session file.")
-    p_ingest.add_argument("--out", required=True, help="Output path for the session JSON file.")
-
-    # replay
-    p_replay = sub.add_parser("replay", help="Replay a session and build context.")
-    p_replay.add_argument("--session", required=True, help="Path to the session JSON file.")
-    p_replay.add_argument(
-        "--phase",
-        default="answer",
-        choices=["route", "call", "interpret", "answer"],
-        help="Phase (default: answer).",
-    )
-    p_replay.add_argument("--budget", type=int, default=4000, help="Token budget (default: 4000).")
-    p_replay.add_argument("--full", action="store_true", default=False, help="Show full prompt.")
-
-    return parser
-
-
-_HANDLERS = {
-    "demo": _cmd_demo,
-    "build": _cmd_build,
-    "route": _cmd_route,
-    "print-tree": _cmd_print_tree,
-    "init": _cmd_init,
-    "ingest": _cmd_ingest,
-    "replay": _cmd_replay,
-}
 
 
 def main() -> None:
     """Entry point for the ``contextweaver`` CLI."""
-    parser = _build_parser()
-    args = parser.parse_args()
-    if args.command is None:
-        parser.print_help()
-        sys.exit(0)
-    handler = _HANDLERS.get(args.command)
-    if handler is None:
-        parser.print_help()
-        sys.exit(1)
     try:
-        sys.exit(handler(args))
+        app()
     except FileNotFoundError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/src/contextweaver/__main__.py
+++ b/src/contextweaver/__main__.py
@@ -126,8 +126,11 @@ def _restore_manager_from_session(session_path: str, budget_tokens: int) -> Cont
             answer=budget_tokens,
         )
     )
-    for raw_event in session.get("events", []):
-        item = ContextItem.from_dict(raw_event)
+    for idx, raw_event in enumerate(session.get("events", []), 1):
+        try:
+            item = ContextItem.from_dict(raw_event)
+        except Exception as exc:
+            raise ValueError(f"{session_path}: session event {idx}: {exc}") from exc
         mgr.ingest(item)
     for key, value in session.get("facts", {}).items():
         mgr.add_fact(key, value)

--- a/src/contextweaver/_schema_gen.py
+++ b/src/contextweaver/_schema_gen.py
@@ -1,0 +1,273 @@
+"""Dataclass → JSON Schema (Draft 2020-12) generator (issue #225).
+
+Stdlib-only.  Inspects ``dataclasses.fields()`` and the type annotations on a
+contextweaver dataclass and emits a deterministic JSON Schema document.
+
+Output is byte-stable for the same input — uses ``json.dumps(sort_keys=True,
+indent=2)`` and sorts every collection field.  The generator handles the
+subset of Python typing used by contextweaver's public envelope types:
+
+- Primitives: ``str``, ``int``, ``float``, ``bool``.
+- ``list[T]`` and ``dict[str, T]``.
+- ``Literal[a, b, c]`` → ``enum``.
+- ``T | None`` / ``Optional[T]`` → ``{"anyOf": [<T>, {"type": "null"}]}``.
+- :class:`~enum.Enum` subclasses → enum of member ``value``\\s.
+- ``datetime`` → ``{"type": "string", "format": "date-time"}``.
+- ``Any`` → ``{}`` (any JSON value).
+- Nested dataclasses — inlined as ``$ref`` to a ``$defs`` entry.
+
+Anything outside this subset raises :class:`TypeError` so unsupported field
+types fail loud during ``make schemas`` rather than producing a vague /
+silently-wrong schema.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime as _dt
+import enum
+import json
+import sys
+import types
+import typing
+from typing import Any, Literal, get_args, get_origin
+
+#: Stable ``$id`` host for published schemas (mkdocs site under ``/schemas/v0/``).
+SCHEMA_ID_BASE: str = "https://dgenio.github.io/contextweaver/schemas/v0"
+
+#: Draft URI used in every ``$schema`` field.
+JSON_SCHEMA_DRAFT: str = "https://json-schema.org/draft/2020-12/schema"
+
+
+# ---------------------------------------------------------------------------
+# Per-type extras (size bounds, descriptions overrides) — kept here so the
+# generator stays dataclass-agnostic.  Issue #225 acceptance criterion:
+# ChoiceCard size bounds in docs/gateway_spec.md §2 must round-trip into the
+# emitted schema as maxLength / maxItems.
+# ---------------------------------------------------------------------------
+
+
+_FIELD_EXTRAS: dict[str, dict[str, dict[str, Any]]] = {
+    "ChoiceCard": {
+        "name": {"maxLength": 64},
+        "tags": {"maxItems": 5, "items": {"type": "string", "maxLength": 24}},
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Type → schema mapping
+# ---------------------------------------------------------------------------
+
+
+def _schema_for_type(tp: Any, defs: dict[str, Any]) -> dict[str, Any]:  # noqa: ANN401
+    """Map a Python type annotation to a JSON Schema fragment.
+
+    Args:
+        tp: The runtime type annotation (already resolved by
+            :func:`typing.get_type_hints`).
+        defs: The ``$defs`` dict.  Nested dataclasses are added in-place.
+
+    Returns:
+        A JSON Schema fragment (dict).
+    """
+    # Any -> permissive
+    if tp is Any or tp is object:
+        return {}
+
+    # None -> JSON null
+    if tp is type(None):
+        return {"type": "null"}
+
+    # datetime -> ISO 8601 string per envelope.py serialisation
+    if tp is _dt.datetime:
+        return {"type": "string", "format": "date-time"}
+
+    # Primitives
+    if tp is str:
+        return {"type": "string"}
+    if tp is int:
+        return {"type": "integer"}
+    if tp is float:
+        return {"type": "number"}
+    if tp is bool:
+        return {"type": "boolean"}
+
+    # Enum -> enum of member .value's
+    if isinstance(tp, type) and issubclass(tp, enum.Enum):
+        values = [member.value for member in tp]
+        return {"enum": values}
+
+    # Dataclass -> $ref into defs
+    if isinstance(tp, type) and dataclasses.is_dataclass(tp):
+        name = tp.__name__
+        if name not in defs:
+            # Insert a sentinel first to break recursion.
+            defs[name] = {"$comment": "filling"}
+            defs[name] = _dataclass_object_schema(tp, defs)
+        return {"$ref": f"#/$defs/{name}"}
+
+    origin = get_origin(tp)
+    args = get_args(tp)
+
+    # Literal[a, b, c] -> enum
+    if origin is Literal:
+        return {"enum": list(args)}
+
+    # Union / Optional
+    if origin is typing.Union or _is_union(origin):
+        non_none = [a for a in args if a is not type(None)]
+        has_none = len(non_none) != len(args)
+        sub_schemas = [_schema_for_type(a, defs) for a in non_none]
+        if has_none:
+            sub_schemas.append({"type": "null"})
+        # Optional[T] simplification: anyOf with a single element collapses.
+        if len(sub_schemas) == 1:
+            return sub_schemas[0]
+        return {"anyOf": sub_schemas}
+
+    # list[T]
+    if origin in (list, typing.List):  # noqa: UP006 — typing.List for compatibility
+        item_tp = args[0] if args else Any
+        return {"type": "array", "items": _schema_for_type(item_tp, defs)}
+
+    # tuple[X, Y] — used for trace.scored_children (str, float) pairs.
+    # JSON-serialised as either lists of two-elt tuples or as objects; the
+    # routing trace's ``scored_children`` is serialised by to_dict() as
+    # ``[{"id": str, "score": float}]`` so we surface that form here when the
+    # dataclass field is a tuple-of-(str, float).
+    if origin in (tuple, typing.Tuple):  # noqa: UP006
+        if args == (str, float):
+            return {
+                "type": "object",
+                "properties": {"id": {"type": "string"}, "score": {"type": "number"}},
+                "required": ["id", "score"],
+                "additionalProperties": False,
+            }
+        # Generic fallback: positional tuple = fixed-length array.
+        return {
+            "type": "array",
+            "prefixItems": [_schema_for_type(a, defs) for a in args],
+            "items": False,
+        }
+
+    # dict[str, T]
+    if origin in (dict, typing.Dict):  # noqa: UP006
+        if not args or args[0] is str:
+            value_tp = args[1] if len(args) >= 2 else Any
+            return {
+                "type": "object",
+                "additionalProperties": _schema_for_type(value_tp, defs),
+            }
+        raise TypeError(f"dict key type must be str, got {args[0]!r}")
+
+    raise TypeError(f"Unsupported type for schema generation: {tp!r}")
+
+
+def _is_union(origin: Any) -> bool:  # noqa: ANN401 — runtime-introspection helper
+    """Return ``True`` for both ``Union[...]`` and ``X | Y`` origins (PEP 604)."""
+    if origin is typing.Union:
+        return True
+    return sys.version_info >= (3, 10) and origin is types.UnionType
+
+
+# ---------------------------------------------------------------------------
+# Dataclass → object schema
+# ---------------------------------------------------------------------------
+
+
+def _dataclass_object_schema(cls: type, defs: dict[str, Any]) -> dict[str, Any]:
+    """Convert a dataclass into a JSON Schema ``object`` fragment."""
+    hints = typing.get_type_hints(cls)
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    extras = _FIELD_EXTRAS.get(cls.__name__, {})
+
+    for f in dataclasses.fields(cls):
+        if f.name not in hints:
+            continue
+        schema = _schema_for_type(hints[f.name], defs)
+        # Merge per-field extras (size bounds etc.) on top of the inferred schema.
+        if f.name in extras:
+            # ``items`` override needs to replace, not merge, since lists may
+            # specify both type-level (T schema) and bounds-level (items schema).
+            for key, value in extras[f.name].items():
+                schema[key] = value
+        properties[f.name] = schema
+        if f.default is dataclasses.MISSING and f.default_factory is dataclasses.MISSING:
+            required.append(f.name)
+
+    obj: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        obj["required"] = sorted(required)
+    docstring = (cls.__doc__ or "").strip().split("\n", 1)[0]
+    if docstring:
+        obj["description"] = docstring
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_schema(cls: type, *, schema_id: str, title: str | None = None) -> dict[str, Any]:
+    """Generate a top-level JSON Schema document for a dataclass.
+
+    Args:
+        cls: The dataclass to generate a schema for.
+        schema_id: Stable ``$id`` URL (e.g.
+            ``"https://dgenio.github.io/contextweaver/schemas/v0/build_stats.schema.json"``).
+        title: Human-readable title; defaults to ``cls.__name__``.
+
+    Returns:
+        A JSON Schema document ready to serialise to disk via
+        :func:`schema_to_json`.
+    """
+    if not dataclasses.is_dataclass(cls):
+        raise TypeError(f"generate_schema requires a dataclass, got {cls!r}")
+    defs: dict[str, Any] = {}
+    object_schema = _dataclass_object_schema(cls, defs)
+    doc: dict[str, Any] = {
+        "$schema": JSON_SCHEMA_DRAFT,
+        "$id": schema_id,
+        "title": title or cls.__name__,
+        **object_schema,
+    }
+    # Remove the self-reference from $defs (we inlined it as the top-level).
+    defs.pop(cls.__name__, None)
+    if defs:
+        doc["$defs"] = defs
+    return doc
+
+
+def generate_array_schema(item_cls: type, *, schema_id: str, title: str) -> dict[str, Any]:
+    """Generate a schema for ``list[item_cls]`` — used for catalog files."""
+    if not dataclasses.is_dataclass(item_cls):
+        raise TypeError(f"generate_array_schema requires a dataclass, got {item_cls!r}")
+    defs: dict[str, Any] = {}
+    item_schema = _dataclass_object_schema(item_cls, defs)
+    doc: dict[str, Any] = {
+        "$schema": JSON_SCHEMA_DRAFT,
+        "$id": schema_id,
+        "title": title,
+        "type": "array",
+        "items": item_schema,
+    }
+    defs.pop(item_cls.__name__, None)
+    if defs:
+        doc["$defs"] = defs
+    return doc
+
+
+def schema_to_json(schema: dict[str, Any]) -> str:
+    """Serialise a schema to deterministic JSON bytes.
+
+    Trailing newline so the file matches POSIX ``cat``-style conventions and
+    ``make schemas-check`` diffs cleanly.
+    """
+    return json.dumps(schema, indent=2, sort_keys=True) + "\n"

--- a/src/contextweaver/_schema_gen.py
+++ b/src/contextweaver/_schema_gen.py
@@ -19,6 +19,13 @@ subset of Python typing used by contextweaver's public envelope types:
 Anything outside this subset raises :class:`TypeError` so unsupported field
 types fail loud during ``make schemas`` rather than producing a vague /
 silently-wrong schema.
+
+.. note::
+   This module exceeds the 300-line soft cap (~360 lines).  The generator's
+   ``_python_type_to_schema`` dispatch and the ``$defs``-collection logic are
+   tightly coupled — splitting into two files would scatter the type→schema
+   mapping without a clean module boundary.  Exempt per ``AGENTS.md`` §Coding
+   Style (alongside ``types.py``, ``envelope.py``, ``__main__.py``).
 """
 
 from __future__ import annotations

--- a/src/contextweaver/envelope.py
+++ b/src/contextweaver/envelope.py
@@ -431,6 +431,11 @@ class ChoiceCard:
 
     def __post_init__(self) -> None:
         """Enforce the gateway-spec §2 size bounds (issue #225)."""
+        if self.kind not in CHOICE_CARD_KINDS:
+            raise ValueError(
+                f"ChoiceCard.kind must be one of {CHOICE_CARD_KINDS}, "
+                f"got {self.kind!r}; see docs/gateway_spec.md §2"
+            )
         if len(self.name) > CHOICE_CARD_NAME_MAX_LEN:
             raise ValueError(
                 f"ChoiceCard.name exceeds {CHOICE_CARD_NAME_MAX_LEN} chars "

--- a/src/contextweaver/envelope.py
+++ b/src/contextweaver/envelope.py
@@ -17,6 +17,10 @@ from typing import Any, Literal
 
 from contextweaver.types import ArtifactRef, Phase, SelectableItem, ViewSpec
 
+#: Schema version for :meth:`BuildStats.report_dict` payloads.  Bumped on
+#: backwards-incompatible field changes.
+BUILD_STATS_REPORT_VERSION: int = 1
+
 
 @dataclass
 class ResultEnvelope:
@@ -70,6 +74,18 @@ class BuildStats:
     dependency_closures: int = 0
     header_footer_tokens: int = 0
 
+    @property
+    def prompt_tokens(self) -> int:
+        """Total tokens in the rendered prompt (sections + header/footer).
+
+        Single source of truth for the "how many tokens did this build emit?"
+        question — previously each caller (``extras/otel.py``, ``__main__.py``,
+        the OTel hook, scattered example scripts) computed
+        ``sum(stats.tokens_per_section.values()) + stats.header_footer_tokens``
+        inline.  Issue #106.
+        """
+        return sum(self.tokens_per_section.values()) + self.header_footer_tokens
+
     def to_dict(self) -> dict[str, Any]:
         """Serialise to a JSON-compatible dict."""
         return {
@@ -96,6 +112,247 @@ class BuildStats:
             dependency_closures=int(data.get("dependency_closures", 0)),
             header_footer_tokens=int(data.get("header_footer_tokens", 0)),
         )
+
+    def report(
+        self,
+        format: Literal["text", "rich"] = "text",  # noqa: A002 — public API kwarg
+        *,
+        phase: str | None = None,
+        budget: int | None = None,
+    ) -> str:
+        """Render a human-readable diagnostic report (issue #106).
+
+        Args:
+            format: ``"text"`` for a grep-friendly ASCII report; ``"rich"``
+                for a Rich-markup string ready for ``rich.Console.print()``.
+            phase: Optional phase label to print at the top of the report.
+            budget: Optional token budget; when supplied, the report includes
+                ``% Budget`` columns and headroom.
+
+        Returns:
+            A deterministic, paste-friendly string.  Same inputs → byte-identical
+            output across calls (sorted keys, stable spacing).
+        """
+        return _render_build_stats_report(self, format=format, phase=phase, budget=budget)
+
+    def report_dict(
+        self,
+        *,
+        phase: str | None = None,
+        budget: int | None = None,
+    ) -> dict[str, Any]:
+        """Return the structured payload backing :meth:`report` (issue #106).
+
+        Intended for programmatic consumers (dashboards, alerts, span attributes
+        on :class:`~contextweaver.extras.otel.OTelEventHook`).  Stable schema —
+        bumped via the top-level ``version`` field.
+        """
+        return _build_stats_report_dict(self, phase=phase, budget=budget)
+
+
+# ---------------------------------------------------------------------------
+# BuildStats report rendering (issue #106)
+# ---------------------------------------------------------------------------
+
+# Module-private helpers kept at file scope so that the data-layer invariant
+# ("no I/O in envelope.py") is preserved: this is pure string formatting.
+
+
+def _build_stats_report_dict(
+    stats: BuildStats,
+    *,
+    phase: str | None,
+    budget: int | None,
+) -> dict[str, Any]:
+    """Structured payload for :meth:`BuildStats.report_dict`."""
+    prompt_tokens = stats.prompt_tokens
+    total_tokens = prompt_tokens  # alias preserved for spec clarity
+    sections = sorted(stats.tokens_per_section.items())  # deterministic order
+    reasons = sorted(stats.dropped_reasons.items())  # deterministic order
+
+    recommendations: list[str] = []
+    if budget and budget > 0:
+        for name, tokens in sections:
+            if tokens / budget > 0.50:
+                recommendations.append(
+                    f"⚠ {tokens / budget:.0%} of budget used by {name} — "
+                    f"consider lowering firewall threshold"
+                )
+        headroom = budget - total_tokens
+        if headroom > 0 and total_tokens / budget < 0.95:
+            recommendations.append(f"✓ {headroom / budget:.1%} budget headroom — efficient")
+        elif headroom <= 0:
+            recommendations.append(
+                f"⚠ over budget by {-headroom} tokens — raise the budget or drop more aggressively"
+            )
+
+    return {
+        "version": 1,
+        "phase": phase,
+        "budget": budget,
+        "prompt_tokens": prompt_tokens,
+        "tokens_per_section": dict(sections),
+        "candidates": {
+            "total": stats.total_candidates,
+            "included": stats.included_count,
+            "dropped": stats.dropped_count,
+            "deduplicated": stats.dedup_removed,
+            "dependency_closures": stats.dependency_closures,
+        },
+        "dropped_reasons": dict(reasons),
+        "recommendations": recommendations,
+    }
+
+
+def _render_build_stats_report(
+    stats: BuildStats,
+    *,
+    format: Literal["text", "rich"],  # noqa: A002 — mirrors public BuildStats.report kwarg
+    phase: str | None,
+    budget: int | None,
+) -> str:
+    """Render :class:`BuildStats` as ``text`` or ``rich`` markup string.
+
+    Pure string formatting — no I/O.  Determinism is guaranteed by the
+    sorted ``tokens_per_section`` / ``dropped_reasons`` iteration order.
+    """
+    payload = _build_stats_report_dict(stats, phase=phase, budget=budget)
+
+    if format == "rich":
+        return _render_rich(payload)
+    return _render_text(payload)
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    """Plain ASCII rendering of the report payload."""
+    lines: list[str] = []
+    lines.append("=" * 50)
+    lines.append("Context Build Report")
+    lines.append("=" * 50)
+    phase = payload.get("phase")
+    budget = payload.get("budget")
+    if phase:
+        lines.append(f"Phase:  {phase}")
+    if budget:
+        lines.append(f"Budget: {budget} tokens")
+    lines.append("")
+
+    lines.append("-- Candidates --")
+    cand = payload["candidates"]
+    lines.append(f"  Generated:    {cand['total']}")
+    lines.append(f"  Included:     {cand['included']}")
+    lines.append(f"  Dropped:      {cand['dropped']}")
+    lines.append(f"  Deduplicated: {cand['deduplicated']}")
+    lines.append(f"  Dep. closures:{cand['dependency_closures']}")
+    lines.append("")
+
+    lines.append("-- Token Usage --")
+    sections: dict[str, int] = payload["tokens_per_section"]
+    if not sections:
+        lines.append("  (no sections rendered)")
+    else:
+        if budget:
+            lines.append(f"  {'Section':<16}{'Tokens':>10}{'% Budget':>12}")
+        else:
+            lines.append(f"  {'Section':<16}{'Tokens':>10}")
+        for name, tokens in sections.items():
+            if budget:
+                pct = f"{tokens / budget:>7.1%}" if budget else ""
+                lines.append(f"  {name:<16}{tokens:>10}{pct:>12}")
+            else:
+                lines.append(f"  {name:<16}{tokens:>10}")
+        lines.append(f"  {'-' * 36}")
+        total = payload["prompt_tokens"]
+        if budget:
+            lines.append(f"  {'Total':<16}{total:>10}{total / budget:>11.1%}")
+            remaining = budget - total
+            lines.append(f"  {'Remaining':<16}{remaining:>10}{remaining / budget:>11.1%}")
+        else:
+            lines.append(f"  {'Total':<16}{total:>10}")
+    lines.append("")
+
+    reasons: dict[str, int] = payload["dropped_reasons"]
+    if reasons:
+        lines.append("-- Dropped Items --")
+        for reason, count in reasons.items():
+            lines.append(f"  {reason}: {count}")
+        lines.append("")
+
+    recs: list[str] = payload["recommendations"]
+    if recs:
+        lines.append("-- Recommendations --")
+        for rec in recs:
+            lines.append(f"  {rec}")
+
+    return "\n".join(lines)
+
+
+def _render_rich(payload: dict[str, Any]) -> str:
+    """Rich-markup rendering of the report payload.
+
+    Output is a single string with Rich tag spans; callers pipe it through
+    ``rich.console.Console.print`` to render colours and panels.  Plain-text
+    callers should use ``format="text"`` instead.
+    """
+    lines: list[str] = []
+    phase = payload.get("phase")
+    budget = payload.get("budget")
+    header_parts = ["[bold cyan]Context Build Report[/bold cyan]"]
+    if phase:
+        header_parts.append(f"phase=[yellow]{phase}[/yellow]")
+    if budget:
+        header_parts.append(f"budget=[yellow]{budget}[/yellow] tokens")
+    lines.append("  ".join(header_parts))
+    lines.append("")
+
+    cand = payload["candidates"]
+    lines.append("[bold]Candidates[/bold]")
+    lines.append(
+        f"  generated={cand['total']}  included=[green]{cand['included']}[/green]  "
+        f"dropped=[red]{cand['dropped']}[/red]  "
+        f"dedup={cand['deduplicated']}  closures={cand['dependency_closures']}"
+    )
+    lines.append("")
+
+    sections: dict[str, int] = payload["tokens_per_section"]
+    lines.append("[bold]Token Usage[/bold]")
+    if not sections:
+        lines.append("  [dim](no sections rendered)[/dim]")
+    else:
+        for name, tokens in sections.items():
+            if budget:
+                pct = tokens / budget
+                colour = "red" if pct > 0.5 else "green"
+                lines.append(f"  {name:<16}{tokens:>8}  [{colour}]{pct:>6.1%}[/{colour}]")
+            else:
+                lines.append(f"  {name:<16}{tokens:>8}")
+        total = payload["prompt_tokens"]
+        if budget:
+            remaining = budget - total
+            r_colour = "red" if remaining < 0 else "green"
+            lines.append(f"  [bold]{'Total':<16}{total:>8}  {total / budget:>6.1%}[/bold]")
+            lines.append(
+                f"  [{r_colour}]{'Remaining':<16}{remaining:>8}  "
+                f"{remaining / budget:>6.1%}[/{r_colour}]"
+            )
+        else:
+            lines.append(f"  [bold]{'Total':<16}{total:>8}[/bold]")
+    lines.append("")
+
+    reasons: dict[str, int] = payload["dropped_reasons"]
+    if reasons:
+        lines.append("[bold]Dropped Items[/bold]")
+        for reason, count in reasons.items():
+            lines.append(f"  [red]{reason}[/red]: {count}")
+        lines.append("")
+
+    recs: list[str] = payload["recommendations"]
+    if recs:
+        lines.append("[bold]Recommendations[/bold]")
+        for rec in recs:
+            lines.append(f"  {rec}")
+
+    return "\n".join(lines)
 
 
 @dataclass
@@ -132,6 +389,15 @@ class ContextPack:
         )
 
 
+# ChoiceCard size bounds from docs/gateway_spec.md §2.  Centralised here so
+# both the dataclass __post_init__ validator and the schema generator stay in
+# sync.  Issue #225.
+CHOICE_CARD_NAME_MAX_LEN: int = 64
+CHOICE_CARD_TAG_MAX_LEN: int = 24
+CHOICE_CARD_TAGS_MAX_COUNT: int = 5
+CHOICE_CARD_KINDS: tuple[str, ...] = ("tool", "agent", "skill", "internal")
+
+
 @dataclass
 class ChoiceCard:
     """A compact, LLM-friendly representation of a :class:`SelectableItem`.
@@ -139,18 +405,48 @@ class ChoiceCard:
     Never includes full arg schemas — keeps prompt token usage minimal.
     ``has_schema`` is a boolean flag indicating whether the source item has
     an argument schema; the schema itself is never included.
+
+    Size bounds (see ``docs/gateway_spec.md`` §2 and issue #225):
+
+    - ``name`` ≤ :data:`CHOICE_CARD_NAME_MAX_LEN` (64) characters.
+    - ``tags`` ≤ :data:`CHOICE_CARD_TAGS_MAX_COUNT` (5) entries,
+      each ≤ :data:`CHOICE_CARD_TAG_MAX_LEN` (24) characters.
+    - ``kind`` ∈ :data:`CHOICE_CARD_KINDS`.
+
+    Violations raise :class:`ValueError` at construction time so the
+    invariants hold for every code path (including
+    :meth:`ChoiceCard.from_dict`).
     """
 
     id: str
     name: str
     description: str
     tags: list[str] = field(default_factory=list)
-    kind: str = "tool"
+    kind: Literal["tool", "agent", "skill", "internal"] = "tool"
     namespace: str = ""
     has_schema: bool = False
     score: float | None = None
     cost_hint: float = 0.0
     side_effects: bool = False
+
+    def __post_init__(self) -> None:
+        """Enforce the gateway-spec §2 size bounds (issue #225)."""
+        if len(self.name) > CHOICE_CARD_NAME_MAX_LEN:
+            raise ValueError(
+                f"ChoiceCard.name exceeds {CHOICE_CARD_NAME_MAX_LEN} chars "
+                f"({len(self.name)}); see docs/gateway_spec.md §2"
+            )
+        if len(self.tags) > CHOICE_CARD_TAGS_MAX_COUNT:
+            raise ValueError(
+                f"ChoiceCard.tags exceeds {CHOICE_CARD_TAGS_MAX_COUNT} entries "
+                f"({len(self.tags)}); see docs/gateway_spec.md §2"
+            )
+        for tag in self.tags:
+            if len(tag) > CHOICE_CARD_TAG_MAX_LEN:
+                raise ValueError(
+                    f"ChoiceCard.tags entry {tag!r} exceeds "
+                    f"{CHOICE_CARD_TAG_MAX_LEN} chars; see docs/gateway_spec.md §2"
+                )
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise to a JSON-compatible dict."""

--- a/src/contextweaver/extras/otel.py
+++ b/src/contextweaver/extras/otel.py
@@ -1,15 +1,58 @@
-"""OpenTelemetry integration for contextweaver.
+"""OpenTelemetry GenAI integration for contextweaver (issue #224).
 
 Provides :class:`OTelEventHook` — an :class:`~contextweaver.protocols.EventHook`
-implementation that emits OpenTelemetry spans and metrics for every context
-build, firewall trigger, item exclusion, budget overrun, and routing call.
+implementation that emits OpenTelemetry spans and metrics conforming to the
+official **OpenTelemetry GenAI Semantic Conventions**.  Observability
+platforms that already understand the ``gen_ai.*`` namespace (Laminar,
+Phoenix, Langfuse, LangSmith) render contextweaver activity as
+native agent / tool spans instead of generic ones.
 
 This module requires the ``[otel]`` optional extra::
 
     pip install 'contextweaver[otel]'
 
 Without that extra, importing this module raises :class:`ImportError` with
-the exact install hint above. The rest of contextweaver works unchanged.
+the exact install hint above.  The rest of contextweaver works unchanged.
+
+Span shapes
+-----------
+
+- ``invoke_agent`` — one span per :meth:`ContextManager.build()`.  Operation
+  name ``gen_ai.operation.name = "invoke_agent"``; system identifier
+  ``gen_ai.system = "contextweaver"``; ``gen_ai.usage.input_tokens`` is the
+  prompt the agent will hand the LLM (i.e. :attr:`BuildStats.prompt_tokens`).
+- ``execute_tool`` — one span per :meth:`Router.route()`.  Operation name
+  ``gen_ai.operation.name = "execute_tool"``; ``gen_ai.tool.name`` is the
+  rank-1 candidate (the routing decision).
+
+Metric shapes
+-------------
+
+- ``gen_ai.client.token.usage`` (histogram) — prompt tokens per build,
+  with ``gen_ai.operation.name`` and ``gen_ai.token.type`` attributes
+  per SemConv.
+- ``contextweaver.firewall.interceptions`` (counter) — engine-specific.
+- ``contextweaver.items.excluded`` (counter) — engine-specific.
+- ``contextweaver.budget.exceeded`` (counter) — engine-specific.
+- ``contextweaver.routing.candidates`` (histogram) — engine-specific.
+
+The OTel GenAI semantic conventions are currently under the
+``opentelemetry.semconv._incubating`` namespace upstream (the GenAI SemConv
+is in **Development** status as of the 1.41 SDK release).  contextweaver
+imports them via that path and re-exports the canonical attribute strings.
+When upstream graduates them to stable, only the import path changes — the
+emitted attribute names are spec-stable.
+
+Privacy guidance
+----------------
+
+The default emission does **not** include raw query strings, full tool
+descriptions, or any ``args_schema`` content — those can carry sensitive
+payloads in some tool catalogs.  When ``otel_emit_experimental=True`` is
+passed at construction time, opt-in experimental attributes (e.g. the
+``gen_ai.prompt`` raw-prompt attribute) are emitted; only enable that flag
+when the observability backend is trusted to handle PII appropriately.
+References: https://maketocreate.com/opentelemetry-genai-tracing-ai-agents-without-leaking-pii/.
 """
 
 from __future__ import annotations
@@ -24,6 +67,8 @@ if TYPE_CHECKING:
 try:
     from opentelemetry import metrics as _otel_metrics
     from opentelemetry import trace as _otel_trace
+    from opentelemetry.semconv._incubating.attributes import gen_ai_attributes as _ga
+    from opentelemetry.semconv._incubating.metrics import gen_ai_metrics as _gm
 except ImportError as _otel_import_err:  # pragma: no cover - exercised only when extra is missing
     raise ImportError(
         "OpenTelemetry integration requires the [otel] extra. "
@@ -31,43 +76,62 @@ except ImportError as _otel_import_err:  # pragma: no cover - exercised only whe
     ) from _otel_import_err
 
 
+#: ``gen_ai.system`` value identifying contextweaver in OTLP-exported telemetry.
+#: Hardcoded rather than using ``GenAiSystemValues`` since the upstream enum
+#: only lists LLM vendors; the SemConv allows custom values for
+#: framework-style emitters.
+GEN_AI_SYSTEM_CONTEXTWEAVER: str = "contextweaver"
+
+#: ``gen_ai.operation.name`` value for context-build spans.
+GEN_AI_OPERATION_INVOKE_AGENT: str = "invoke_agent"
+
+#: ``gen_ai.operation.name`` value for routing spans.
+GEN_AI_OPERATION_EXECUTE_TOOL: str = "execute_tool"
+
+
 class OTelEventHook:
-    """:class:`~contextweaver.protocols.EventHook` that emits OTel spans + metrics.
+    """:class:`~contextweaver.protocols.EventHook` emitting OTel GenAI spans + metrics.
 
     Pass an instance to :class:`~contextweaver.context.manager.ContextManager`
-    via ``hook=``; spans are created for build / firewall / route events and
-    metrics are exported to whatever OTel backend you have configured
-    (Jaeger, Honeycomb, Datadog, console exporter, …).
+    via ``hook=``; spans are created with shapes matching the GenAI
+    Semantic Conventions so Laminar / Phoenix / Langfuse / LangSmith
+    render the agent and tool decomposition natively.
 
     Span names emitted:
 
-    - ``contextweaver.context.build`` — one span per :meth:`ContextManager.build`
-    - ``contextweaver.context.firewall`` — one span per firewall interception
-    - ``contextweaver.context.exclude`` — one span per item-exclusion event
-    - ``contextweaver.routing.route`` — one span per routing call
+    - ``invoke_agent`` — one span per :meth:`ContextManager.build`.
+    - ``execute_tool`` — one span per :meth:`Router.route`.
+    - ``contextweaver.context.firewall`` — engine-specific, kept for
+      detailed audit; not currently part of the GenAI SemConv.
+    - ``contextweaver.context.exclude`` — engine-specific.
 
     Metrics emitted:
 
-    - ``contextweaver.tokens.used`` (histogram) — prompt tokens per build
-    - ``contextweaver.firewall.interceptions`` (counter) — total intercepts
-    - ``contextweaver.items.excluded`` (counter) — total items dropped
-    - ``contextweaver.budget.exceeded`` (counter) — over-budget events
-    - ``contextweaver.routing.candidates`` (histogram) — candidates returned
+    - ``gen_ai.client.token.usage`` (histogram) — prompt tokens.
+    - ``contextweaver.firewall.interceptions`` (counter).
+    - ``contextweaver.items.excluded`` (counter).
+    - ``contextweaver.budget.exceeded`` (counter).
+    - ``contextweaver.routing.candidates`` (histogram).
+
+    Args:
+        service_name: OTel resource name; defaults to ``"contextweaver"``.
+        otel_emit_experimental: When ``True``, emit GenAI SemConv
+            attributes that are still flagged experimental upstream
+            (e.g. raw-prompt content).  Default ``False`` keeps the
+            emission PII-safe.
     """
 
-    def __init__(self, service_name: str = "contextweaver") -> None:
-        """Initialise tracer + meter for the given service name.
-
-        ``contextweaver.tokens.used`` is recorded as a histogram so it stays
-        portable across all ``opentelemetry-api>=1.20`` releases — the
-        synchronous ``create_gauge`` instrument only landed in 1.27, and an
-        observable gauge would force callers to keep a global "latest
-        value" cache. Histograms record per-build distributions which is
-        usually the more useful surface for dashboards anyway.
-        """
+    def __init__(
+        self,
+        service_name: str = "contextweaver",
+        *,
+        otel_emit_experimental: bool = False,
+    ) -> None:
         self._tracer = _otel_trace.get_tracer(service_name)
         self._meter = _otel_metrics.get_meter(service_name)
-        self._tokens_hist: Any = self._meter.create_histogram("contextweaver.tokens.used")
+        # GenAI SemConv-named token-usage histogram.
+        self._token_hist: Any = self._meter.create_histogram(_gm.GEN_AI_CLIENT_TOKEN_USAGE)
+        # Engine-specific counters (no SemConv equivalent yet).
         self._firewall_counter: Any = self._meter.create_counter(
             "contextweaver.firewall.interceptions"
         )
@@ -76,53 +140,106 @@ class OTelEventHook:
         self._candidates_hist: Any = self._meter.create_histogram(
             "contextweaver.routing.candidates"
         )
+        self._emit_experimental = otel_emit_experimental
+
+    # ------------------------------------------------------------------
+    # Context build → invoke_agent span (GenAI SemConv)
+    # ------------------------------------------------------------------
 
     def on_context_built(self, pack: ContextPack) -> None:
-        """Record a span + tokens-used histogram observation for one build."""
+        """Emit an ``invoke_agent``-shaped span + token-usage metric."""
         stats = pack.stats
-        prompt_tokens = sum(stats.tokens_per_section.values()) + stats.header_footer_tokens
+        prompt_tokens = stats.prompt_tokens
         attrs: dict[str, Any] = {
-            "phase": pack.phase.value,
-            "tokens": prompt_tokens,
-            "candidates": stats.total_candidates,
-            "included": stats.included_count,
-            "dropped": stats.dropped_count,
-            "dedup_removed": stats.dedup_removed,
+            _ga.GEN_AI_SYSTEM: GEN_AI_SYSTEM_CONTEXTWEAVER,
+            _ga.GEN_AI_OPERATION_NAME: GEN_AI_OPERATION_INVOKE_AGENT,
+            _ga.GEN_AI_USAGE_INPUT_TOKENS: prompt_tokens,
+            # Engine-specific diagnostic attributes — surface under the
+            # ``contextweaver.*`` namespace so they don't collide with future
+            # SemConv additions.
+            "contextweaver.phase": pack.phase.value,
+            "contextweaver.candidates.total": stats.total_candidates,
+            "contextweaver.candidates.included": stats.included_count,
+            "contextweaver.candidates.dropped": stats.dropped_count,
+            "contextweaver.candidates.dedup_removed": stats.dedup_removed,
         }
-        with self._tracer.start_as_current_span("contextweaver.context.build", attributes=attrs):
+        with self._tracer.start_as_current_span(GEN_AI_OPERATION_INVOKE_AGENT, attributes=attrs):
             pass
-        self._tokens_hist.record(prompt_tokens, attributes={"phase": pack.phase.value})
+        # Histogram per SemConv: tag with operation.name + token.type.
+        self._token_hist.record(
+            prompt_tokens,
+            attributes={
+                _ga.GEN_AI_OPERATION_NAME: GEN_AI_OPERATION_INVOKE_AGENT,
+                _ga.GEN_AI_TOKEN_TYPE: "input",
+                _ga.GEN_AI_SYSTEM: GEN_AI_SYSTEM_CONTEXTWEAVER,
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Engine-specific events (no canonical SemConv equivalent)
+    # ------------------------------------------------------------------
 
     def on_firewall_triggered(self, item: ContextItem, reason: str) -> None:
         """Record a span + counter increment for one firewall interception."""
         with self._tracer.start_as_current_span(
             "contextweaver.context.firewall",
-            attributes={"reason": reason, "item_kind": item.kind.value},
+            attributes={
+                "contextweaver.firewall.reason": reason,
+                "contextweaver.item.kind": item.kind.value,
+            },
         ):
             pass
-        self._firewall_counter.add(1, attributes={"reason": reason})
+        self._firewall_counter.add(1, attributes={"contextweaver.firewall.reason": reason})
 
     def on_items_excluded(self, items: list[ContextItem], reason: str) -> None:
         """Record a span + counter increment for one exclusion batch."""
         with self._tracer.start_as_current_span(
             "contextweaver.context.exclude",
-            attributes={"reason": reason, "count": len(items)},
+            attributes={
+                "contextweaver.exclude.reason": reason,
+                "contextweaver.exclude.count": len(items),
+            },
         ):
             pass
-        self._exclude_counter.add(len(items), attributes={"reason": reason})
+        self._exclude_counter.add(len(items), attributes={"contextweaver.exclude.reason": reason})
 
     def on_budget_exceeded(self, requested: int, budget: int) -> None:
         """Increment the budget-exceeded counter with the overrun ratio."""
         self._budget_counter.add(
             1,
-            attributes={"requested": requested, "budget": budget},
+            attributes={
+                "contextweaver.budget.requested": requested,
+                "contextweaver.budget.limit": budget,
+            },
         )
 
+    # ------------------------------------------------------------------
+    # Route → execute_tool span (GenAI SemConv)
+    # ------------------------------------------------------------------
+
     def on_route_completed(self, tool_ids: list[str]) -> None:
-        """Record a span + candidates-histogram observation for one route."""
-        with self._tracer.start_as_current_span(
-            "contextweaver.routing.route",
-            attributes={"candidate_count": len(tool_ids)},
-        ):
+        """Emit an ``execute_tool``-shaped span + candidates-histogram observation.
+
+        The rank-1 candidate (``tool_ids[0]``) populates
+        :data:`gen_ai_attributes.GEN_AI_TOOL_NAME` — that's the routing
+        decision the LLM is being offered.  The full candidate list is
+        surfaced under the ``contextweaver.*`` namespace for callers that
+        want to audit the runners-up.
+        """
+        attrs: dict[str, Any] = {
+            _ga.GEN_AI_SYSTEM: GEN_AI_SYSTEM_CONTEXTWEAVER,
+            _ga.GEN_AI_OPERATION_NAME: GEN_AI_OPERATION_EXECUTE_TOOL,
+            "contextweaver.routing.candidate_count": len(tool_ids),
+        }
+        if tool_ids:
+            attrs[_ga.GEN_AI_TOOL_NAME] = tool_ids[0]
+            attrs["contextweaver.routing.candidate_ids"] = tuple(tool_ids)
+        with self._tracer.start_as_current_span(GEN_AI_OPERATION_EXECUTE_TOOL, attributes=attrs):
             pass
-        self._candidates_hist.record(len(tool_ids))
+        self._candidates_hist.record(
+            len(tool_ids),
+            attributes={
+                _ga.GEN_AI_OPERATION_NAME: GEN_AI_OPERATION_EXECUTE_TOOL,
+                _ga.GEN_AI_SYSTEM: GEN_AI_SYSTEM_CONTEXTWEAVER,
+            },
+        )

--- a/src/contextweaver/extras/otel.py
+++ b/src/contextweaver/extras/otel.py
@@ -67,6 +67,12 @@ if TYPE_CHECKING:
 try:
     from opentelemetry import metrics as _otel_metrics
     from opentelemetry import trace as _otel_trace
+
+    # GenAI SemConv lives under ``_incubating`` while upstream status is
+    # "Development".  Pinned via ``opentelemetry-semantic-conventions-ai``
+    # or ``opentelemetry-semantic-conventions>=0.48b0`` in pyproject.toml
+    # ``[otel]`` extra.  If upstream graduates to stable, only this import
+    # path changes — emitted attribute *names* are already spec-stable.
     from opentelemetry.semconv._incubating.attributes import gen_ai_attributes as _ga
     from opentelemetry.semconv._incubating.metrics import gen_ai_metrics as _gm
 except ImportError as _otel_import_err:  # pragma: no cover - exercised only when extra is missing
@@ -163,6 +169,10 @@ class OTelEventHook:
             "contextweaver.candidates.dropped": stats.dropped_count,
             "contextweaver.candidates.dedup_removed": stats.dedup_removed,
         }
+        if self._emit_experimental:
+            # Experimental: include the rendered prompt.  PII-prone — only
+            # enable when the observability backend is trusted.
+            attrs["contextweaver.prompt.rendered"] = pack.prompt
         with self._tracer.start_as_current_span(GEN_AI_OPERATION_INVOKE_AGENT, attributes=attrs):
             pass
         # Histogram per SemConv: tag with operation.name + token.type.

--- a/src/contextweaver/metrics.py
+++ b/src/contextweaver/metrics.py
@@ -107,7 +107,7 @@ class MetricsCollector:
                 by :meth:`~contextweaver.context.manager.ContextManager.build`.
         """
         stats = pack.stats
-        prompt_tokens = sum(stats.tokens_per_section.values()) + stats.header_footer_tokens
+        prompt_tokens = stats.prompt_tokens
         with self._lock:
             self._c.total_builds += 1
             self._c.total_prompt_tokens += prompt_tokens

--- a/src/contextweaver/routing/explanation.py
+++ b/src/contextweaver/routing/explanation.py
@@ -1,0 +1,173 @@
+"""Routing-decision explanation rendering (issue #226).
+
+Produces a human-readable rationale of *why* a :class:`RouteResult` ranked the
+top-k candidates the way it did.  Extracted from :mod:`router` so the
+``RouteResult.explanation()`` method stays a thin one-liner and ``router.py``
+does not grow further beyond the soft 300-line cap.
+
+The rendering is pure data — same input ``RouteResult`` → byte-identical
+output.  No I/O, no randomness, no network calls.  Two surfaces:
+
+- :func:`explain_route` returns a markdown string suitable for pasting into a
+  GitHub issue body, a Slack thread, or a CLI dump.
+- :func:`explain_route_dict` returns a versioned dict (``{"version": 1, ...}``)
+  for programmatic consumers and downstream observability platforms.
+
+Privacy guidance: this renderer surfaces item *ids*, *names*, *scores*, and the
+original *query string*.  It does **not** surface ``args_schema`` content or
+full item descriptions — those can carry sensitive payloads in some tool
+catalogs (see ``docs/agent-context/invariants.md`` "Do not put schemas on
+ChoiceCard").
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from contextweaver.routing.router import RouteResult
+
+#: Schema version for :func:`explain_route_dict` payloads.  Bumped on
+#: backwards-incompatible field changes (e.g. removing a key).
+EXPLANATION_VERSION: int = 1
+
+
+def explain_route_dict(result: RouteResult) -> dict[str, Any]:
+    """Structured rationale dict for a :class:`RouteResult` (issue #226).
+
+    The dict is versioned via the ``version`` key so downstream programmatic
+    consumers can detect schema changes.  Output is deterministic given the
+    same input.
+    """
+    paired: list[tuple[str, float]] = list(zip(result.candidate_ids, result.scores, strict=False))
+    top_score = paired[0][1] if paired else 0.0
+    runner_up_score = paired[1][1] if len(paired) > 1 else None
+    confidence_gap = (top_score - runner_up_score) if runner_up_score is not None else None
+
+    rank_one = paired[0] if paired else None
+    rank_two = paired[1] if len(paired) > 1 else None
+
+    return {
+        "version": EXPLANATION_VERSION,
+        "query": result.trace.query,
+        "retriever_engine": result.trace.retriever_engine,
+        "candidates": [
+            {"rank": i + 1, "id": cid, "score": round(s, 4)} for i, (cid, s) in enumerate(paired)
+        ],
+        "top": {"id": rank_one[0], "score": round(rank_one[1], 4)} if rank_one else None,
+        "runner_up": ({"id": rank_two[0], "score": round(rank_two[1], 4)} if rank_two else None),
+        "confidence_gap": round(confidence_gap, 4) if confidence_gap is not None else None,
+        "is_ambiguous": result.is_ambiguous,
+        "clarifying_question": result.clarifying_question,
+        "context_hints": list(result.context_hints),
+        "context_boost_applied": result.context_boost_applied,
+        "excluded_count": result.excluded_count,
+        "gated_count": result.gated_count,
+    }
+
+
+def explain_route(
+    result: RouteResult,
+    format: Literal["md", "dict"] = "md",  # noqa: A002 — public API kwarg
+) -> str | dict[str, Any]:
+    """Render :class:`RouteResult` as a human-readable rationale (issue #226).
+
+    Args:
+        result: The :class:`RouteResult` to explain.
+        format: ``"md"`` for a paste-friendly Markdown string;
+            ``"dict"`` for the structured payload (see
+            :func:`explain_route_dict`).
+
+    Returns:
+        A markdown string when ``format == "md"``, a dict otherwise.
+    """
+    payload = explain_route_dict(result)
+    if format == "dict":
+        return payload
+    return _render_markdown(payload)
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    """Render the payload as deterministic, paste-friendly Markdown."""
+    lines: list[str] = []
+    query = payload.get("query") or "(no query)"
+    lines.append(f"### Routing explanation for query `{query}`")
+    lines.append("")
+    lines.append(f"_Retriever engine: `{payload['retriever_engine']}`._")
+    lines.append("")
+
+    # Top-k table
+    cands: list[dict[str, Any]] = payload["candidates"]
+    if cands:
+        lines.append("**Top candidates**")
+        lines.append("")
+        lines.append("| Rank | Tool id | Score |")
+        lines.append("|---:|:---|---:|")
+        for c in cands:
+            lines.append(f"| {c['rank']} | `{c['id']}` | {c['score']:.4f} |")
+        lines.append("")
+    else:
+        lines.append("**Top candidates**")
+        lines.append("")
+        lines.append("_No candidates returned._")
+        lines.append("")
+
+    # Confidence summary
+    top = payload.get("top")
+    runner_up = payload.get("runner_up")
+    gap = payload.get("confidence_gap")
+    if top is not None and runner_up is not None and gap is not None:
+        lines.append(
+            f"**Confidence gap**: `{top['id']}` ({top['score']:.4f}) "
+            f"vs runner-up `{runner_up['id']}` ({runner_up['score']:.4f}) "
+            f"= **{gap:+.4f}**."
+        )
+    elif top is not None:
+        lines.append(f"**Top pick**: `{top['id']}` ({top['score']:.4f}) — no runner-up.")
+    else:
+        lines.append("**Confidence gap**: n/a (no candidates).")
+    lines.append("")
+
+    # Ambiguity
+    if payload["is_ambiguous"]:
+        lines.append("⚠️ **Ambiguous result** (gap below router's `confidence_gap` threshold).")
+        cq = payload.get("clarifying_question")
+        if cq:
+            lines.append("")
+            lines.append(f"> Suggested clarifying question: _{cq}_")
+        lines.append("")
+    else:
+        lines.append("✅ Result is **not** ambiguous (gap above threshold).")
+        lines.append("")
+
+    # Filters applied
+    excluded = payload["excluded_count"]
+    gated = payload["gated_count"]
+    if excluded or gated:
+        lines.append("**Filters applied**")
+        lines.append("")
+        if excluded:
+            lines.append(f"- {excluded} item(s) filtered by `exclude_ids` / `exclude_tags`.")
+        if gated:
+            lines.append(
+                f"- {gated} item(s) filtered by `allowed_namespaces` /"
+                " `allowed_tags` toolset gating."
+            )
+        lines.append("")
+
+    # Context hints
+    hints: list[str] = payload["context_hints"]
+    if hints:
+        lines.append("**Context hints applied**")
+        lines.append("")
+        for h in hints:
+            lines.append(f"- {h}")
+        if payload["context_boost_applied"]:
+            lines.append("")
+            lines.append("_Hints altered the scoring query._")
+        else:
+            lines.append("")
+            lines.append("_Hints did not change the scoring query._")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/contextweaver/routing/router.py
+++ b/src/contextweaver/routing/router.py
@@ -21,7 +21,7 @@ import logging
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal, overload
 
 from contextweaver._utils import BM25Scorer, FuzzyScorer, TfIdfScorer, jaccard, tokenize
 from contextweaver.envelope import RoutingDecision
@@ -29,6 +29,7 @@ from contextweaver.exceptions import ConfigError, RouteError
 from contextweaver.profiles import RoutingConfig
 from contextweaver.protocols import Retriever
 from contextweaver.routing.cards import make_choice_cards
+from contextweaver.routing.explanation import explain_route, explain_route_dict
 from contextweaver.routing.filters import (
     augment_query,
     filter_items,
@@ -120,6 +121,38 @@ class RouteResult:
     def debug_trace(self) -> list[dict[str, Any]]:
         """Legacy view of :attr:`trace` in the pre-#51 dict-of-dicts shape."""
         return self.trace.to_legacy_dicts()
+
+    @overload
+    def explanation(self, format: Literal["md"] = "md") -> str: ...  # noqa: A002
+    @overload
+    def explanation(self, format: Literal["dict"]) -> dict[str, Any]: ...  # noqa: A002
+
+    def explanation(
+        self,
+        format: Literal["md", "dict"] = "md",  # noqa: A002 — public API kwarg
+    ) -> str | dict[str, Any]:
+        """Render a human-readable rationale of the routing decision (issue #226).
+
+        Surfaces top-k candidates with scores, the rank-1/rank-2 confidence
+        gap, ambiguity + clarifying question, applied context hints, and the
+        excluded/gated filter counts.
+
+        Args:
+            format: ``"md"`` for a paste-friendly Markdown string (default);
+                ``"dict"`` for the versioned structured payload.
+
+        Returns:
+            A markdown string when ``format == "md"``, a dict otherwise.
+
+        Privacy: the explanation surfaces item ids + scores + the original
+        query.  It does **not** include ``args_schema`` content or full item
+        descriptions.  Use the dict form when attaching to span attributes on
+        :class:`~contextweaver.extras.otel.OTelEventHook` and similar
+        observability surfaces.
+        """
+        if format == "dict":
+            return explain_route_dict(self)
+        return explain_route(self, format="md")
 
     def to_routing_decision(
         self,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,8 +28,14 @@ def _run(*args: str, cwd: str | None = None) -> subprocess.CompletedProcess[str]
 
 def test_no_args_prints_help() -> None:
     result = _run()
-    assert result.returncode == 0
-    assert "contextweaver" in result.stdout.lower() or "usage" in result.stdout.lower()
+    # Typer exits with code 2 when invoked without a subcommand (Click's
+    # ``UsageError`` convention) while still printing the help banner.  The
+    # argparse predecessor exited 0; the v0.5 CLI rewrite (#221) adopts
+    # Typer's convention.  Accept either to keep the test useful as a
+    # smoke check regardless of which framework is in use.
+    assert result.returncode in (0, 2)
+    output = (result.stdout + result.stderr).lower()
+    assert "contextweaver" in output or "usage" in output
 
 
 # ------------------------------------------------------------------
@@ -245,3 +251,43 @@ def test_replay_budget(tmp_path: Path) -> None:
     result = _run("replay", "--session", str(ingested_path), "--budget", "500")
     assert result.returncode == 0
     assert "500" in result.stdout
+
+
+# ------------------------------------------------------------------
+# stats (issue #106)
+# ------------------------------------------------------------------
+
+
+def test_stats_subcommand_renders_report(tmp_path: Path) -> None:
+    """End-to-end: ingest a JSONL session, then run ``stats`` against it."""
+    jsonl_path = _write_session_jsonl(tmp_path)
+    ingested_path = tmp_path / "ingested.json"
+    _run("ingest", "--events", str(jsonl_path), "--out", str(ingested_path))
+
+    result = _run(
+        "stats",
+        "--session",
+        str(ingested_path),
+        "--phase",
+        "answer",
+        "--budget",
+        "1000",
+        "--format",
+        "text",
+    )
+    assert result.returncode == 0
+    assert "Context Build Report" in result.stdout
+    assert "answer" in result.stdout
+    assert "Candidates" in result.stdout
+
+
+def test_stats_subcommand_rich_format(tmp_path: Path) -> None:
+    jsonl_path = _write_session_jsonl(tmp_path)
+    ingested_path = tmp_path / "ingested.json"
+    _run("ingest", "--events", str(jsonl_path), "--out", str(ingested_path))
+
+    result = _run("stats", "--session", str(ingested_path), "--budget", "1000", "--format", "rich")
+    assert result.returncode == 0
+    # Rich-rendered output strips markup but keeps the headers.
+    assert "Context Build Report" in result.stdout
+    assert "Candidates" in result.stdout

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -307,6 +307,25 @@ def test_choice_card_roundtrip() -> None:
     assert restored.side_effects is True
 
 
+def test_choice_card_rejects_unknown_kind() -> None:
+    """`kind` is constrained to the gateway-spec enum at runtime, not only by mypy."""
+    with pytest.raises(ValueError, match="ChoiceCard.kind must be one of"):
+        ChoiceCard(id="c1", name="n", description="d", kind="bogus")  # type: ignore[arg-type]
+
+
+def test_choice_card_from_dict_rejects_unknown_kind() -> None:
+    """`from_dict` must reject an out-of-enum `kind` value rather than silently accept it."""
+    with pytest.raises(ValueError, match="ChoiceCard.kind must be one of"):
+        ChoiceCard.from_dict({"id": "c1", "name": "n", "description": "d", "kind": "bogus"})
+
+
+def test_choice_card_accepts_all_documented_kinds() -> None:
+    """Every value of the `Literal[...]` enum constructs successfully."""
+    for kind in ("tool", "agent", "skill", "internal"):
+        card = ChoiceCard(id=f"c-{kind}", name="n", description="d", kind=kind)  # type: ignore[arg-type]
+        assert card.kind == kind
+
+
 def test_choice_card_from_partial_dict() -> None:
     card = ChoiceCard.from_dict({"id": "x", "name": "n", "description": "d"})
     assert card.tags == []

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -106,6 +106,136 @@ def test_build_stats_from_empty_dict() -> None:
 
 
 # ---------------------------------------------------------------------------
+# BuildStats.prompt_tokens (issue #106)
+# ---------------------------------------------------------------------------
+
+
+def test_build_stats_prompt_tokens_property() -> None:
+    bs = BuildStats(
+        tokens_per_section={"system": 200, "history": 400, "facts": 50},
+        header_footer_tokens=42,
+    )
+    # Single source of truth: sum of sections + header/footer.
+    assert bs.prompt_tokens == 200 + 400 + 50 + 42
+
+
+def test_build_stats_prompt_tokens_empty() -> None:
+    assert BuildStats().prompt_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# BuildStats.report() / report_dict() (issue #106)
+# ---------------------------------------------------------------------------
+
+
+def _sample_stats() -> BuildStats:
+    return BuildStats(
+        tokens_per_section={"facts": 180, "history": 1200, "tool_results": 1800, "episodes": 320},
+        total_candidates=24,
+        included_count=12,
+        dropped_count=8,
+        dropped_reasons={"budget_exceeded": 5, "sensitivity": 2, "dedup": 1},
+        dedup_removed=4,
+        dependency_closures=2,
+        header_footer_tokens=0,
+    )
+
+
+def test_build_stats_report_text_contains_sections() -> None:
+    out = _sample_stats().report(format="text", phase="answer", budget=4000)
+    assert "Context Build Report" in out
+    assert "Phase:  answer" in out
+    assert "Budget: 4000" in out
+    assert "Generated:    24" in out
+    assert "Included:     12" in out
+    assert "Dropped:      8" in out
+    # token-section table row
+    assert "tool_results" in out and "1800" in out
+    # drop reasons section
+    assert "budget_exceeded: 5" in out
+
+
+def test_build_stats_report_deterministic() -> None:
+    stats = _sample_stats()
+    a = stats.report(format="text", phase="answer", budget=4000)
+    b = stats.report(format="text", phase="answer", budget=4000)
+    assert a == b
+    # Sorted section order — independent of insertion order — yields stable bytes
+    # even when ``tokens_per_section`` is built from a different insertion order.
+    shuffled = BuildStats(
+        tokens_per_section={"tool_results": 1800, "facts": 180, "episodes": 320, "history": 1200},
+        total_candidates=stats.total_candidates,
+        included_count=stats.included_count,
+        dropped_count=stats.dropped_count,
+        dropped_reasons=stats.dropped_reasons,
+        dedup_removed=stats.dedup_removed,
+        dependency_closures=stats.dependency_closures,
+        header_footer_tokens=stats.header_footer_tokens,
+    )
+    assert shuffled.report(format="text", phase="answer", budget=4000) == a
+
+
+def test_build_stats_report_recommends_when_section_over_budget() -> None:
+    stats = BuildStats(
+        tokens_per_section={"history": 2500},  # 62.5 % of 4000 budget
+        total_candidates=10,
+        included_count=8,
+    )
+    out = stats.report(format="text", phase="answer", budget=4000)
+    assert "history" in out
+    assert "lowering firewall threshold" in out
+
+
+def test_build_stats_report_recommends_headroom_when_efficient() -> None:
+    stats = BuildStats(tokens_per_section={"facts": 1000}, included_count=5, total_candidates=5)
+    out = stats.report(format="text", phase="answer", budget=4000)
+    assert "budget headroom" in out
+
+
+def test_build_stats_report_warns_when_over_budget() -> None:
+    stats = BuildStats(tokens_per_section={"history": 5000})
+    out = stats.report(format="text", phase="answer", budget=4000)
+    assert "over budget" in out
+
+
+def test_build_stats_report_no_budget_skips_percentages() -> None:
+    out = _sample_stats().report(format="text", phase="answer", budget=None)
+    assert "% Budget" not in out
+    # Section table still present without percentage columns.
+    assert "1800" in out
+
+
+def test_build_stats_report_rich_has_markup() -> None:
+    out = _sample_stats().report(format="rich", phase="answer", budget=4000)
+    assert "[bold cyan]Context Build Report[/bold cyan]" in out
+    assert "[bold]Candidates[/bold]" in out
+    # Determinism applies to rich format too
+    assert out == _sample_stats().report(format="rich", phase="answer", budget=4000)
+
+
+def test_build_stats_report_dict_versioned() -> None:
+    payload = _sample_stats().report_dict(phase="answer", budget=4000)
+    assert payload["version"] == 1
+    assert payload["phase"] == "answer"
+    assert payload["budget"] == 4000
+    assert payload["prompt_tokens"] == 180 + 1200 + 1800 + 320
+    assert payload["candidates"] == {
+        "total": 24,
+        "included": 12,
+        "dropped": 8,
+        "deduplicated": 4,
+        "dependency_closures": 2,
+    }
+    # dropped_reasons sorted deterministically
+    assert list(payload["dropped_reasons"].keys()) == ["budget_exceeded", "dedup", "sensitivity"]
+
+
+def test_build_stats_report_dict_empty_recommendations_without_budget() -> None:
+    payload = _sample_stats().report_dict(phase="answer", budget=None)
+    assert payload["recommendations"] == []
+
+
+# ---------------------------------------------------------------------------
 # ContextPack
 # ---------------------------------------------------------------------------
 

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -200,9 +200,42 @@ def test_experimental_flag_defaults_off() -> None:
 
     hook = OTelEventHook(service_name="cw-test")
     assert hook._emit_experimental is False
-    # Calling with the flag flips the bit but doesn't (yet) change emission shape.
     enabled = OTelEventHook(service_name="cw-test", otel_emit_experimental=True)
     assert enabled._emit_experimental is True
+
+
+@pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed ([otel] extra)")
+def test_experimental_flag_gates_prompt_in_span(span_exporter: InMemorySpanExporter) -> None:
+    """``otel_emit_experimental=True`` must include prompt text; ``False`` must not."""
+    from contextweaver.envelope import BuildStats, ContextPack
+    from contextweaver.extras.otel import OTelEventHook
+    from contextweaver.types import Phase
+
+    prompt_text = "find all overdue invoices for ACME Corp"
+    pack = ContextPack(
+        prompt=prompt_text,
+        stats=BuildStats(total_candidates=1, included_count=1),
+        phase=Phase.answer,
+    )
+
+    # Default (experimental off) → prompt must NOT appear.
+    OTelEventHook(service_name="cw-test").on_context_built(pack)
+    spans_off = span_exporter.get_finished_spans()
+    for span in spans_off:
+        assert "contextweaver.prompt.rendered" not in (span.attributes or {})
+
+    span_exporter.clear()
+
+    # Experimental on → prompt MUST appear.
+    OTelEventHook(service_name="cw-test", otel_emit_experimental=True).on_context_built(pack)
+    spans_on = span_exporter.get_finished_spans()
+    found = False
+    for span in spans_on:
+        attrs = dict(span.attributes or {})
+        if "contextweaver.prompt.rendered" in attrs:
+            assert attrs["contextweaver.prompt.rendered"] == prompt_text
+            found = True
+    assert found, "experimental span must include contextweaver.prompt.rendered"
 
 
 @pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed ([otel] extra)")

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -1,9 +1,13 @@
-"""Tests for contextweaver.extras.otel — OpenTelemetry integration.
+"""Tests for contextweaver.extras.otel — OpenTelemetry GenAI integration (#224).
 
 The whole module is skipped when the ``[otel]`` extra is not installed, with
 one exception: a single test that imports the module and asserts the friendly
 ImportError surfaces. This guarantees both code paths are covered without
 requiring opentelemetry in the default CI install.
+
+The functional tests use the OTel SDK's :class:`InMemorySpanExporter` so the
+assertions check actual emitted span names + attribute keys, not the hook's
+internal state.  This is what makes the SemConv-name claim verifiable.
 """
 
 from __future__ import annotations
@@ -17,6 +21,7 @@ def _otel_available() -> bool:
     try:
         importlib.import_module("opentelemetry.trace")
         importlib.import_module("opentelemetry.metrics")
+        importlib.import_module("opentelemetry.semconv._incubating.attributes.gen_ai_attributes")
     except ImportError:
         return False
     return True
@@ -33,10 +38,42 @@ HAS_OTEL = _otel_available()
 def test_import_error_message_when_extra_missing() -> None:
     """If opentelemetry is missing, importing extras.otel must guide the user."""
     if HAS_OTEL:
-        # Cannot meaningfully test the ImportError path when the extra IS installed.
         pytest.skip("opentelemetry is installed; ImportError path not exercised here")
     with pytest.raises(ImportError, match=r"\[otel\]"):
         importlib.import_module("contextweaver.extras.otel")
+
+
+# ---------------------------------------------------------------------------
+# Test helpers — wire an InMemorySpanExporter for assertions
+# ---------------------------------------------------------------------------
+
+
+if HAS_OTEL:  # pragma: no cover - exercised only with [otel]
+    from opentelemetry import trace as _trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    # OTel's global ``TracerProvider`` can only be set once per process.
+    # We install the in-memory exporter at module import time and re-use
+    # the same exporter across tests (clearing between cases).
+    _EXPORTER: InMemorySpanExporter | None = InMemorySpanExporter()
+    _PROVIDER = TracerProvider()
+    _PROVIDER.add_span_processor(SimpleSpanProcessor(_EXPORTER))
+    _trace.set_tracer_provider(_PROVIDER)
+else:  # pragma: no cover - the no-extra path
+    _EXPORTER = None
+
+
+@pytest.fixture
+def span_exporter() -> InMemorySpanExporter:
+    """Yield the module-level :class:`InMemorySpanExporter`, cleared before use."""
+    if not HAS_OTEL or _EXPORTER is None:
+        pytest.skip("opentelemetry not installed ([otel] extra)")
+    _EXPORTER.clear()
+    return _EXPORTER
 
 
 # ---------------------------------------------------------------------------
@@ -49,9 +86,9 @@ def test_otel_event_hook_constructs() -> None:
     from contextweaver.extras.otel import OTelEventHook
 
     hook = OTelEventHook(service_name="cw-test")
-    # Tracer and meter handles are created at construction time.
     assert hook._tracer is not None
     assert hook._meter is not None
+    assert hook._emit_experimental is False
 
 
 @pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed ([otel] extra)")
@@ -63,27 +100,148 @@ def test_otel_event_hook_satisfies_event_hook_protocol() -> None:
 
 
 @pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed ([otel] extra)")
-def test_otel_event_hook_records_build() -> None:
+def test_invoke_agent_span_shape_matches_genai_semconv(span_exporter: InMemorySpanExporter) -> None:
+    """``on_context_built`` must emit an ``invoke_agent`` span with stable SemConv attrs."""
+    from opentelemetry.semconv._incubating.attributes import gen_ai_attributes as ga
+
+    from contextweaver.envelope import BuildStats, ContextPack
+    from contextweaver.extras.otel import (
+        GEN_AI_OPERATION_INVOKE_AGENT,
+        GEN_AI_SYSTEM_CONTEXTWEAVER,
+        OTelEventHook,
+    )
+    from contextweaver.types import Phase
+
+    pack = ContextPack(
+        prompt="x" * 100,
+        stats=BuildStats(
+            tokens_per_section={"body": 100, "facts": 50},
+            total_candidates=5,
+            included_count=4,
+            dropped_count=1,
+            dedup_removed=2,
+            header_footer_tokens=20,
+        ),
+        phase=Phase.answer,
+    )
+    OTelEventHook(service_name="cw-test").on_context_built(pack)
+
+    spans = span_exporter.get_finished_spans()
+    invoke = [s for s in spans if s.name == GEN_AI_OPERATION_INVOKE_AGENT]
+    assert len(invoke) == 1, f"expected one invoke_agent span, got {[s.name for s in spans]}"
+    attrs = dict(invoke[0].attributes or {})
+    # GenAI SemConv attributes:
+    assert attrs[ga.GEN_AI_SYSTEM] == GEN_AI_SYSTEM_CONTEXTWEAVER
+    assert attrs[ga.GEN_AI_OPERATION_NAME] == GEN_AI_OPERATION_INVOKE_AGENT
+    # prompt_tokens = sum(100, 50) + 20 = 170
+    assert attrs[ga.GEN_AI_USAGE_INPUT_TOKENS] == 170
+    # Engine-specific contextweaver attributes:
+    assert attrs["contextweaver.phase"] == "answer"
+    assert attrs["contextweaver.candidates.total"] == 5
+    assert attrs["contextweaver.candidates.included"] == 4
+    assert attrs["contextweaver.candidates.dropped"] == 1
+    assert attrs["contextweaver.candidates.dedup_removed"] == 2
+
+
+@pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed ([otel] extra)")
+def test_execute_tool_span_shape_matches_genai_semconv(span_exporter: InMemorySpanExporter) -> None:
+    """``on_route_completed`` must emit an ``execute_tool`` span with rank-1 tool name."""
+    from opentelemetry.semconv._incubating.attributes import gen_ai_attributes as ga
+
+    from contextweaver.extras.otel import (
+        GEN_AI_OPERATION_EXECUTE_TOOL,
+        GEN_AI_SYSTEM_CONTEXTWEAVER,
+        OTelEventHook,
+    )
+
+    OTelEventHook(service_name="cw-test").on_route_completed(
+        ["billing.invoices.search", "billing.invoices.list", "billing.invoices.get"]
+    )
+
+    spans = span_exporter.get_finished_spans()
+    execs = [s for s in spans if s.name == GEN_AI_OPERATION_EXECUTE_TOOL]
+    assert len(execs) == 1, f"expected one execute_tool span, got {[s.name for s in spans]}"
+    attrs = dict(execs[0].attributes or {})
+    assert attrs[ga.GEN_AI_SYSTEM] == GEN_AI_SYSTEM_CONTEXTWEAVER
+    assert attrs[ga.GEN_AI_OPERATION_NAME] == GEN_AI_OPERATION_EXECUTE_TOOL
+    # Rank-1 tool name surfaces under the canonical SemConv attribute.
+    assert attrs[ga.GEN_AI_TOOL_NAME] == "billing.invoices.search"
+    assert attrs["contextweaver.routing.candidate_count"] == 3
+    # Full candidate list lives under contextweaver.* (not SemConv yet).
+    assert tuple(attrs["contextweaver.routing.candidate_ids"]) == (
+        "billing.invoices.search",
+        "billing.invoices.list",
+        "billing.invoices.get",
+    )
+
+
+@pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed ([otel] extra)")
+def test_execute_tool_span_handles_empty_candidate_list(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """``on_route_completed([])`` should not raise and should omit GEN_AI_TOOL_NAME."""
+    from opentelemetry.semconv._incubating.attributes import gen_ai_attributes as ga
+
+    from contextweaver.extras.otel import GEN_AI_OPERATION_EXECUTE_TOOL, OTelEventHook
+
+    OTelEventHook(service_name="cw-test").on_route_completed([])
+    spans = span_exporter.get_finished_spans()
+    execs = [s for s in spans if s.name == GEN_AI_OPERATION_EXECUTE_TOOL]
+    assert len(execs) == 1
+    attrs = dict(execs[0].attributes or {})
+    assert ga.GEN_AI_TOOL_NAME not in attrs
+    assert attrs["contextweaver.routing.candidate_count"] == 0
+
+
+@pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed ([otel] extra)")
+def test_experimental_flag_defaults_off() -> None:
+    """By default, raw prompt content + experimental attrs must NOT be emitted."""
+    from contextweaver.extras.otel import OTelEventHook
+
+    hook = OTelEventHook(service_name="cw-test")
+    assert hook._emit_experimental is False
+    # Calling with the flag flips the bit but doesn't (yet) change emission shape.
+    enabled = OTelEventHook(service_name="cw-test", otel_emit_experimental=True)
+    assert enabled._emit_experimental is True
+
+
+@pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed ([otel] extra)")
+def test_no_pii_in_default_attributes(span_exporter: InMemorySpanExporter) -> None:
+    """Default emission must not include raw queries / descriptions."""
     from contextweaver.envelope import BuildStats, ContextPack
     from contextweaver.extras.otel import OTelEventHook
     from contextweaver.types import Phase
 
     pack = ContextPack(
-        prompt="",
-        stats=BuildStats(
-            tokens_per_section={"body": 100},
-            total_candidates=5,
-            included_count=4,
-            dropped_count=1,
-            header_footer_tokens=20,
-        ),
+        prompt="sensitive customer PII here please redact",
+        stats=BuildStats(total_candidates=1, included_count=1),
         phase=Phase.answer,
     )
-    OTelEventHook().on_context_built(pack)  # must not raise
+    OTelEventHook(service_name="cw-test").on_context_built(pack)
+
+    spans = span_exporter.get_finished_spans()
+    for span in spans:
+        attrs = dict(span.attributes or {})
+        for value in attrs.values():
+            if isinstance(value, str):
+                assert "sensitive" not in value
+                assert "PII" not in value
 
 
 @pytest.mark.skipif(not HAS_OTEL, reason="opentelemetry not installed ([otel] extra)")
-def test_otel_event_hook_route_completed() -> None:
+def test_firewall_event_uses_contextweaver_namespace(span_exporter: InMemorySpanExporter) -> None:
+    """Firewall + exclude events stay under contextweaver.* (no SemConv equivalent yet)."""
     from contextweaver.extras.otel import OTelEventHook
+    from contextweaver.types import ContextItem, ItemKind
 
-    OTelEventHook().on_route_completed(["a", "b", "c"])  # must not raise
+    hook = OTelEventHook(service_name="cw-test")
+    hook.on_firewall_triggered(
+        ContextItem(id="x", kind=ItemKind.tool_result, text="big"),
+        reason="size_threshold",
+    )
+    spans = span_exporter.get_finished_spans()
+    fw = [s for s in spans if s.name == "contextweaver.context.firewall"]
+    assert len(fw) == 1
+    attrs = dict(fw[0].attributes or {})
+    assert attrs["contextweaver.firewall.reason"] == "size_threshold"
+    assert attrs["contextweaver.item.kind"] == "tool_result"

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -691,3 +691,84 @@ def test_context_hints_surface_on_result_and_trace() -> None:
     restored = type(with_hints.trace).from_dict(with_hints.trace.to_dict())
     assert restored.extra["context_hints"] == ["email"]
     assert restored.extra["context_boost_applied"] is True
+
+
+# ---------------------------------------------------------------------------
+# RouteResult.explanation() — issue #226
+# ---------------------------------------------------------------------------
+
+
+def test_route_result_explanation_md_contains_query_and_table() -> None:
+    items = _build_catalog_items()
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items, top_k=3)
+    result = router.route("read database")
+
+    md = result.explanation()  # default "md"
+
+    assert isinstance(md, str)
+    assert "### Routing explanation for query `read database`" in md
+    # Top-k table header
+    assert "| Rank | Tool id | Score |" in md
+    # At least one rank-1 row referencing one of the items
+    assert any(f"| 1 | `{item.id}` |" in md for item in items)
+    # Either gap text (n>=2 candidates) or top-pick fallback
+    assert "Confidence gap" in md or "Top pick" in md
+
+
+def test_route_result_explanation_dict_versioned_and_shaped() -> None:
+    items = _build_catalog_items()
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items, top_k=3)
+    result = router.route("write database")
+
+    payload = result.explanation(format="dict")
+    assert isinstance(payload, dict)
+    assert payload["version"] == 1
+    # The trace records the query that was actually scored (may be augmented)
+    assert "query" in payload and isinstance(payload["query"], str)
+    assert payload["retriever_engine"] in {"tfidf", "bm25", "fuzzy"}
+    assert isinstance(payload["candidates"], list)
+    assert all({"rank", "id", "score"} <= set(c) for c in payload["candidates"])
+    if payload["candidates"]:
+        assert payload["candidates"][0]["rank"] == 1
+    # Versioned, stable boolean fields
+    assert isinstance(payload["is_ambiguous"], bool)
+    assert isinstance(payload["context_boost_applied"], bool)
+
+
+def test_route_result_explanation_deterministic() -> None:
+    items = _build_catalog_items()
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items, top_k=3)
+    result = router.route("send notification")
+    a = result.explanation()
+    b = result.explanation()
+    assert a == b
+    # Determinism extends to the dict form
+    assert result.explanation(format="dict") == result.explanation(format="dict")
+
+
+def test_route_result_explanation_handles_empty() -> None:
+    """An empty :class:`RouteResult` should not blow up on explanation()."""
+    empty = RouteResult()
+    md = empty.explanation()
+    assert "No candidates returned" in md
+    payload = empty.explanation(format="dict")
+    assert payload["candidates"] == []
+    assert payload["top"] is None
+    assert payload["runner_up"] is None
+    assert payload["confidence_gap"] is None
+
+
+def test_route_result_explanation_surfaces_context_hints() -> None:
+    items = [
+        _item("send_email", "send_email", "Send notification", tags=["comm"]),
+        _item("send_sms", "send_sms", "Send notification", tags=["comm"]),
+    ]
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items, top_k=2)
+
+    md = router.route("send notification", context_hints=["email"]).explanation()
+    assert "Context hints applied" in md
+    assert "email" in md

--- a/tests/test_schema_gen.py
+++ b/tests/test_schema_gen.py
@@ -1,0 +1,278 @@
+"""Tests for the JSON Schema generator + drift check (issue #225).
+
+Two responsibilities exercised here:
+
+1. ``scripts/gen_schemas.py`` produces deterministic output that matches the
+   files committed under ``schemas/`` and ``docs/schemas/v0/``.
+2. Every published schema validates round-trip via ``to_dict()`` for the
+   matching dataclass — i.e. the contract is honest.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from contextweaver._schema_gen import (
+    SCHEMA_ID_BASE,
+    generate_array_schema,
+    generate_schema,
+    schema_to_json,
+)
+from contextweaver.envelope import BuildStats, ChoiceCard, ResultEnvelope
+from contextweaver.routing.manifest import GraphManifest
+from contextweaver.routing.trace import RouteTrace, TraceStep
+from contextweaver.types import SelectableItem
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMAS_DIR = REPO_ROOT / "schemas"
+DOCS_SCHEMAS_DIR = REPO_ROOT / "docs" / "schemas" / "v0"
+
+
+# ---------------------------------------------------------------------------
+# Drift check: regenerator output must match committed files
+# ---------------------------------------------------------------------------
+
+
+def test_schemas_check_passes_on_clean_tree() -> None:
+    """The committed schemas must match what the generator produces."""
+    result = subprocess.run(
+        [sys.executable, "scripts/gen_schemas.py", "--check"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"schemas drifted:\n{result.stderr}"
+
+
+def test_all_six_schemas_present() -> None:
+    expected = {
+        "catalog.schema.json",
+        "choice_card.schema.json",
+        "result_envelope.schema.json",
+        "route_trace.schema.json",
+        "build_stats.schema.json",
+        "graph_manifest.schema.json",
+    }
+    on_disk_root = {p.name for p in SCHEMAS_DIR.glob("*.schema.json")}
+    on_disk_docs = {p.name for p in DOCS_SCHEMAS_DIR.glob("*.schema.json")}
+    assert expected == on_disk_root == on_disk_docs
+
+
+def test_schemas_have_stable_id_urls() -> None:
+    for path in sorted(SCHEMAS_DIR.glob("*.schema.json")):
+        schema = json.loads(path.read_text())
+        assert schema["$id"].startswith(SCHEMA_ID_BASE + "/")
+        assert schema["$id"].endswith(path.name)
+        assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip validation: every dataclass.to_dict() validates against its schema
+# ---------------------------------------------------------------------------
+
+
+def _load_schema(name: str) -> dict[str, object]:
+    return json.loads((SCHEMAS_DIR / name).read_text())
+
+
+def test_choice_card_validates_against_schema() -> None:
+    card = ChoiceCard(
+        id="tool.search",
+        name="search",
+        description="Search the catalog",
+        tags=["search", "read"],
+        kind="tool",
+        namespace="tool",
+        has_schema=False,
+        score=0.85,
+        cost_hint=0.1,
+        side_effects=False,
+    )
+    jsonschema.validate(card.to_dict(), _load_schema("choice_card.schema.json"))
+
+
+def test_choice_card_schema_enforces_tag_count() -> None:
+    schema = _load_schema("choice_card.schema.json")
+    bad = ChoiceCard(id="t", name="t", description="d").to_dict()
+    bad["tags"] = ["a", "b", "c", "d", "e", "f"]  # 6 > 5
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
+def test_choice_card_schema_enforces_tag_length() -> None:
+    schema = _load_schema("choice_card.schema.json")
+    bad = ChoiceCard(id="t", name="t", description="d").to_dict()
+    bad["tags"] = ["x" * 25]  # > 24 chars
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
+def test_choice_card_schema_enforces_name_length() -> None:
+    schema = _load_schema("choice_card.schema.json")
+    bad = ChoiceCard(id="t", name="t", description="d").to_dict()
+    bad["name"] = "x" * 65  # > 64 chars
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
+def test_choice_card_post_init_rejects_oversize_tags() -> None:
+    """ChoiceCard __post_init__ enforces the same bounds the schema does."""
+    with pytest.raises(ValueError, match="tags"):
+        ChoiceCard(id="t", name="t", description="d", tags=["a", "b", "c", "d", "e", "f"])
+
+
+def test_choice_card_post_init_rejects_oversize_name() -> None:
+    with pytest.raises(ValueError, match="name"):
+        ChoiceCard(id="t", name="x" * 65, description="d")
+
+
+def test_result_envelope_validates_against_schema() -> None:
+    env = ResultEnvelope(
+        status="ok",
+        summary="done",
+        facts=["x=1"],
+        provenance={"tool": "db"},
+    )
+    jsonschema.validate(env.to_dict(), _load_schema("result_envelope.schema.json"))
+
+
+def test_build_stats_validates_against_schema() -> None:
+    stats = BuildStats(
+        tokens_per_section={"history": 200},
+        total_candidates=5,
+        included_count=3,
+        dropped_count=2,
+        dropped_reasons={"budget": 2},
+        dedup_removed=1,
+        dependency_closures=0,
+        header_footer_tokens=20,
+    )
+    jsonschema.validate(stats.to_dict(), _load_schema("build_stats.schema.json"))
+
+
+def test_route_trace_validates_against_schema() -> None:
+    trace = RouteTrace(
+        query="example",
+        confidence_gap=0.15,
+        top_score=0.9,
+        runner_up_score=0.5,
+        is_ambiguous=False,
+        retriever_engine="tfidf",
+        steps=[
+            TraceStep(
+                depth=0,
+                node="root",
+                scored_children=[("a", 0.9), ("b", 0.5)],
+                kept=["a"],
+            )
+        ],
+    )
+    jsonschema.validate(trace.to_dict(), _load_schema("route_trace.schema.json"))
+
+
+def test_graph_manifest_validates_against_schema() -> None:
+    manifest = GraphManifest(
+        build_hash="abcd1234",
+        seed=42,
+        engine_versions={"retriever": "tfidf:1.0"},
+        timestamp=1_700_000_000.0,
+        item_count=10,
+        strategy="namespace",
+        max_depth=3,
+    )
+    jsonschema.validate(manifest.to_dict(), _load_schema("graph_manifest.schema.json"))
+
+
+def test_catalog_validates_against_schema() -> None:
+    items = [
+        SelectableItem(
+            id="tool.read",
+            kind="tool",
+            name="read",
+            description="Read",
+            namespace="tool",
+        ),
+        SelectableItem(
+            id="agent.handler",
+            kind="agent",
+            name="handler",
+            description="Handles",
+            namespace="agent",
+        ),
+    ]
+    payload = [it.to_dict() for it in items]
+    jsonschema.validate(payload, _load_schema("catalog.schema.json"))
+
+
+# ---------------------------------------------------------------------------
+# Generator unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_generate_schema_is_byte_deterministic() -> None:
+    schema_id = f"{SCHEMA_ID_BASE}/build_stats.schema.json"
+    a = schema_to_json(generate_schema(BuildStats, schema_id=schema_id))
+    b = schema_to_json(generate_schema(BuildStats, schema_id=schema_id))
+    assert a == b
+
+
+def test_generate_array_schema_for_catalog() -> None:
+    schema_id = f"{SCHEMA_ID_BASE}/catalog.schema.json"
+    doc = generate_array_schema(SelectableItem, schema_id=schema_id, title="catalog")
+    assert doc["type"] == "array"
+    assert "items" in doc
+    assert doc["items"]["type"] == "object"
+
+
+def test_drift_detection_fires_when_field_added() -> None:
+    """Simulate drift: a field added to BuildStats should fail schemas-check.
+
+    We don't actually mutate BuildStats — instead we compare a known-drifted
+    schema against the generator output to prove ``--check`` would reject it.
+    """
+    schema_id = f"{SCHEMA_ID_BASE}/build_stats.schema.json"
+    current = schema_to_json(generate_schema(BuildStats, schema_id=schema_id))
+    drifted_doc = json.loads(current)
+    drifted_doc["properties"]["new_field"] = {"type": "string"}
+    drifted = schema_to_json(drifted_doc)
+    assert current != drifted
+
+
+# ---------------------------------------------------------------------------
+# Datetime field handling (RoutingDecision.timestamp)
+# ---------------------------------------------------------------------------
+
+
+def test_datetime_field_renders_as_iso_string_format() -> None:
+    """`datetime` fields must surface as ``{"type": "string", "format": "date-time"}``."""
+    from contextweaver.envelope import RoutingDecision
+
+    schema = generate_schema(
+        RoutingDecision,
+        schema_id=f"{SCHEMA_ID_BASE}/routing_decision.schema.json",
+    )
+    assert schema["properties"]["timestamp"]["type"] == "string"
+    assert schema["properties"]["timestamp"]["format"] == "date-time"
+
+
+def test_routing_decision_round_trip_matches_datetime_format() -> None:
+    """The generated ``RoutingDecision`` schema accepts the dict ``to_dict`` emits."""
+    from contextweaver.envelope import RoutingDecision
+
+    decision = RoutingDecision(
+        id="rd-1",
+        choice_cards=[ChoiceCard(id="t", name="t", description="d")],
+        timestamp=datetime(2026, 5, 16, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    schema = generate_schema(
+        RoutingDecision,
+        schema_id=f"{SCHEMA_ID_BASE}/routing_decision.schema.json",
+    )
+    jsonschema.validate(decision.to_dict(), schema)


### PR DESCRIPTION
Lands the 5-issue "decision-surface inspectability" group selected by the
triage pass.  Shared blast radius: envelope.py, __main__.py,
routing/router.py + new explanation.py, extras/otel.py, new schemas/
directory.  Owner-mode (Mode B) authorised; bumps version to 0.5.0 with
documented public-API deltas under CHANGELOG ## [Unreleased].

#221 — argparse → Typer + Rich rewrite of __main__.py
  - typer>=0.9 + rich>=13.0 promoted from [cli] extra to core deps
  - [cli] extra kept as empty alias for one cycle (removal: v0.6)
  - 7 existing subcommands preserved verbatim (build, route, demo,
    print-tree, init, ingest, replay); 1 new subcommand (stats, #106)
  - tests/test_cli.py exit-code-0 assertion relaxed to accept Typer's
    code-2 no-args convention; all other golden assertions unchanged

#106 — BuildStats diagnostic report
  - BuildStats.prompt_tokens @property (single source of truth; replaces
    sum(tokens_per_section.values()) + header_footer_tokens across 6+
    inline call sites in extras/otel.py, __main__.py, metrics.py)
  - BuildStats.report(format='text'|'rich', *, phase, budget) returns
    deterministic, paste-friendly diagnostic string with sections,
    drop-reasons, and budget-utilisation recommendations
  - BuildStats.report_dict(...) returns versioned ({"version": 1, ...})
    structured payload for programmatic consumers
  - contextweaver stats CLI subcommand renders against ingested session
    JSON; --format {rich,text}, --phase, --budget flags

#226 — RouteResult.explanation()
  - New routing/explanation.py module keeps router.py under soft cap
  - RouteResult.explanation(format='md'|'dict') overload pair
  - Markdown: top-k table, confidence-gap line, ambiguity flag +
    clarifying question, context-hints / filters sections
  - Dict: versioned schema; safe for OTel span attributes
  - Privacy: never emits args_schema or full descriptions
  - docs/troubleshooting.md gains paste-ready example

#225 — JSON Schemas + drift gate (closes #196)
  - 6 schemas under schemas/ and docs/schemas/v0/ (mkdocs-published $id
    URLs): catalog, choice_card, result_envelope, route_trace,
    build_stats, graph_manifest
  - src/contextweaver/_schema_gen.py — stdlib-only dataclass → Draft
    2020-12 generator; deterministic byte-stable output
  - ChoiceCard.kind tightened to Literal[...]; __post_init__ enforces
    gateway-spec §2 size bounds (name ≤64, ≤5 tags each ≤24 chars)
    on every code path including from_dict
  - make schemas / make schemas-check (gating in make ci); CI workflow
    runs --check after the scorecard drift gate
  - new docs/contracts.md; examples/sample_catalog.yaml gets the
    # yaml-language-server: $schema= header

#224 — OTel GenAI semantic conventions
  - extras/otel.py rewritten on top of opentelemetry.semconv._incubating
    .attributes.gen_ai_attributes (opentelemetry-api>=1.27 floor +
    opentelemetry-semantic-conventions>=0.48b0)
  - Span shapes: invoke_agent for build(), execute_tool for route()
  - Stable attrs: gen_ai.system='contextweaver', gen_ai.operation.name,
    gen_ai.usage.input_tokens, gen_ai.tool.name
  - Engine-specific telemetry under contextweaver.* namespace
  - Token-usage histogram renamed to canonical gen_ai.client.token.usage
  - otel_emit_experimental flag (default False) gates PII-prone attrs
  - tests/test_otel.py uses InMemorySpanExporter for deterministic
    SemConv-name assertions
  - new docs/integration_otel.md (Laminar + Phoenix worked examples,
    PII-safety guidance)

Verification (all green on v0.5 branch):
  ruff format --check src/ tests/ examples/ scripts/   → clean
  ruff check src/ tests/ examples/ scripts/            → clean
  mypy src/                                            → 0 issues / 66 files
  pytest --cov=contextweaver -q                        → 995 passed, 2 skipped
                                                         (+41 new tests over baseline)
  python scripts/gen_schemas.py --check                → schemas up to date
  python -m contextweaver demo                         → completes
  make example                                         → all examples clean