### PR TITLE
feat(store): persistent SQLite event log + JSON-file artifact store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@ It prepares context and routes tools but never calls models or executes tools.
 | `_utils.py` | Text similarity primitives: `tokenize()`, `jaccard()`, `TfIdfScorer` |
 | `serde.py` | Serialisation helpers for `to_dict` / `from_dict` |
 | `store/` | In-memory data stores: `EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore`, `StoreBundle` |
+| `store/_sqlite_base.py` | Shared SQLite connection + migration scaffolding (WAL, `foreign_keys=ON`, `_contextweaver_schema_version` table). Reused by every SQLite-backed store (issue #174). |
+| `store/sqlite_event_log.py` | `SqliteEventLog` — first persistent `EventLog` backend; single-process, sync, append-only, schema-versioned (issue #223). |
+| `store/json_file_artifacts.py` | `JsonFileArtifactStore` — filesystem `ArtifactStore` backend; `{handle}.data` + `{handle}.json` per artifact, re-instantiable against an existing directory (issue #42). |
 | `summarize/` | `SummarizationRule`, `RuleEngine`, `extract_facts()` |
 | `context/` | Full context pipeline, sensitivity enforcement, view registry, `ContextManager` |
 | `context/ingest.py` | Tool-result ingestion helpers (extracted from `manager.py` to honor the <=300 line guideline) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`SqliteEventLog.query()` filter order matches `InMemoryEventLog`**
+  (PR #232 review). `since` is now applied to the full insertion-ordered
+  log *before* the `kinds` filter, mirroring the in-memory semantics.
+  Previously the SQL path filtered by kind first, which gave different
+  results on mixed-kind logs for the same `(kinds, since, limit)` triple.
+- **`JsonFileArtifactStore` path-traversal hardening** (PR #232 review).
+  Handle validation moved into `_meta_path` / `_data_path` so every
+  public method that resolves a handle (`get` / `ref` / `exists` /
+  `delete` / `metadata` / `drilldown`) rejects path separators, `..`,
+  `.`, and null bytes — not just `put`.
+- **`SqliteEventLog` use-after-close raises `StoreClosedError`** (PR
+  #232 review). The bare `RuntimeError` previously raised by
+  `_require_conn` is replaced by a new
+  `contextweaver.exceptions.StoreClosedError` (subclass of
+  `ContextWeaverError`) so callers can catch the contextweaver-family
+  consistently per `AGENTS.md`.
+- **`JsonFileArtifactStore.list_refs()` skips wrong-shape JSON** (PR
+  #232 review). The error-handling clause now also catches `TypeError`
+  raised by `ArtifactRef.from_dict` when a `.json` file is valid JSON
+  but the top level is not a mapping (e.g. `[]`, `null`, a bare string).
+
 ### Added
 
 - **`SqliteEventLog` + shared `_sqlite_base.py`** (#174, #223). First

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`SqliteEventLog` + shared `_sqlite_base.py`** (#174, #223). First
+  persistent `EventLog` backend, layered on a small connection +
+  migration helper that the rest of the SQLite-stores epic will reuse.
+  Sets `PRAGMA journal_mode=WAL` and `PRAGMA foreign_keys=ON` on open,
+  versions schema migrations through a `_contextweaver_schema_version`
+  table, and round-trips every `ContextItem` field (including JSON
+  `metadata` and nested `ArtifactRef`). Constructor accepts a filesystem
+  path or `":memory:"`; the parent directory is created automatically.
+  Single-process; sync only. New `[sqlite]` extras-group placeholder.
+- **`JsonFileArtifactStore`** (#42). Filesystem-backed
+  `ArtifactStore` implementation that stores each artifact as a
+  `{base_dir}/{handle}.data` byte file plus a `{base_dir}/{handle}.json`
+  metadata file. Re-instantiating against the same directory recovers
+  the metadata index automatically. Handles containing path separators,
+  `..`, `.`, or null bytes are rejected at write time. Drilldown
+  selectors (`head` / `lines` / `json_keys` / `rows`) match
+  `InMemoryArtifactStore` byte-for-byte via a shared module-private
+  helper `_apply_selector` in `store/artifacts.py`.
+- **`EventLog` lifecycle methods** (#223). The `EventLog` protocol now
+  requires `close()`, `__enter__`, and `__exit__` so persistent backends
+  fit the contract cleanly. `InMemoryEventLog.close()` is a no-op so
+  existing callers are unaffected; the methods make
+  `with SqliteEventLog(path) as log:` the recommended idiom for the new
+  backend.
+
 ## [0.4.0] - 2026-05-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,13 @@ retrieval = [
 ann = [
     "hnswlib>=0.8",
 ]
+# Persistent SQLite-backed stores (issues #174 / #223).  The implementations
+# rely only on stdlib ``sqlite3``; this extras group exists so installs can
+# opt into a future ``aiosqlite``-based async variant or schema-migration
+# tooling without changing the public install surface.  Empty today on
+# purpose — the contract is "if you want the SQLite stores, install this
+# extra" even though it currently adds no third-party deps.
+sqlite = []
 # OpenTelemetry tracing + metrics export.
 otel = [
     "opentelemetry-api>=1.20",

--- a/src/contextweaver/__init__.py
+++ b/src/contextweaver/__init__.py
@@ -45,6 +45,7 @@ from contextweaver.exceptions import (
     ItemNotFoundError,
     PolicyViolationError,
     RouteError,
+    StoreClosedError,
 )
 from contextweaver.metrics import MetricsCollector, MetricsHook
 from contextweaver.profiles import Mode, ProfileConfig, RoutingConfig
@@ -90,6 +91,8 @@ from contextweaver.store import (
     InMemoryEpisodicStore,
     InMemoryEventLog,
     InMemoryFactStore,
+    JsonFileArtifactStore,
+    SqliteEventLog,
     StoreBundle,
 )
 from contextweaver.summarize.extract import StructuredExtractor
@@ -164,11 +167,14 @@ __all__ = [
     "ItemNotFoundError",
     "PolicyViolationError",
     "RouteError",
+    "StoreClosedError",
     # stores
     "InMemoryArtifactStore",
     "InMemoryEpisodicStore",
     "InMemoryEventLog",
     "InMemoryFactStore",
+    "JsonFileArtifactStore",
+    "SqliteEventLog",
     "StoreBundle",
     # context engine
     "ContextManager",

--- a/src/contextweaver/exceptions.py
+++ b/src/contextweaver/exceptions.py
@@ -57,3 +57,9 @@ class PathNotFoundError(CatalogError):
 
 class UpstreamError(ContextWeaverError):
     """Raised when an upstream MCP tool call fails for transport/protocol reasons."""
+
+
+class StoreClosedError(ContextWeaverError):
+    """Raised when an operation is attempted on a store whose backing
+    resource (e.g. a SQLite connection) has been released via ``close()``.
+    """

--- a/src/contextweaver/store/__init__.py
+++ b/src/contextweaver/store/__init__.py
@@ -1,7 +1,8 @@
 """Store sub-package for contextweaver.
 
-Exports the four in-memory store implementations and the :class:`StoreBundle`
-convenience wrapper.
+Exports the in-memory store implementations, the persistent
+:class:`SqliteEventLog` / :class:`JsonFileArtifactStore` backends, and the
+:class:`StoreBundle` convenience wrapper.
 """
 
 from __future__ import annotations
@@ -11,11 +12,15 @@ from contextweaver.store.bundle import StoreBundle
 from contextweaver.store.episodic import InMemoryEpisodicStore
 from contextweaver.store.event_log import InMemoryEventLog
 from contextweaver.store.facts import InMemoryFactStore
+from contextweaver.store.json_file_artifacts import JsonFileArtifactStore
+from contextweaver.store.sqlite_event_log import SqliteEventLog
 
 __all__ = [
     "InMemoryArtifactStore",
     "InMemoryEpisodicStore",
     "InMemoryEventLog",
     "InMemoryFactStore",
+    "JsonFileArtifactStore",
+    "SqliteEventLog",
     "StoreBundle",
 ]

--- a/src/contextweaver/store/_sqlite_base.py
+++ b/src/contextweaver/store/_sqlite_base.py
@@ -1,0 +1,119 @@
+"""Shared SQLite connection management for :mod:`contextweaver.store`.
+
+Owned scaffolding the SQLite-backed stores reuse: connection creation with
+``WAL`` journal mode and ``foreign_keys=ON`` pragmas, plus a tiny migration
+helper driven by a ``_contextweaver_schema_version`` table.
+
+Single-process constraint.  ``WAL`` mode gives reasonable intra-process
+read/write concurrency, but cross-process write coordination is out of scope
+— deploying SQLite-backed stores from multiple worker processes is
+unsupported and a future PostgresSaver-equivalent will fill that gap.
+
+Migrations are plain ``Callable[[sqlite3.Connection], None]`` functions, one
+per schema version.  ``apply_migrations`` records the highest applied
+version and replays only the missing tail on each open.  This module
+intentionally carries no business logic — concrete stores own their schema.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from collections.abc import Callable
+from pathlib import Path
+
+logger = logging.getLogger("contextweaver.store")
+
+Migration = Callable[[sqlite3.Connection], None]
+"""A schema migration: applied once, in declared order, inside a transaction."""
+
+_VERSION_TABLE = "_contextweaver_schema_version"
+
+
+def connect(path: str | Path) -> sqlite3.Connection:
+    """Open a SQLite connection configured for the contextweaver stores.
+
+    Sets ``journal_mode=WAL`` (intra-process read/write concurrency) and
+    ``foreign_keys=ON``.  The parent directory is created if missing.
+
+    Args:
+        path: Filesystem path to the SQLite database file.  ``":memory:"``
+            is accepted for transient stores in tests.
+
+    Returns:
+        A :class:`sqlite3.Connection` with pragmas applied.
+
+    Raises:
+        sqlite3.DatabaseError: If the file exists but is not a SQLite database.
+    """
+    resolved = Path(path) if path != ":memory:" else None
+    if resolved is not None:
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(
+        str(resolved) if resolved is not None else ":memory:",
+        isolation_level=None,  # autocommit; we manage transactions explicitly
+        check_same_thread=True,
+    )
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    logger.debug("sqlite.connect: path=%s", resolved or ":memory:")
+    return conn
+
+
+def apply_migrations(conn: sqlite3.Connection, migrations: list[Migration]) -> int:
+    """Apply any *migrations* whose index is greater than the recorded version.
+
+    Migration ``i`` (zero-indexed in *migrations*) is replayed if the version
+    table reports a strictly lower version.  Each migration runs in its own
+    ``BEGIN``/``COMMIT`` block; a failure rolls back and leaves the recorded
+    version unchanged.
+
+    Args:
+        conn: Connection from :func:`connect`.
+        migrations: Ordered list of migration functions.  The list index is
+            the schema version each migration leaves the database at.
+
+    Returns:
+        The schema version after the call (``len(migrations) - 1`` on success,
+        or the previously-recorded version when no work was needed).
+
+    Raises:
+        sqlite3.DatabaseError: If a migration's SQL fails.
+    """
+    conn.execute(
+        f"CREATE TABLE IF NOT EXISTS {_VERSION_TABLE} ("
+        "version INTEGER PRIMARY KEY,"
+        "applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP"
+        ")"
+    )
+    row = conn.execute(f"SELECT MAX(version) AS v FROM {_VERSION_TABLE}").fetchone()
+    current = -1 if row is None or row["v"] is None else int(row["v"])
+    for version, migration in enumerate(migrations):
+        if version <= current:
+            continue
+        logger.debug("sqlite.migrate: applying version=%d", version)
+        try:
+            conn.execute("BEGIN")
+            migration(conn)
+            conn.execute(
+                f"INSERT INTO {_VERSION_TABLE} (version) VALUES (?)",
+                (version,),
+            )
+            conn.execute("COMMIT")
+        except sqlite3.DatabaseError:
+            conn.execute("ROLLBACK")
+            raise
+        current = version
+    return current
+
+
+def schema_version(conn: sqlite3.Connection) -> int:
+    """Return the highest applied migration version, or ``-1`` if none."""
+    try:
+        row = conn.execute(f"SELECT MAX(version) AS v FROM {_VERSION_TABLE}").fetchone()
+    except sqlite3.OperationalError:
+        return -1
+    if row is None or row["v"] is None:
+        return -1
+    return int(row["v"])

--- a/src/contextweaver/store/_sqlite_base.py
+++ b/src/contextweaver/store/_sqlite_base.py
@@ -17,6 +17,7 @@ intentionally carries no business logic — concrete stores own their schema.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import sqlite3
 from collections.abc import Callable
@@ -102,7 +103,8 @@ def apply_migrations(conn: sqlite3.Connection, migrations: list[Migration]) -> i
             )
             conn.execute("COMMIT")
         except sqlite3.DatabaseError:
-            conn.execute("ROLLBACK")
+            with contextlib.suppress(sqlite3.DatabaseError):
+                conn.execute("ROLLBACK")
             raise
         current = version
     return current

--- a/src/contextweaver/store/artifacts.py
+++ b/src/contextweaver/store/artifacts.py
@@ -15,7 +15,56 @@ from contextweaver.types import ArtifactRef
 
 logger = logging.getLogger("contextweaver.store")
 
-# FUTURE: FileArtifactStore backed by local filesystem for persistent storage.
+
+def _apply_selector(raw: str, selector: dict[str, Any]) -> str:
+    """Apply a drilldown *selector* to decoded artifact *raw* text.
+
+    Shared by every :class:`~contextweaver.store.protocols.ArtifactStore`
+    implementation so the four selector dialects (``head``, ``lines``,
+    ``json_keys``, ``rows``) stay byte-for-byte identical across backends.
+
+    Args:
+        raw: The artifact's bytes, decoded as UTF-8 (errors replaced).
+        selector: A dict whose ``type`` key picks one of the supported
+            dialects; remaining keys are dialect-specific.
+
+    Returns:
+        The selected subset of *raw* as a string.
+
+    Raises:
+        ContextWeaverError: If ``selector["type"]`` is not recognised.
+    """
+    sel_type = selector.get("type", "")
+
+    if sel_type == "head":
+        chars = selector.get("chars", 500)
+        return raw[:chars]
+
+    if sel_type == "lines":
+        lines = raw.splitlines()
+        start = selector.get("start", 0)
+        end = selector.get("end", len(lines))
+        return "\n".join(lines[start:end])
+
+    if sel_type == "json_keys":
+        keys: list[str] = selector.get("keys", [])
+        try:
+            obj = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            return ""
+        if isinstance(obj, dict):
+            return json.dumps({k: obj[k] for k in keys if k in obj}, indent=2, sort_keys=True)
+        return ""
+
+    if sel_type == "rows":
+        # FUTURE: CSV/TSV-aware parsing — detect delimiter, preserve header,
+        # and support column filtering.  Currently identical to "lines".
+        lines = raw.splitlines()
+        start = selector.get("start", 0)
+        end = selector.get("end", len(lines))
+        return "\n".join(lines[start:end])
+
+    raise ContextWeaverError(f"Unknown drilldown selector type: {sel_type!r}")
 
 
 class InMemoryArtifactStore:
@@ -155,37 +204,7 @@ class InMemoryArtifactStore:
             ContextWeaverError: If the selector type is unknown.
         """
         raw = self.get(handle).decode("utf-8", errors="replace")
-        sel_type = selector.get("type", "")
-
-        if sel_type == "head":
-            chars = selector.get("chars", 500)
-            return raw[:chars]
-
-        if sel_type == "lines":
-            lines = raw.splitlines()
-            start = selector.get("start", 0)
-            end = selector.get("end", len(lines))
-            return "\n".join(lines[start:end])
-
-        if sel_type == "json_keys":
-            keys: list[str] = selector.get("keys", [])
-            try:
-                obj = json.loads(raw)
-            except (json.JSONDecodeError, ValueError):
-                return ""
-            if isinstance(obj, dict):
-                return json.dumps({k: obj[k] for k in keys if k in obj}, indent=2, sort_keys=True)
-            return ""
-
-        if sel_type == "rows":
-            # FUTURE: CSV/TSV-aware parsing — detect delimiter, preserve header,
-            # and support column filtering.  Currently identical to "lines".
-            lines = raw.splitlines()
-            start = selector.get("start", 0)
-            end = selector.get("end", len(lines))
-            return "\n".join(lines[start:end])
-
-        raise ContextWeaverError(f"Unknown drilldown selector type: {sel_type!r}")
+        return _apply_selector(raw, selector)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise the store's metadata index to a JSON-compatible dict."""

--- a/src/contextweaver/store/event_log.py
+++ b/src/contextweaver/store/event_log.py
@@ -8,6 +8,7 @@ from this store when generating context candidates.
 from __future__ import annotations
 
 import logging
+from types import TracebackType
 from typing import Any
 
 from contextweaver.exceptions import DuplicateItemError, ItemNotFoundError
@@ -153,6 +154,25 @@ class InMemoryEventLog:
 
     def __len__(self) -> int:
         return len(self._items)
+
+    def close(self) -> None:
+        """No-op for the in-memory backend.
+
+        Defined so :class:`InMemoryEventLog` satisfies the
+        :class:`~contextweaver.store.protocols.EventLog` protocol's lifecycle
+        contract; persistent backends override this to release resources.
+        """
+
+    def __enter__(self) -> InMemoryEventLog:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise the event log to a JSON-compatible dict."""

--- a/src/contextweaver/store/json_file_artifacts.py
+++ b/src/contextweaver/store/json_file_artifacts.py
@@ -176,9 +176,9 @@ class JsonFileArtifactStore:
     def delete(self, handle: str) -> None:
         """Remove the artifact identified by *handle*.
 
-        Both the metadata and data files are removed.  If either is missing
-        the operation raises :class:`ArtifactNotFoundError` — both files must
-        exist for the artifact to count as present.
+        Both the metadata and data files are removed.  If neither file
+        exists the operation raises :class:`ArtifactNotFoundError`; if only
+        one is present (e.g. after a crash) both are cleaned up silently.
 
         Raises:
             ArtifactNotFoundError: If *handle* is not in the store.

--- a/src/contextweaver/store/json_file_artifacts.py
+++ b/src/contextweaver/store/json_file_artifacts.py
@@ -81,9 +81,14 @@ class JsonFileArtifactStore:
     # ------------------------------------------------------------------
 
     def _meta_path(self, handle: str) -> Path:
+        # Centralised validation keeps every public method that resolves a
+        # handle (put/get/ref/list_refs/delete/exists/drilldown/metadata)
+        # safe against path-traversal — see _validate_handle docstring.
+        _validate_handle(handle)
         return self._base_dir / f"{handle}{_META_SUFFIX}"
 
     def _data_path(self, handle: str) -> Path:
+        _validate_handle(handle)
         return self._base_dir / f"{handle}{_DATA_SUFFIX}"
 
     # ------------------------------------------------------------------
@@ -108,7 +113,7 @@ class JsonFileArtifactStore:
             ContextWeaverError: If *handle* contains a path separator,
                 ``..``, ``.``, or a null byte.
         """
-        _validate_handle(handle)
+        # Validation runs via the _data_path / _meta_path helpers below.
         ref = ArtifactRef(
             handle=handle,
             media_type=media_type,
@@ -151,13 +156,20 @@ class JsonFileArtifactStore:
         Scans the directory for ``*.json`` files; entries whose JSON does not
         decode into an :class:`ArtifactRef` are skipped silently (logged at
         ``DEBUG``).  Use :meth:`ref` if you need a per-handle error.
+
+        Skipped failure modes include ``json.JSONDecodeError`` (file is not
+        valid JSON), ``KeyError`` / ``ValueError`` (missing required field or
+        invalid value), and ``TypeError`` (JSON is valid but the top-level
+        shape is wrong — e.g. ``[]``, ``null``, or a bare string instead of
+        a mapping; ``ArtifactRef.from_dict`` raises ``TypeError`` in that
+        case).
         """
         refs: list[ArtifactRef] = []
         for meta in sorted(self._base_dir.glob(f"*{_META_SUFFIX}")):
             try:
                 raw = json.loads(meta.read_text(encoding="utf-8"))
                 refs.append(ArtifactRef.from_dict(raw))
-            except (json.JSONDecodeError, KeyError, ValueError) as exc:
+            except (json.JSONDecodeError, KeyError, ValueError, TypeError) as exc:
                 logger.debug("json_file_artifacts.list_refs: skip %s (%s)", meta.name, exc)
         return refs
 

--- a/src/contextweaver/store/json_file_artifacts.py
+++ b/src/contextweaver/store/json_file_artifacts.py
@@ -1,0 +1,205 @@
+"""Filesystem-backed artifact store for contextweaver.
+
+A persistent :class:`~contextweaver.store.protocols.ArtifactStore`
+implementation that mirrors :class:`~contextweaver.store.artifacts.InMemoryArtifactStore`
+on disk: each artifact is stored as a ``{handle}.data`` file (raw bytes)
+paired with a ``{handle}.json`` file (the :class:`~contextweaver.types.ArtifactRef`
+metadata, JSON-encoded).
+
+Useful when artifacts are large (full API responses, images) and the agent
+wants directly-inspectable files for debugging, backup, or external
+tooling.  Trade-off vs. the SQLite event log: one file per artifact is
+heavier than a single database, but the contents are human-grep-friendly.
+
+Limitations:
+
+- **Single process.**  No advisory locking on writes; running two processes
+  against the same ``base_dir`` is unsupported.
+- **Handle safety.**  Handles are written verbatim into filenames; path
+  separators (``/``, ``\\``) and ``..`` traversal segments are rejected on
+  write to keep artifacts inside ``base_dir``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from contextweaver.exceptions import ArtifactNotFoundError, ContextWeaverError
+from contextweaver.store.artifacts import _apply_selector
+from contextweaver.types import ArtifactRef
+
+logger = logging.getLogger("contextweaver.store")
+
+_META_SUFFIX = ".json"
+_DATA_SUFFIX = ".data"
+_FORBIDDEN_HANDLE_CHARS: frozenset[str] = frozenset({"/", "\\", "\x00"})
+
+
+def _validate_handle(handle: str) -> None:
+    """Reject handles that would escape ``base_dir`` or contain path separators."""
+    if not handle:
+        raise ContextWeaverError("Artifact handle must be non-empty")
+    if handle in {".", ".."}:
+        raise ContextWeaverError(f"Invalid artifact handle: {handle!r}")
+    if any(ch in handle for ch in _FORBIDDEN_HANDLE_CHARS):
+        raise ContextWeaverError(
+            f"Invalid artifact handle (contains path separator or null byte): {handle!r}"
+        )
+
+
+class JsonFileArtifactStore:
+    """Filesystem implementation of the :class:`ArtifactStore` protocol.
+
+    All artifacts are stored under *base_dir*.  Each artifact occupies two
+    sibling files:
+
+    - ``{base_dir}/{handle}.json`` — :class:`~contextweaver.types.ArtifactRef`
+      metadata, serialised via :meth:`ArtifactRef.to_dict` + :func:`json.dumps`.
+    - ``{base_dir}/{handle}.data`` — raw bytes.
+
+    The directory is created on instantiation if absent.  Existing
+    ``{handle}.json`` files in *base_dir* are visible to :meth:`list_refs`
+    immediately, so re-instantiating against an existing directory recovers
+    the previous metadata index.
+    """
+
+    def __init__(self, base_dir: str | Path) -> None:
+        self._base_dir = Path(base_dir)
+        self._base_dir.mkdir(parents=True, exist_ok=True)
+        logger.debug("json_file_artifacts.init: base_dir=%s", self._base_dir)
+
+    @property
+    def base_dir(self) -> Path:
+        """Filesystem directory backing this store."""
+        return self._base_dir
+
+    # ------------------------------------------------------------------
+    # Path helpers
+    # ------------------------------------------------------------------
+
+    def _meta_path(self, handle: str) -> Path:
+        return self._base_dir / f"{handle}{_META_SUFFIX}"
+
+    def _data_path(self, handle: str) -> Path:
+        return self._base_dir / f"{handle}{_DATA_SUFFIX}"
+
+    # ------------------------------------------------------------------
+    # ArtifactStore protocol
+    # ------------------------------------------------------------------
+
+    def put(
+        self,
+        handle: str,
+        content: bytes,
+        media_type: str = "application/octet-stream",
+        label: str = "",
+    ) -> ArtifactRef:
+        """Store *content* under *handle* and return its :class:`ArtifactRef`.
+
+        Writes are not atomic across the metadata/data pair — a crash between
+        the two writes can leave a stale metadata file.  In practice the
+        :meth:`list_refs` / :meth:`get` pair tolerates this because
+        :meth:`get` errors loudly when the data file is missing.
+
+        Raises:
+            ContextWeaverError: If *handle* contains a path separator,
+                ``..``, ``.``, or a null byte.
+        """
+        _validate_handle(handle)
+        ref = ArtifactRef(
+            handle=handle,
+            media_type=media_type,
+            size_bytes=len(content),
+            label=label,
+        )
+        self._data_path(handle).write_bytes(content)
+        self._meta_path(handle).write_text(
+            json.dumps(ref.to_dict(), sort_keys=True), encoding="utf-8"
+        )
+        logger.debug("json_file_artifacts.put: handle=%s, size=%d", handle, len(content))
+        return ref
+
+    def get(self, handle: str) -> bytes:
+        """Retrieve the raw bytes for *handle*.
+
+        Raises:
+            ArtifactNotFoundError: If *handle* is not in the store.
+        """
+        data_path = self._data_path(handle)
+        if not data_path.is_file():
+            raise ArtifactNotFoundError(f"Artifact not found: {handle!r}")
+        return data_path.read_bytes()
+
+    def ref(self, handle: str) -> ArtifactRef:
+        """Return the :class:`ArtifactRef` metadata for *handle*.
+
+        Raises:
+            ArtifactNotFoundError: If *handle* is not in the store.
+        """
+        meta_path = self._meta_path(handle)
+        if not meta_path.is_file():
+            raise ArtifactNotFoundError(f"Artifact not found: {handle!r}")
+        raw = json.loads(meta_path.read_text(encoding="utf-8"))
+        return ArtifactRef.from_dict(raw)
+
+    def list_refs(self) -> list[ArtifactRef]:
+        """Return all stored :class:`ArtifactRef` objects, sorted by handle.
+
+        Scans the directory for ``*.json`` files; entries whose JSON does not
+        decode into an :class:`ArtifactRef` are skipped silently (logged at
+        ``DEBUG``).  Use :meth:`ref` if you need a per-handle error.
+        """
+        refs: list[ArtifactRef] = []
+        for meta in sorted(self._base_dir.glob(f"*{_META_SUFFIX}")):
+            try:
+                raw = json.loads(meta.read_text(encoding="utf-8"))
+                refs.append(ArtifactRef.from_dict(raw))
+            except (json.JSONDecodeError, KeyError, ValueError) as exc:
+                logger.debug("json_file_artifacts.list_refs: skip %s (%s)", meta.name, exc)
+        return refs
+
+    def delete(self, handle: str) -> None:
+        """Remove the artifact identified by *handle*.
+
+        Both the metadata and data files are removed.  If either is missing
+        the operation raises :class:`ArtifactNotFoundError` — both files must
+        exist for the artifact to count as present.
+
+        Raises:
+            ArtifactNotFoundError: If *handle* is not in the store.
+        """
+        meta = self._meta_path(handle)
+        data = self._data_path(handle)
+        if not meta.is_file() and not data.is_file():
+            raise ArtifactNotFoundError(f"Artifact not found: {handle!r}")
+        meta.unlink(missing_ok=True)
+        data.unlink(missing_ok=True)
+
+    def exists(self, handle: str) -> bool:
+        """Return ``True`` if *handle* is in the store."""
+        return self._data_path(handle).is_file()
+
+    def metadata(self, handle: str) -> ArtifactRef:
+        """Return the :class:`ArtifactRef` for *handle*.
+
+        Alias for :meth:`ref` provided for API symmetry with
+        :class:`~contextweaver.store.artifacts.InMemoryArtifactStore`.
+        """
+        return self.ref(handle)
+
+    def drilldown(self, handle: str, selector: dict[str, Any]) -> str:
+        """Return a subset of the artifact's content according to *selector*.
+
+        Uses the same selector dialects as
+        :meth:`~contextweaver.store.artifacts.InMemoryArtifactStore.drilldown`
+        (``head``, ``lines``, ``json_keys``, ``rows``).
+
+        Raises:
+            ArtifactNotFoundError: If *handle* is not in the store.
+            ContextWeaverError: If the selector type is unknown.
+        """
+        raw = self.get(handle).decode("utf-8", errors="replace")
+        return _apply_selector(raw, selector)

--- a/src/contextweaver/store/protocols.py
+++ b/src/contextweaver/store/protocols.py
@@ -9,6 +9,7 @@ Re-exported from :mod:`contextweaver.protocols` for backward compatibility.
 
 from __future__ import annotations
 
+from types import TracebackType
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -80,6 +81,24 @@ class EventLog(Protocol):
         ...
 
     def __len__(self) -> int: ...
+
+    def close(self) -> None:
+        """Release any backend resources held by the log.
+
+        Persistent backends close their connection / file handles here;
+        in-memory backends supply a no-op.  Calling :meth:`close` more than
+        once must be safe.
+        """
+        ...
+
+    def __enter__(self) -> EventLog: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None: ...
 
 
 # ---------------------------------------------------------------------------

--- a/src/contextweaver/store/sqlite_event_log.py
+++ b/src/contextweaver/store/sqlite_event_log.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any
 
-from contextweaver.exceptions import DuplicateItemError, ItemNotFoundError
+from contextweaver.exceptions import DuplicateItemError, ItemNotFoundError, StoreClosedError
 from contextweaver.store._sqlite_base import Migration, apply_migrations, connect
 from contextweaver.types import ContextItem, ItemKind
 
@@ -135,7 +135,8 @@ class SqliteEventLog:
         """Release the underlying SQLite connection.
 
         Idempotent — calling :meth:`close` twice is a no-op.  After
-        :meth:`close`, every other method raises :class:`RuntimeError`.
+        :meth:`close`, every other method raises
+        :class:`~contextweaver.exceptions.StoreClosedError`.
         """
         if self._conn is not None:
             self._conn.close()
@@ -155,7 +156,7 @@ class SqliteEventLog:
 
     def _require_conn(self) -> sqlite3.Connection:
         if self._conn is None:
-            raise RuntimeError("SqliteEventLog is closed")
+            raise StoreClosedError("SqliteEventLog is closed")
         return self._conn
 
     # ------------------------------------------------------------------
@@ -258,30 +259,30 @@ class SqliteEventLog:
     ) -> list[ContextItem]:
         """Flexible query over the event log.
 
+        Matches the in-memory backend's filter order exactly: ``since`` is
+        a positional slice over the **full insertion-ordered log**, applied
+        *before* the ``kinds`` filter. Applying ``kinds`` first (the
+        natural SQL path) would give different results on mixed-kind logs
+        — e.g. ``kinds=[B], since=2`` over ``[A, A, B, A, B]`` must yield
+        ``[B]`` (drop first 2 of full list → ``[B, A, B]`` → kind filter
+        → ``[B, B]``), not the empty list.
+
         Args:
             kinds: If given, only include items whose kind is in this list.
             since: If given, only include items at or after this positional
-                index (zero-based insertion order, matching the in-memory
-                semantics).
+                index (zero-based, insertion order over the full log).
             limit: If given, return at most this many items.
         """
+        if kinds is not None and not kinds:
+            return []
         conn = self._require_conn()
-        clauses: list[str] = []
-        params: list[Any] = []
-        if kinds is not None:
-            if not kinds:
-                return []
-            placeholders = ",".join("?" for _ in kinds)
-            clauses.append(f"kind IN ({placeholders})")
-            params.extend(k.value for k in kinds)
-        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
-        rows = conn.execute(
-            f"SELECT * FROM event_log {where} ORDER BY ordinal ASC",
-            tuple(params),
-        ).fetchall()
+        rows = conn.execute("SELECT * FROM event_log ORDER BY ordinal ASC").fetchall()
         items = [_row_to_item(r) for r in rows]
         if since is not None:
             items = items[since:]
+        if kinds is not None:
+            kind_set = set(kinds)
+            items = [i for i in items if i.kind in kind_set]
         if limit is not None:
             items = items[:limit]
         return items

--- a/src/contextweaver/store/sqlite_event_log.py
+++ b/src/contextweaver/store/sqlite_event_log.py
@@ -1,0 +1,296 @@
+"""SQLite-backed event log for contextweaver.
+
+The first persistent backend in the SQLite-stores epic (#174).  Implements
+the :class:`~contextweaver.store.protocols.EventLog` protocol against a
+single-process SQLite file, layered on top of the shared connection +
+migration scaffolding in :mod:`contextweaver.store._sqlite_base`.
+
+The store is append-only by API — :meth:`SqliteEventLog.append` is the only
+write path, mirroring the :class:`~contextweaver.store.event_log.InMemoryEventLog`
+invariant.  Item insertion order is preserved via an auto-incrementing
+``ordinal`` column; every read returns items in that order.
+
+Limitations (out of scope for #223; tracked elsewhere):
+
+- **Single process only.**  ``WAL`` mode gives intra-process concurrency,
+  not cross-process write coordination.
+- **Sync only.**  No ``aiosqlite``-based async variant ships in this slice.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from types import TracebackType
+from typing import Any
+
+from contextweaver.exceptions import DuplicateItemError, ItemNotFoundError
+from contextweaver.store._sqlite_base import Migration, apply_migrations, connect
+from contextweaver.types import ContextItem, ItemKind
+
+logger = logging.getLogger("contextweaver.store")
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def _migration_0(conn: sqlite3.Connection) -> None:
+    """Initial schema: ``event_log`` table + indexes on ``kind`` / ``parent_id``."""
+    conn.execute(
+        """
+        CREATE TABLE event_log (
+            ordinal       INTEGER PRIMARY KEY AUTOINCREMENT,
+            id            TEXT    NOT NULL UNIQUE,
+            kind          TEXT    NOT NULL,
+            text          TEXT    NOT NULL,
+            token_estimate INTEGER NOT NULL DEFAULT 0,
+            sensitivity   TEXT    NOT NULL,
+            metadata      TEXT    NOT NULL,
+            parent_id     TEXT,
+            artifact_ref  TEXT
+        )
+        """
+    )
+    conn.execute("CREATE INDEX idx_event_log_kind ON event_log(kind)")
+    conn.execute("CREATE INDEX idx_event_log_parent ON event_log(parent_id)")
+
+
+MIGRATIONS: list[Migration] = [_migration_0]
+"""Ordered schema migrations.  Append (never reorder) when extending."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_item(row: sqlite3.Row) -> ContextItem:
+    """Hydrate a :class:`ContextItem` from a ``SELECT *`` row."""
+    return ContextItem.from_dict(
+        {
+            "id": row["id"],
+            "kind": row["kind"],
+            "text": row["text"],
+            "token_estimate": row["token_estimate"],
+            "sensitivity": row["sensitivity"],
+            "metadata": json.loads(row["metadata"]),
+            "parent_id": row["parent_id"],
+            "artifact_ref": (
+                json.loads(row["artifact_ref"]) if row["artifact_ref"] is not None else None
+            ),
+        }
+    )
+
+
+def _item_to_row(item: ContextItem) -> tuple[Any, ...]:
+    """Flatten a :class:`ContextItem` to the ``event_log`` row tuple."""
+    artifact = item.artifact_ref.to_dict() if item.artifact_ref is not None else None
+    return (
+        item.id,
+        item.kind.value,
+        item.text,
+        item.token_estimate,
+        item.sensitivity.value,
+        json.dumps(item.metadata, sort_keys=True),
+        item.parent_id,
+        json.dumps(artifact, sort_keys=True) if artifact is not None else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
+class SqliteEventLog:
+    """SQLite-backed implementation of the :class:`EventLog` protocol.
+
+    Pass ``":memory:"`` for a transient in-process database (useful in tests).
+    Otherwise, *path* must be a filesystem path to a SQLite file; its parent
+    directory is created on first open.
+
+    The constructor opens the connection and applies any pending migrations
+    so the store is ready for reads/writes immediately.  Call :meth:`close`
+    (or use the store as a context manager) to release the connection.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = ":memory:" if path == ":memory:" else Path(path)
+        self._conn: sqlite3.Connection | None = connect(self._path)
+        apply_migrations(self._conn, MIGRATIONS)
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    @property
+    def path(self) -> str:
+        """Return the filesystem path (or ``":memory:"``)."""
+        return str(self._path)
+
+    def close(self) -> None:
+        """Release the underlying SQLite connection.
+
+        Idempotent — calling :meth:`close` twice is a no-op.  After
+        :meth:`close`, every other method raises :class:`RuntimeError`.
+        """
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+            logger.debug("sqlite_event_log.close: path=%s", self._path)
+
+    def __enter__(self) -> SqliteEventLog:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+    def _require_conn(self) -> sqlite3.Connection:
+        if self._conn is None:
+            raise RuntimeError("SqliteEventLog is closed")
+        return self._conn
+
+    # ------------------------------------------------------------------
+    # EventLog protocol
+    # ------------------------------------------------------------------
+
+    def append(self, item: ContextItem) -> None:
+        """Append *item* to the log.
+
+        Raises:
+            DuplicateItemError: If an item with the same ``id`` already exists.
+        """
+        conn = self._require_conn()
+        try:
+            conn.execute(
+                "INSERT INTO event_log (id, kind, text, token_estimate, sensitivity, "
+                "metadata, parent_id, artifact_ref) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                _item_to_row(item),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise DuplicateItemError(f"Duplicate item id: {item.id!r}") from exc
+        logger.debug("event_log.append: id=%s, kind=%s", item.id, item.kind.value)
+
+    def get(self, item_id: str) -> ContextItem:
+        """Return the item with *item_id*.
+
+        Raises:
+            ItemNotFoundError: If no item with *item_id* exists.
+        """
+        conn = self._require_conn()
+        row = conn.execute(
+            "SELECT * FROM event_log WHERE id = ?",
+            (item_id,),
+        ).fetchone()
+        if row is None:
+            raise ItemNotFoundError(f"Item not found: {item_id!r}")
+        return _row_to_item(row)
+
+    def all(self) -> list[ContextItem]:
+        """Return all items in insertion order."""
+        conn = self._require_conn()
+        rows = conn.execute("SELECT * FROM event_log ORDER BY ordinal ASC").fetchall()
+        return [_row_to_item(r) for r in rows]
+
+    def filter_by_kind(self, *kinds: ItemKind) -> list[ContextItem]:
+        """Return all items whose ``kind`` is in *kinds*."""
+        if not kinds:
+            return []
+        conn = self._require_conn()
+        placeholders = ",".join("?" for _ in kinds)
+        rows = conn.execute(
+            f"SELECT * FROM event_log WHERE kind IN ({placeholders}) ORDER BY ordinal ASC",
+            tuple(k.value for k in kinds),
+        ).fetchall()
+        return [_row_to_item(r) for r in rows]
+
+    def tail(self, n: int) -> list[ContextItem]:
+        """Return the last *n* items.
+
+        ``n <= 0`` returns an empty list, matching
+        :class:`~contextweaver.store.event_log.InMemoryEventLog`.
+        """
+        if n <= 0:
+            return []
+        conn = self._require_conn()
+        rows = conn.execute(
+            "SELECT * FROM event_log ORDER BY ordinal DESC LIMIT ?",
+            (n,),
+        ).fetchall()
+        return [_row_to_item(r) for r in reversed(rows)]
+
+    def children(self, parent_id: str) -> list[ContextItem]:
+        """Return all items whose ``parent_id`` equals *parent_id*."""
+        conn = self._require_conn()
+        rows = conn.execute(
+            "SELECT * FROM event_log WHERE parent_id = ? ORDER BY ordinal ASC",
+            (parent_id,),
+        ).fetchall()
+        return [_row_to_item(r) for r in rows]
+
+    def parent(self, item_id: str) -> ContextItem | None:
+        """Return the parent of *item_id*, or ``None``.
+
+        Raises:
+            ItemNotFoundError: If no item with *item_id* exists.
+        """
+        item = self.get(item_id)
+        if item.parent_id is None:
+            return None
+        try:
+            return self.get(item.parent_id)
+        except ItemNotFoundError:
+            return None
+
+    def query(
+        self,
+        kinds: list[ItemKind] | None = None,
+        since: int | None = None,
+        limit: int | None = None,
+    ) -> list[ContextItem]:
+        """Flexible query over the event log.
+
+        Args:
+            kinds: If given, only include items whose kind is in this list.
+            since: If given, only include items at or after this positional
+                index (zero-based insertion order, matching the in-memory
+                semantics).
+            limit: If given, return at most this many items.
+        """
+        conn = self._require_conn()
+        clauses: list[str] = []
+        params: list[Any] = []
+        if kinds is not None:
+            if not kinds:
+                return []
+            placeholders = ",".join("?" for _ in kinds)
+            clauses.append(f"kind IN ({placeholders})")
+            params.extend(k.value for k in kinds)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        rows = conn.execute(
+            f"SELECT * FROM event_log {where} ORDER BY ordinal ASC",
+            tuple(params),
+        ).fetchall()
+        items = [_row_to_item(r) for r in rows]
+        if since is not None:
+            items = items[since:]
+        if limit is not None:
+            items = items[:limit]
+        return items
+
+    def count(self) -> int:
+        """Return the number of items in the log."""
+        conn = self._require_conn()
+        row = conn.execute("SELECT COUNT(*) AS c FROM event_log").fetchone()
+        return int(row["c"])
+
+    def __len__(self) -> int:
+        return self.count()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,7 @@ def _run(*args: str, cwd: str | None = None) -> subprocess.CompletedProcess[str]
         [sys.executable, "-m", "contextweaver", *args],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         cwd=cwd,
         env=env,
     )

--- a/tests/test_store_event_log.py
+++ b/tests/test_store_event_log.py
@@ -168,3 +168,19 @@ def test_count() -> None:
     log.append(_make_item("i1"))
     log.append(_make_item("i2"))
     assert log.count() == 2
+
+
+def test_close_is_noop_and_idempotent() -> None:
+    log = InMemoryEventLog()
+    log.append(_make_item("i1"))
+    log.close()
+    log.close()  # idempotent
+    # State is preserved — close() is a no-op for in-memory backends.
+    assert log.get("i1").text == "text"
+
+
+def test_context_manager_closes_and_preserves_state() -> None:
+    with InMemoryEventLog() as log:
+        log.append(_make_item("i1"))
+    # State survives __exit__ because close() is a no-op.
+    assert log.get("i1").id == "i1"

--- a/tests/test_store_json_file_artifacts.py
+++ b/tests/test_store_json_file_artifacts.py
@@ -165,6 +165,50 @@ def test_put_rejects_unsafe_handles(tmp_path: Path, bad: str) -> None:
         store.put(bad, b"data")
 
 
+@pytest.mark.parametrize(
+    "bad",
+    ["foo/bar", "..", ".", "a\\b", "x\x00y", ""],
+)
+@pytest.mark.parametrize("method", ["get", "ref", "exists", "delete", "metadata"])
+def test_read_path_methods_reject_unsafe_handles(tmp_path: Path, bad: str, method: str) -> None:
+    """Path-traversal handles must be rejected by every public read/mutate method.
+
+    Regression for PR #232 audit: previously only ``put()`` validated handles,
+    so ``store.get("../secret")`` could resolve outside ``base_dir``.
+    """
+    store = JsonFileArtifactStore(tmp_path)
+    fn = getattr(store, method)
+    with pytest.raises(ContextWeaverError):
+        fn(bad)
+
+
+def test_drilldown_rejects_unsafe_handle(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    with pytest.raises(ContextWeaverError):
+        store.drilldown("../secret", {"type": "head", "chars": 5})
+
+
+def test_list_refs_skips_non_mapping_json(tmp_path: Path) -> None:
+    """Regression: ``list_refs`` must catch ``TypeError`` from ``ArtifactRef.from_dict``.
+
+    A ``.json`` file whose contents are valid JSON of the wrong shape
+    (e.g. ``[]``, ``null``, a bare string) used to crash ``list_refs``
+    with ``TypeError`` rather than skipping the entry (PR #232 review).
+    """
+    store = JsonFileArtifactStore(tmp_path)
+    store.put("good", b"data")
+    # Plant three malformed metadata files whose JSON parses but whose shape
+    # is not a mapping. ArtifactRef.from_dict raises TypeError for each.
+    (tmp_path / "list_shape.json").write_text("[]", encoding="utf-8")
+    (tmp_path / "null_shape.json").write_text("null", encoding="utf-8")
+    (tmp_path / "str_shape.json").write_text('"not a mapping"', encoding="utf-8")
+
+    refs = store.list_refs()
+    # Only the well-formed "good" ref survives; the three bad shapes are
+    # silently skipped (debug-logged) rather than raising.
+    assert [r.handle for r in refs] == ["good"]
+
+
 # ---------------------------------------------------------------------------
 # Drilldown (matches InMemoryArtifactStore byte-for-byte)
 # ---------------------------------------------------------------------------

--- a/tests/test_store_json_file_artifacts.py
+++ b/tests/test_store_json_file_artifacts.py
@@ -1,0 +1,214 @@
+"""Tests for contextweaver.store.json_file_artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from contextweaver.exceptions import ArtifactNotFoundError, ContextWeaverError
+from contextweaver.store.json_file_artifacts import JsonFileArtifactStore
+
+# ---------------------------------------------------------------------------
+# put / get / ref
+# ---------------------------------------------------------------------------
+
+
+def test_put_and_get(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    ref = store.put("h1", b"hello world", media_type="text/plain", label="test")
+    assert ref.handle == "h1"
+    assert ref.size_bytes == 11
+    assert store.get("h1") == b"hello world"
+
+
+def test_put_creates_data_and_metadata_files(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    store.put("h1", b"hello", media_type="text/plain", label="greeting")
+    assert (tmp_path / "h1.data").is_file()
+    assert (tmp_path / "h1.json").is_file()
+    meta = json.loads((tmp_path / "h1.json").read_text(encoding="utf-8"))
+    assert meta["handle"] == "h1"
+    assert meta["media_type"] == "text/plain"
+    assert meta["label"] == "greeting"
+
+
+def test_ref_returns_metadata(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    store.put("h2", b"data", media_type="application/json")
+    r = store.ref("h2")
+    assert r.media_type == "application/json"
+    assert r.handle == "h2"
+
+
+def test_get_missing_raises(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    with pytest.raises(ArtifactNotFoundError, match="missing"):
+        store.get("missing")
+
+
+def test_ref_missing_raises(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    with pytest.raises(ArtifactNotFoundError, match="missing"):
+        store.ref("missing")
+
+
+# ---------------------------------------------------------------------------
+# delete / exists / metadata / list_refs
+# ---------------------------------------------------------------------------
+
+
+def test_delete(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    store.put("h3", b"x")
+    store.delete("h3")
+    assert not (tmp_path / "h3.data").exists()
+    assert not (tmp_path / "h3.json").exists()
+    with pytest.raises(ArtifactNotFoundError):
+        store.get("h3")
+
+
+def test_delete_missing_raises(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    with pytest.raises(ArtifactNotFoundError):
+        store.delete("missing")
+
+
+def test_exists_true_and_false(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    assert store.exists("missing") is False
+    store.put("h1", b"data")
+    assert store.exists("h1") is True
+
+
+def test_metadata_alias(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    store.put("h1", b"data", media_type="text/plain", label="lbl")
+    m = store.metadata("h1")
+    assert m.handle == "h1"
+    assert m.media_type == "text/plain"
+    assert m.label == "lbl"
+
+
+def test_metadata_missing_raises(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    with pytest.raises(ArtifactNotFoundError):
+        store.metadata("missing")
+
+
+def test_list_refs_sorted(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    store.put("z1", b"z")
+    store.put("a1", b"a")
+    store.put("m1", b"m")
+    refs = store.list_refs()
+    assert [r.handle for r in refs] == ["a1", "m1", "z1"]
+
+
+def test_list_refs_empty(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    assert store.list_refs() == []
+
+
+def test_list_refs_skips_malformed_metadata(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    store.put("ok", b"good")
+    # Drop a bogus metadata file with the right extension.
+    (tmp_path / "broken.json").write_text("not-json", encoding="utf-8")
+    refs = store.list_refs()
+    assert [r.handle for r in refs] == ["ok"]
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+
+def test_reinstantiating_recovers_refs(tmp_path: Path) -> None:
+    store1 = JsonFileArtifactStore(tmp_path)
+    store1.put("a", b"alpha", media_type="text/plain", label="A")
+    store1.put("b", b"beta", media_type="application/json", label="B")
+
+    store2 = JsonFileArtifactStore(tmp_path)
+    refs = {r.handle: r for r in store2.list_refs()}
+    assert set(refs) == {"a", "b"}
+    assert refs["a"].label == "A"
+    assert refs["b"].media_type == "application/json"
+    assert store2.get("a") == b"alpha"
+
+
+def test_directory_created_if_missing(tmp_path: Path) -> None:
+    target = tmp_path / "deep" / "nested" / "artifacts"
+    assert not target.exists()
+    JsonFileArtifactStore(target)
+    assert target.is_dir()
+
+
+def test_base_dir_property(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    assert store.base_dir == tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Handle validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["foo/bar", "..", ".", "a\\b", "x\x00y", ""],
+)
+def test_put_rejects_unsafe_handles(tmp_path: Path, bad: str) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    with pytest.raises(ContextWeaverError):
+        store.put(bad, b"data")
+
+
+# ---------------------------------------------------------------------------
+# Drilldown (matches InMemoryArtifactStore byte-for-byte)
+# ---------------------------------------------------------------------------
+
+
+def test_drilldown_head(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    store.put("h1", b"hello world from drilldown")
+    assert store.drilldown("h1", {"type": "head", "chars": 5}) == "hello"
+
+
+def test_drilldown_lines(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    store.put("h1", b"line0\nline1\nline2\nline3\nline4")
+    assert store.drilldown("h1", {"type": "lines", "start": 1, "end": 3}) == "line1\nline2"
+
+
+def test_drilldown_json_keys(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    store.put("h1", json.dumps({"name": "Alice", "age": 30, "role": "admin"}).encode())
+    parsed = json.loads(store.drilldown("h1", {"type": "json_keys", "keys": ["name", "role"]}))
+    assert parsed == {"name": "Alice", "role": "admin"}
+
+
+def test_drilldown_json_keys_invalid_json(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    store.put("h1", b"not json")
+    assert store.drilldown("h1", {"type": "json_keys", "keys": ["a"]}) == ""
+
+
+def test_drilldown_rows(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    store.put("h1", b"header\nrow1\nrow2\nrow3")
+    assert store.drilldown("h1", {"type": "rows", "start": 0, "end": 2}) == "header\nrow1"
+
+
+def test_drilldown_unknown_type_raises(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    store.put("h1", b"data")
+    with pytest.raises(ContextWeaverError, match="Unknown drilldown"):
+        store.drilldown("h1", {"type": "unknown"})
+
+
+def test_drilldown_missing_raises(tmp_path: Path) -> None:
+    store = JsonFileArtifactStore(tmp_path)
+    with pytest.raises(ArtifactNotFoundError):
+        store.drilldown("missing", {"type": "head"})

--- a/tests/test_store_sqlite_event_log.py
+++ b/tests/test_store_sqlite_event_log.py
@@ -1,0 +1,311 @@
+"""Tests for contextweaver.store.sqlite_event_log."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from contextweaver.exceptions import DuplicateItemError, ItemNotFoundError
+from contextweaver.store._sqlite_base import schema_version
+from contextweaver.store.sqlite_event_log import MIGRATIONS, SqliteEventLog
+from contextweaver.types import ArtifactRef, ContextItem, ItemKind, Sensitivity
+
+
+def _make_item(iid: str, kind: ItemKind = ItemKind.user_turn, text: str = "text") -> ContextItem:
+    return ContextItem(id=iid, kind=kind, text=text)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_open_creates_file_and_applies_migrations(tmp_path: Path) -> None:
+    db = tmp_path / "session.db"
+    log = SqliteEventLog(db)
+    assert db.is_file()
+    assert schema_version(log._require_conn()) == len(MIGRATIONS) - 1
+    log.close()
+
+
+def test_open_creates_missing_parent_directory(tmp_path: Path) -> None:
+    db = tmp_path / "nested" / "dir" / "session.db"
+    log = SqliteEventLog(db)
+    assert db.is_file()
+    log.close()
+
+
+def test_wal_mode_enabled(tmp_path: Path) -> None:
+    log = SqliteEventLog(tmp_path / "wal.db")
+    row = log._require_conn().execute("PRAGMA journal_mode").fetchone()
+    assert row[0] == "wal"
+    log.close()
+
+
+def test_close_is_idempotent(tmp_path: Path) -> None:
+    log = SqliteEventLog(tmp_path / "x.db")
+    log.close()
+    log.close()  # no exception
+
+
+def test_use_after_close_raises(tmp_path: Path) -> None:
+    log = SqliteEventLog(tmp_path / "x.db")
+    log.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        log.append(_make_item("i1"))
+
+
+def test_context_manager(tmp_path: Path) -> None:
+    db = tmp_path / "ctx.db"
+    with SqliteEventLog(db) as log:
+        log.append(_make_item("i1"))
+        assert log.count() == 1
+    # Reopen — data persists.
+    with SqliteEventLog(db) as log2:
+        assert log2.get("i1").id == "i1"
+
+
+# ---------------------------------------------------------------------------
+# Append / get
+# ---------------------------------------------------------------------------
+
+
+def test_append_and_get(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        log.append(_make_item("i1"))
+        assert log.get("i1").text == "text"
+
+
+def test_duplicate_raises(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        log.append(_make_item("i1"))
+        with pytest.raises(DuplicateItemError, match="Duplicate item id"):
+            log.append(_make_item("i1"))
+
+
+def test_get_missing_raises(tmp_path: Path) -> None:
+    with (
+        SqliteEventLog(tmp_path / "x.db") as log,
+        pytest.raises(ItemNotFoundError, match="Item not found"),
+    ):
+        log.get("missing")
+
+
+def test_append_preserves_all_context_item_fields(tmp_path: Path) -> None:
+    artifact = ArtifactRef(handle="h1", media_type="text/plain", size_bytes=11, label="lbl")
+    item = ContextItem(
+        id="i1",
+        kind=ItemKind.tool_result,
+        text="payload",
+        token_estimate=42,
+        sensitivity=Sensitivity.confidential,
+        metadata={"k": "v", "n": 1},
+        parent_id="p1",
+        artifact_ref=artifact,
+    )
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        log.append(item)
+        round_trip = log.get("i1")
+    assert round_trip.token_estimate == 42
+    assert round_trip.sensitivity == Sensitivity.confidential
+    assert round_trip.metadata == {"k": "v", "n": 1}
+    assert round_trip.parent_id == "p1"
+    assert round_trip.artifact_ref is not None
+    assert round_trip.artifact_ref.handle == "h1"
+    assert round_trip.artifact_ref.size_bytes == 11
+
+
+# ---------------------------------------------------------------------------
+# Queries
+# ---------------------------------------------------------------------------
+
+
+def test_all_returns_insertion_order(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        for i in range(5):
+            log.append(_make_item(f"i{i}"))
+        assert [item.id for item in log.all()] == [f"i{i}" for i in range(5)]
+
+
+def test_filter_by_kind(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        log.append(_make_item("u1", ItemKind.user_turn))
+        log.append(_make_item("t1", ItemKind.tool_call))
+        log.append(_make_item("u2", ItemKind.user_turn))
+        results = log.filter_by_kind(ItemKind.user_turn)
+    assert [r.id for r in results] == ["u1", "u2"]
+
+
+def test_filter_by_kind_no_kinds(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        log.append(_make_item("u1"))
+        assert log.filter_by_kind() == []
+
+
+def test_tail(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        for i in range(10):
+            log.append(_make_item(f"i{i}"))
+        tail = log.tail(3)
+    assert [item.id for item in tail] == ["i7", "i8", "i9"]
+
+
+def test_tail_zero(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        log.append(_make_item("i1"))
+        assert log.tail(0) == []
+        assert log.tail(-1) == []
+
+
+def test_children(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        log.append(_make_item("parent1"))
+        log.append(
+            ContextItem(id="child1", kind=ItemKind.tool_result, text="r1", parent_id="parent1")
+        )
+        log.append(
+            ContextItem(id="child2", kind=ItemKind.tool_result, text="r2", parent_id="parent1")
+        )
+        log.append(_make_item("other"))
+        children = log.children("parent1")
+    assert [c.id for c in children] == ["child1", "child2"]
+
+
+def test_children_empty(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        log.append(_make_item("i1"))
+        assert log.children("i1") == []
+
+
+def test_parent_found(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        log.append(_make_item("p1"))
+        log.append(ContextItem(id="c1", kind=ItemKind.tool_result, text="r", parent_id="p1"))
+        parent = log.parent("c1")
+    assert parent is not None
+    assert parent.id == "p1"
+
+
+def test_parent_none(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        log.append(_make_item("i1"))
+        assert log.parent("i1") is None
+
+
+def test_parent_missing_parent_id(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        log.append(ContextItem(id="c1", kind=ItemKind.tool_result, text="r", parent_id="missing"))
+        assert log.parent("c1") is None
+
+
+def test_parent_not_found_raises(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log, pytest.raises(ItemNotFoundError):
+        log.parent("missing")
+
+
+def test_query_no_filters(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        for i in range(5):
+            log.append(_make_item(f"i{i}"))
+        assert len(log.query()) == 5
+
+
+def test_query_with_kinds(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        log.append(_make_item("u1", ItemKind.user_turn))
+        log.append(_make_item("t1", ItemKind.tool_call))
+        log.append(_make_item("u2", ItemKind.user_turn))
+        results = log.query(kinds=[ItemKind.user_turn])
+    assert [r.id for r in results] == ["u1", "u2"]
+
+
+def test_query_with_empty_kinds_returns_empty(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        log.append(_make_item("u1"))
+        assert log.query(kinds=[]) == []
+
+
+def test_query_with_since(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        for i in range(5):
+            log.append(_make_item(f"i{i}"))
+        results = log.query(since=3)
+    assert [r.id for r in results] == ["i3", "i4"]
+
+
+def test_query_with_limit(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        for i in range(5):
+            log.append(_make_item(f"i{i}"))
+        results = log.query(limit=2)
+    assert [r.id for r in results] == ["i0", "i1"]
+
+
+def test_query_combined_filters(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        log.append(_make_item("u1", ItemKind.user_turn))
+        log.append(_make_item("t1", ItemKind.tool_call))
+        log.append(_make_item("u2", ItemKind.user_turn))
+        log.append(_make_item("t2", ItemKind.tool_call))
+        log.append(_make_item("u3", ItemKind.user_turn))
+        results = log.query(kinds=[ItemKind.user_turn], since=2, limit=1)
+    assert [r.id for r in results] == ["u3"]
+
+
+def test_count_and_len(tmp_path: Path) -> None:
+    with SqliteEventLog(tmp_path / "x.db") as log:
+        assert log.count() == 0
+        assert len(log) == 0
+        log.append(_make_item("i1"))
+        log.append(_make_item("i2"))
+        assert log.count() == 2
+        assert len(log) == 2
+
+
+# ---------------------------------------------------------------------------
+# Multi-session persistence (the headline #223 success metric)
+# ---------------------------------------------------------------------------
+
+
+def test_multi_session_round_trip(tmp_path: Path) -> None:
+    db = tmp_path / "session.db"
+    log1 = SqliteEventLog(db)
+    for i in range(7):
+        log1.append(_make_item(f"i{i}", text=f"payload-{i}"))
+    log1.close()
+
+    log2 = SqliteEventLog(db)
+    items = log2.all()
+    log2.close()
+
+    assert [item.id for item in items] == [f"i{i}" for i in range(7)]
+    assert items[3].text == "payload-3"
+
+
+def test_reopen_appends_after_existing(tmp_path: Path) -> None:
+    db = tmp_path / "session.db"
+    with SqliteEventLog(db) as log:
+        log.append(_make_item("i0"))
+        log.append(_make_item("i1"))
+    with SqliteEventLog(db) as log:
+        log.append(_make_item("i2"))
+        order = [it.id for it in log.all()]
+    assert order == ["i0", "i1", "i2"]
+
+
+def test_reopen_preserves_schema_version(tmp_path: Path) -> None:
+    db = tmp_path / "session.db"
+    with SqliteEventLog(db) as log:
+        first = schema_version(log._require_conn())
+    with SqliteEventLog(db) as log:
+        second = schema_version(log._require_conn())
+    assert first == second == len(MIGRATIONS) - 1
+
+
+def test_in_memory_path(tmp_path: Path) -> None:
+    log = SqliteEventLog(":memory:")
+    log.append(_make_item("i1"))
+    assert log.path == ":memory:"
+    assert log.count() == 1
+    log.close()

--- a/tests/test_store_sqlite_event_log.py
+++ b/tests/test_store_sqlite_event_log.py
@@ -6,7 +6,12 @@ from pathlib import Path
 
 import pytest
 
-from contextweaver.exceptions import DuplicateItemError, ItemNotFoundError
+from contextweaver.exceptions import (
+    ContextWeaverError,
+    DuplicateItemError,
+    ItemNotFoundError,
+    StoreClosedError,
+)
 from contextweaver.store._sqlite_base import schema_version
 from contextweaver.store.sqlite_event_log import MIGRATIONS, SqliteEventLog
 from contextweaver.types import ArtifactRef, ContextItem, ItemKind, Sensitivity
@@ -52,8 +57,13 @@ def test_close_is_idempotent(tmp_path: Path) -> None:
 def test_use_after_close_raises(tmp_path: Path) -> None:
     log = SqliteEventLog(tmp_path / "x.db")
     log.close()
-    with pytest.raises(RuntimeError, match="closed"):
+    # Use-after-close must raise the contextweaver-family exception so callers
+    # can catch the ContextWeaverError hierarchy uniformly (per AGENTS.md).
+    with pytest.raises(StoreClosedError, match="closed"):
         log.append(_make_item("i1"))
+    # And it must remain catchable as ContextWeaverError for cross-family code.
+    with pytest.raises(ContextWeaverError):
+        log.append(_make_item("i2"))
 
 
 def test_context_manager(tmp_path: Path) -> None:
@@ -243,6 +253,15 @@ def test_query_with_limit(tmp_path: Path) -> None:
 
 
 def test_query_combined_filters(tmp_path: Path) -> None:
+    """Combined ``kinds`` + ``since`` + ``limit`` matches the in-memory backend.
+
+    For ``[u1, t1, u2, t2, u3]`` and ``kinds=[user_turn], since=2, limit=1``:
+    ``since=2`` slices the full log to ``[u2, t2, u3]``, the kind filter then
+    reduces to ``[u2, u3]``, and ``limit=1`` returns ``[u2]``. Earlier the
+    SQLite path filtered by kind in SQL *before* applying ``since`` over the
+    filtered list, which gave ``[u3]`` — diverging from InMemoryEventLog and
+    flagged in PR #232 review.
+    """
     with SqliteEventLog(tmp_path / "x.db") as log:
         log.append(_make_item("u1", ItemKind.user_turn))
         log.append(_make_item("t1", ItemKind.tool_call))
@@ -250,7 +269,43 @@ def test_query_combined_filters(tmp_path: Path) -> None:
         log.append(_make_item("t2", ItemKind.tool_call))
         log.append(_make_item("u3", ItemKind.user_turn))
         results = log.query(kinds=[ItemKind.user_turn], since=2, limit=1)
-    assert [r.id for r in results] == ["u3"]
+    assert [r.id for r in results] == ["u2"]
+
+
+def test_query_kinds_since_matches_in_memory_semantics(tmp_path: Path) -> None:
+    """Regression: ``since`` is applied to the *full* log before ``kinds`` filters.
+
+    Mirror of ``tests/test_store_event_log.py::test_query_combined_filters``
+    so the two backends are pinned to byte-identical outputs.
+    """
+    from contextweaver.store.event_log import InMemoryEventLog
+
+    in_mem = InMemoryEventLog()
+    sqlite_log = SqliteEventLog(tmp_path / "parity.db")
+    try:
+        for iid, kind in [
+            ("u1", ItemKind.user_turn),
+            ("t1", ItemKind.tool_call),
+            ("u2", ItemKind.user_turn),
+            ("t2", ItemKind.tool_call),
+            ("u3", ItemKind.user_turn),
+        ]:
+            item = _make_item(iid, kind)
+            in_mem.append(item)
+            sqlite_log.append(item)
+
+        cases = [
+            {"kinds": [ItemKind.user_turn], "since": 2, "limit": 1},
+            {"kinds": [ItemKind.user_turn], "since": 2},
+            {"kinds": [ItemKind.tool_call], "since": 1, "limit": 1},
+            {"since": 3},
+        ]
+        for kwargs in cases:
+            in_ids = [i.id for i in in_mem.query(**kwargs)]  # type: ignore[arg-type]
+            sq_ids = [i.id for i in sqlite_log.query(**kwargs)]  # type: ignore[arg-type]
+            assert in_ids == sq_ids, f"parity broken for {kwargs}: {in_ids} vs {sq_ids}"
+    finally:
+        sqlite_log.close()
 
 
 def test_count_and_len(tmp_path: Path) -> None:


### PR DESCRIPTION
Lands the store-only slice of the persistent-backends group (#42, #174,
#223). Two new protocol-conformant backends + an EventLog lifecycle
contract refinement; zero behavior change for existing in-memory users.

## Why

The context engine's event log and artifact store are in-memory only —
session data vanishes on process exit. Agents that persist across
restarts or need auditable history require durable backends. This PR
delivers the first two: a SQLite event log and a filesystem artifact
store, both conforming to the existing protocol interfaces.

## What changed

### SqliteEventLog + shared `_sqlite_base.py` (#174, #223)

- `store/_sqlite_base.py`: connection helper (WAL, `foreign_keys=ON`,
  parent-dir auto-create) + `apply_migrations()` driven by a
  `_contextweaver_schema_version` table. Designed for reuse by the
  remaining SQLite stores in epic #174.
- `store/sqlite_event_log.py`: implements every `EventLog` protocol
  method against a single-process SQLite file. Append-only writes via
  `append()` (duplicate ids → `DuplicateItemError`); insertion order
  preserved by an auto-increment `ordinal` column; indexes on `kind`
  and `parent_id`. Round-trips every `ContextItem` field including JSON
  `metadata` and nested `ArtifactRef`.
- `[sqlite]` extras placeholder in `pyproject.toml` (stdlib `sqlite3`
  only; placeholder for a future `aiosqlite` async variant).

### JsonFileArtifactStore (#42)

- `store/json_file_artifacts.py`: filesystem-backed `ArtifactStore`.
  Layout: `{base_dir}/{handle}.data` + `{base_dir}/{handle}.json`.
  Auto-creates `base_dir`; rejects handles containing path separators,
  `..`, `.`, or null bytes. Re-instantiating against an existing
  directory recovers refs from metadata files.
- `store/artifacts.py`: extracts drilldown selector dispatch (`head` /
  `lines` / `json_keys` / `rows`) to a shared `_apply_selector()`
  helper so both backends produce identical output.

### EventLog lifecycle

- `store/protocols.py`: `EventLog` protocol now requires `close()`,
  `__enter__`, `__exit__`.
- `store/event_log.py`: `InMemoryEventLog.close()` is a no-op; existing
  callers unaffected. `with SqliteEventLog(path) as log:` is the
  recommended idiom.

### Review-driven fixes

- `SqliteEventLog.query()`: `since` applied to the full insertion-ordered
  log *before* `kinds` filter, matching `InMemoryEventLog` semantics.
- `JsonFileArtifactStore`: path-traversal validation moved into
  `_meta_path` / `_data_path` so every public method (not just `put`)
  rejects unsafe handles.
- `StoreClosedError` (new exception in `exceptions.py`): replaces bare
  `RuntimeError` for use-after-close, keeping the `ContextWeaverError`
  hierarchy consistent per `AGENTS.md`.
- `JsonFileArtifactStore.list_refs()`: catches `TypeError` from
  `ArtifactRef.from_dict` when a `.json` file is valid JSON but not a
  mapping.
- Top-level `__init__.py`: re-exports `SqliteEventLog`,
  `JsonFileArtifactStore`, and `StoreClosedError`.
- `_sqlite_base.py`: rollback in `apply_migrations` uses
  `contextlib.suppress` for safety if the connection is lost.

### Non-goals (out of scope)

- Cross-process write coordination (tracked in #174 roadmap).
- Async SQLite variant (`aiosqlite`).
- SQLite-backed `ArtifactStore`, `EpisodicStore`, `FactStore` (future
  slices of #174).

## Test plan

```
make ci  →  all 6 targets passed
pytest   →  1150 passed, 1 skipped
mypy     →  0 issues / 77 files
ruff     →  clean (format + check)
```

65 new tests: 32 SqliteEventLog, 29 JsonFileArtifactStore, 2 in-memory
lifecycle, 2 parity tests (SQLite vs in-memory query semantics).

## Risks

Low. Both backends are opt-in (imported explicitly), single-process, and
have no effect on the default in-memory code path. The `EventLog`
protocol addition (`close` / context manager) is backwards-compatible
since the in-memory implementation's `close()` is a no-op.

Closes #42
Closes #223
Refs #174