### PR TITLE
feat(examples,adapters,docs): code-review bot + voice agent architectures + FastMCP CodeMode hooks (#87, #204, #205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   answer=1000)`) for sub-300 ms TTS. Pipecat is optional via the new
   `[voice]` extra; the example runs end-to-end without it.
 
+### Fixed
+
+- **FastMCP CodeMode hook factories use `ConfigError`** (PR #233 review).
+  `make_discovery_tool` and `make_context_hook` now raise
+  `contextweaver.exceptions.ConfigError` (a `ContextWeaverError` subclass)
+  on negative `top_k` / `firewall_threshold`, replacing the previous bare
+  `ValueError` per the AGENTS.md custom-exception convention.
+- **`make_discovery_tool` `top_k` counts hydratable tools, not slots**
+  (PR #233 review). The discovery hook used to slice
+  `result.candidate_ids` to `top_k` *before* hydration, so a graph-only
+  candidate appearing early in the list silently shrank the shortlist by
+  one. The hook now iterates the full candidate list, skips non-hydratable
+  IDs, and stops after `top_k` real tools have been appended.
+- **`make_discovery_tool` returns deep-copied `input_schema`** (PR #233
+  review). `dict(hydrated.args_schema)` was a shallow copy that left
+  nested dicts / lists aliased with the catalog item, so an external
+  runtime mutating the returned schema could silently corrupt subsequent
+  `discover()` calls. The schema is now `copy.deepcopy`-ed before
+  handing it to callers.
+- **`make_context_hook` docstring matches implementation** (PR #233
+  review). The "parent user-turn id for dependency closure" wording is
+  replaced with the actual behaviour — the query is stamped onto
+  `item.metadata["codemode_query"]`, no synthetic user_turn item is
+  ingested, matching the inline rationale that the hook is intentionally
+  stateless w.r.t. conversation history.
+
 ## [0.6.0] - 2026-05-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **FastMCP CodeMode hooks** (#87). New
+  `contextweaver.adapters.fastmcp.make_discovery_tool(router, catalog)`
+  and `make_context_hook(context_manager)` factories return plain
+  callables suitable for FastMCP CodeMode's custom-discovery-tool and
+  context hooks (or any runtime with the same shape — LangChain,
+  LlamaIndex, hand-rolled agent loops). Neither hook imports `fastmcp`
+  at runtime; the callable contract is framework-agnostic.
+  `examples/fastmcp_discovery_demo.py` demonstrates a 22-tool catalog
+  shrinking to a 3-tool shortlist (86% token reduction). `fastmcp>=2.0`
+  is now part of the `[dev]` extra so a real in-memory FastMCP server
+  integration test (`tests/test_adapters_fastmcp_discovery.py`) runs on
+  every CI matrix cell. Reference:
+  https://github.com/PrefectHQ/fastmcp/discussions/3365
+- **Code-review bot reference architecture** (#204). New
+  `examples/architectures/code_review_bot/` walks a six-step pull-request
+  review against a 24-tool catalog (grep / git / lint / typecheck /
+  test / review). The firewall is the load-bearing pattern: a synthetic
+  ~28 KB diff dump and ~2.5 KB grep result both compact to ~500-char
+  summaries while raw bytes stay addressable via the artifact store.
+  Linked from `docs/architectures/index.md` and runnable under
+  `make architectures`.
+- **Voice agent reference architecture** (#205). New
+  `examples/architectures/voice_agent/` is the canonical worked example
+  for `docs/integration_pipecat.md`. Walks a five-turn customer-service
+  call against an 18-tool catalog, demonstrating the
+  `asyncio.to_thread(mgr.build_sync, …)` pattern and tight per-phase
+  budgets (`ContextBudget(route=200, call=500, interpret=400,
+  answer=1000)`) for sub-300 ms TTS. Pipecat is optional via the new
+  `[voice]` extra; the example runs end-to-end without it.
+
 ## [0.4.0] - 2026-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `item.metadata["codemode_query"]`, no synthetic user_turn item is
   ingested, matching the inline rationale that the hook is intentionally
   stateless w.r.t. conversation history.
+- **`make_context_hook` accepts `tool_name`** (PR #233 audit). The
+  factory previously hardcoded `tool_name="codemode.discovery"` on every
+  firewalled `ContextItem`, which was both semantically wrong (this is a
+  context / firewall hook, not a discovery hook) and lossy for multi-tool
+  agents whose traces could no longer be sliced by underlying tool. The
+  factory now accepts `tool_name: str = "codemode.tool_result"` and stamps
+  the configured value into the event log. The docstring also pins the
+  timing of the `codemode_query` metadata stamp (post-firewall;
+  visible to event-log reads and `on_context_built` callbacks but
+  *not* to `on_firewall_triggered`).
+- **FastMCP CodeMode test coverage** (PR #233 audit). Added a real
+  FastMCP integration test that exercises `make_context_hook` end-to-end
+  against an in-memory `fastmcp.FastMCP` server (`tests/test_adapters_
+  fastmcp_discovery.py::test_context_hook_compacts_real_fastmcp_tool_call`),
+  a `top_k=0` boundary test for `make_discovery_tool`, and a post-hook
+  metadata-consumability pin for the `codemode_query` contract.
 
 ## [0.6.0] - 2026-05-17
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ example:
 	python examples/mcp_gateway_demo.py
 	python examples/mcp_proxy_demo.py
 	python examples/a2a_adapter_demo.py
+	python examples/fastmcp_discovery_demo.py
 	python examples/langchain_memory_demo.py
 	python examples/cookbook/byot_recipe.py
 	python examples/cookbook/firewall_drilldown_recipe.py
@@ -30,6 +31,8 @@ example:
 
 architectures:
 	python examples/architectures/slack_ops_bot/main.py
+	python examples/architectures/code_review_bot/main.py
+	python examples/architectures/voice_agent/main.py
 
 demo:
 	python -m contextweaver demo

--- a/docs/architectures/code_review_bot.md
+++ b/docs/architectures/code_review_bot.md
@@ -1,0 +1,107 @@
+# Code-review bot
+
+> Production reference architecture for a pull-request review bot fronting
+> ~24 analysis tools. Demonstrates how the **context firewall** carries
+> the weight of a code-review workflow: large diff and grep outputs go
+> straight to the artifact store while the prompt stays compact.
+
+## TL;DR
+
+| What | Where |
+|---|---|
+| The script | [`examples/architectures/code_review_bot/main.py`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/code_review_bot/main.py) |
+| The catalog | [`examples/architectures/code_review_bot/catalog.yaml`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/code_review_bot/catalog.yaml) |
+| Captured output | [`examples/architectures/code_review_bot/OUTPUT.md`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/code_review_bot/OUTPUT.md) |
+| Local README | [`examples/architectures/code_review_bot/README.md`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/code_review_bot/README.md) |
+
+Run it:
+
+```bash
+python examples/architectures/code_review_bot/main.py
+```
+
+(Or `make architectures` / `make example`.)
+
+## The shape
+
+The bot walks a six-step review of a regression-introducing refactor in
+`payments/charge.py`:
+
+1. *"show me the diff of this pull request against main"* — `git.diff` (large output → firewall)
+2. *"grep for the symbol legacy_charge in the codebase"* — `grep.symbol` (large output → firewall)
+3. *"run the test suite for the changed module"* — `test.run_module`
+4. *"run mypy on the changed module to surface type errors"* — `typecheck.module`
+5. *"run ruff on the changed files and report style violations"* — `lint.run`
+6. *"post a review comment requesting changes on the regression"* — `review.post_comment`
+
+For each step:
+
+- The [`Router`](../architecture.md#routing-engine) narrows 24 tools to
+  a top-3 shortlist (`top_k=3`).
+- The bot picks one tool *from the shortlist* using an explicit intent
+  map. That separation is the **load-bearing pattern**: contextweaver
+  bounds the choice, the bot (or, in production, an LLM) makes the final
+  selection.
+- The tool is "called" against a mocked backend. Large outputs go
+  through the [firewall](../architecture.md#context-firewall) — the
+  28 KB diff dump and 2.5 KB grep result become 500-char summaries on
+  the prompt while the raw bytes are parked in the artifact store.
+- Persistent [facts](../concepts.md) (`pr.target_file`,
+  `pr.test_status`, `pr.type_errors`) are written via
+  `ContextManager.add_fact_sync` so they survive into the answer-phase
+  prompt for every subsequent step.
+
+## What's load-bearing
+
+| contextweaver feature | Used | What it does here |
+|---|---|---|
+| `Router.route(query)` | ✅ | Narrows 24 tools → top-3 shortlist (`top_k=3`) |
+| Bounded choice pattern | ✅ | Bot picks from the shortlist, not from the whole catalog |
+| `TreeBuilder` DAG | ✅ | One-shot graph build at startup; routes are sub-millisecond |
+| **Context firewall** | ✅✅ | Compacts the ~28 KB diff dump and ~2.5 KB grep result down to ~500-char summaries before they touch the prompt |
+| Artifact store | ✅ | Raw bytes stay addressable for drilldown; only summaries land in the prompt |
+| Persistent facts | ✅ | Three fact keys survive across all six review steps |
+| Tight per-phase budgets | ✅ | `ContextBudget(route=1500, call=2500, interpret=2500, answer=3500)` keeps the answer prompt small even after the firewall externalises the heavy bytes |
+
+## Why this architecture matters
+
+Code-review bots are firewall-bound. Every step produces output that
+would saturate a model's context window if inlined: a typical PR diff is
+10–50 KB, a grep for a renamed symbol returns dozens of hits, lint and
+typecheck pipelines emit hundreds of lines on a hot patch. Without a
+firewall, the prompt blows the budget by step 3 and the bot starts
+truncating mid-review.
+
+contextweaver's [Context Engine](../architecture.md#context-engine)
+handles this without a per-tool integration: the firewall fires on any
+result exceeding `firewall_threshold` (2 KB default), parks the raw
+bytes in the artifact store, injects a compact summary on the prompt,
+and leaves the artifact handle so the LLM can request a drilldown when
+needed.
+
+## What's intentionally not here
+
+- **Real git integration.** Mock tool responses keep the example
+  deterministic and CI-friendly. A real deployment would wire `git.diff`
+  to `subprocess.run(["git", "diff", "main"], ...)` or to an MCP server.
+- **LLM-based diff summarisation.** The `review.summarize_diff` tool's
+  canned response is a stand-in for what a `Summarizer` plugin
+  ([issue #26](https://github.com/dgenio/contextweaver/issues/26))
+  would do.
+- **Multi-PR session state.** The fact store survives the in-process
+  review, but to persist across PRs you would swap the default
+  `InMemoryFactStore` for a `SqliteFactStore`
+  ([issue #174](https://github.com/dgenio/contextweaver/issues/174)) or
+  a Mem0 / Zep adapter
+  ([issue #195](https://github.com/dgenio/contextweaver/issues/195)).
+
+## Read next
+
+- [Slack ops bot](slack_ops_bot.md) — the first architecture in the
+  series; demonstrates persistent facts and routing across many
+  namespaces.
+- [Voice agent](voice_agent.md) — the third architecture; demonstrates
+  the `asyncio.to_thread(mgr.build_sync, …)` pattern for real-time
+  pipelines.
+- The [cookbook](../cookbook.md) covers the individual primitives —
+  routing, firewall, drilldown — used here.

--- a/docs/architectures/index.md
+++ b/docs/architectures/index.md
@@ -14,7 +14,9 @@ for a production agent, you are in the right place.
 
 | Architecture | What it shows | Size |
 |---|---|---|
-| [Slack ops bot](slack_ops_bot.md) | ~50 internal tools, multi-turn investigations, firewall on log/grep outputs, persistent fact memory across conversations | ~250 lines + YAML catalog |
+| [Slack ops bot](slack_ops_bot.md) | ~48 internal tools, multi-turn investigations, firewall on log/grep outputs, persistent fact memory across conversations | ~280 lines + YAML catalog |
+| [Code-review bot](code_review_bot.md) | ~24 analysis tools, firewall on diff / grep outputs as the load-bearing pattern, tight per-phase budgets for a latency-sensitive review | ~300 lines + YAML catalog |
+| [Voice agent](voice_agent.md) | ~18 customer-service tools, `asyncio.to_thread(mgr.build_sync, …)` async pattern, tight budgets for sub-300 ms TTS — canonical worked example for the [Pipecat guide](../integration_pipecat.md) | ~270 lines + YAML catalog |
 
 ## How each architecture is structured
 
@@ -31,13 +33,3 @@ Every architecture under `examples/architectures/<name>/` contains:
 
 The architectures run under `make example` (via the `make architectures`
 umbrella target) so they cannot bitrot silently as the library evolves.
-
-## Roadmap
-
-Architectures planned as follow-ups (tracked under issue #198):
-
-- **Code-review bot** — firewall on diff / grep outputs, bounded routing
-  across a fixed set of analysis tools, latency-sensitive answer phase.
-- **Real-time voice agent** — Pipecat-backed, demonstrates the
-  `asyncio.to_thread(mgr.build_sync, …)` pattern and tight answer-phase
-  budgets recommended in the [Pipecat guide](../integration_pipecat.md).

--- a/docs/architectures/voice_agent.md
+++ b/docs/architectures/voice_agent.md
@@ -1,0 +1,117 @@
+# Voice agent (Pipecat)
+
+> Production reference architecture for a real-time customer-service
+> voice bot. Demonstrates the
+> **`asyncio.to_thread(mgr.build_sync, …)`** pattern documented in
+> [the Pipecat integration guide](../integration_pipecat.md), plus tight
+> per-phase budgets that keep TTS responsive under a 300 ms latency
+> bound.
+
+## TL;DR
+
+| What | Where |
+|---|---|
+| The script | [`examples/architectures/voice_agent/main.py`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/voice_agent/main.py) |
+| The catalog | [`examples/architectures/voice_agent/catalog.yaml`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/voice_agent/catalog.yaml) |
+| Captured output | [`examples/architectures/voice_agent/OUTPUT.md`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/voice_agent/OUTPUT.md) |
+| Local README | [`examples/architectures/voice_agent/README.md`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/voice_agent/README.md) |
+| Companion guide | [`docs/integration_pipecat.md`](../integration_pipecat.md) |
+
+Run it:
+
+```bash
+python examples/architectures/voice_agent/main.py
+```
+
+(Or `make architectures` / `make example`.)
+
+For the optional Pipecat hook:
+
+```bash
+pip install 'contextweaver[voice]'
+```
+
+## The shape
+
+The bot walks a five-turn customer-service call (order chase, address
+update, callback scheduling):
+
+1. *"hi, can you look up order number A-481 for me"* — `orders.lookup`
+2. *"what is the shipping tracking status for that order"* — `shipping.tracking`
+3. *"can you change the delivery address to my new home"* — `shipping.update_address`
+4. *"when is the next available delivery slot"* — `shipping.delivery_slot`
+5. *"schedule a callback for me at 2pm tomorrow"* — `callback.schedule`
+
+For each turn:
+
+- The [`Router`](../architecture.md#routing-engine) narrows 18 tools to
+  a top-3 shortlist (`top_k=3`). Routing is sub-millisecond and runs
+  on the audio thread.
+- The bot picks one tool *from the shortlist* using an explicit intent
+  map. That separation is the **load-bearing pattern**: contextweaver
+  bounds the choice, the bot (or, in production, an LLM) makes the
+  final selection.
+- **Every context build runs via `asyncio.to_thread(mgr.build_sync,
+  …)`** — keeping the audio event loop free while the prompt is
+  assembled on a worker thread.
+- Persistent [facts](../concepts.md) (`customer.order_id`,
+  `customer.shipping_address`, `customer.callback`) survive across all
+  five turns of the call.
+
+## What's load-bearing
+
+| contextweaver feature | Used | What it does here |
+|---|---|---|
+| `Router.route(query)` | ✅ | Narrows 18 tools → top-3 shortlist (`top_k=3`) |
+| Bounded choice pattern | ✅ | Bot picks from the shortlist, not from the whole catalog |
+| **`asyncio.to_thread(mgr.build_sync, …)`** | ✅ | Every context build runs on a worker thread so the audio pipeline event loop stays free |
+| **Tight per-phase budgets** | ✅ | `ContextBudget(route=200, call=500, interpret=400, answer=1000)` keeps every prompt small enough for sub-300 ms TTS |
+| Persistent facts | ✅ | Three fact keys survive across all five turns of the call |
+
+## The async pattern in detail
+
+contextweaver's context pipeline is sync (deterministic, no IO). For
+real-time pipelines you want it off the audio event loop. The canonical
+pattern, used in this example and documented in the
+[Pipecat integration guide](../integration_pipecat.md):
+
+```python
+async def _async_build(mgr, *, phase, query):
+    return await asyncio.to_thread(mgr.build_sync, phase=phase, query=query)
+```
+
+Why this works:
+
+- The `_build` pipeline (eight sync stages — see the
+  [architecture overview](../architecture.md#context-engine)) is pure
+  Python computation; no awaits, no IO.
+- Wrapping it in `asyncio.to_thread` hands it to the default executor
+  so the event loop can continue draining audio frames.
+- The routing call (`router.route(query)`) is fast enough — typically
+  sub-millisecond for catalogs in the 10–100 range — that you can keep
+  it on the audio thread without measurable jitter.
+
+## What's intentionally not here
+
+- **A live audio pipeline.** The script is text-only; the per-turn
+  output simulates STT. For a worked Pipecat `FrameProcessor`, see the
+  [Pipecat integration guide](../integration_pipecat.md).
+- **TTS latency measurement.** The script prints "off-thread" timings
+  for the context build, which is the part contextweaver controls.
+  TTS / network IO is the model's / transport's responsibility.
+- **Across-call session state.** The fact store survives the in-process
+  call. To persist across calls, swap the default `InMemoryFactStore`
+  for a `SqliteFactStore`
+  ([issue #174](https://github.com/dgenio/contextweaver/issues/174)) or
+  a Mem0 / Zep adapter
+  ([issue #195](https://github.com/dgenio/contextweaver/issues/195)).
+
+## Read next
+
+- The [Pipecat integration guide](../integration_pipecat.md) — worked
+  `FrameProcessor` against the same patterns this architecture uses.
+- [Slack ops bot](slack_ops_bot.md) and
+  [code-review bot](code_review_bot.md) — the other two reference
+  architectures in the series.
+- The [cookbook](../cookbook.md) covers the individual primitives —
+  routing, firewall, drilldown — used here.

--- a/docs/integration_pipecat.md
+++ b/docs/integration_pipecat.md
@@ -5,6 +5,17 @@
 > agents stay budget-aware and don't stall the pipeline on a single
 > multi-KB function result.
 
+!!! tip "Canonical worked example"
+    The [Voice agent reference architecture](architectures/voice_agent.md)
+    is the canonical end-to-end worked example for this guide. It walks
+    a five-turn customer-service call against an 18-tool catalog,
+    exercises every recommendation on this page (the
+    `asyncio.to_thread(mgr.build_sync, …)` pattern, tight per-phase
+    budgets, persistent facts across the call), and ships a deterministic
+    `OUTPUT.md` you can read without running the script. Start there if
+    you want to see the pieces work together before reading the
+    integration details below.
+
 ## Why
 
 Pipecat's pipeline architecture is designed for sub-100 ms turn-taking.

--- a/examples/architectures/code_review_bot/OUTPUT.md
+++ b/examples/architectures/code_review_bot/OUTPUT.md
@@ -1,0 +1,111 @@
+# Code-review bot — captured run
+
+Output of `python examples/architectures/code_review_bot/main.py` from a
+clean checkout. Deterministic: routing is seed-stable, tool responses are
+canned, the firewall is hash-based on artifact content. The review walks
+six steps; the routing scoreboard at the end reports the intent /
+shortlist match rate, and the firewall scoreboard reports how many tool
+results were compacted.
+
+```
+============================================================================
+contextweaver -- Code-review bot reference architecture
+============================================================================
+Loaded catalog: 24 tools from catalog.yaml
+
+============================================================================
+Step 1
+============================================================================
+reviewer: show me the diff of this pull request against main
+routed:   ['git.diff', 'review.summarize_diff', 'review.approve']
+chosen:   git.diff  (intent='git.diff', in shortlist)
+route prompt: 1 items / 12 tokens
+firewall: 24,782 chars -> 247-char summary (artifact artifact:result:tc1)
+answer prompt: included=3  dropped=0  dedup=0  closures=0  tokens=76
+
+============================================================================
+Step 2
+============================================================================
+reviewer: grep for the symbol legacy_charge in the codebase
+routed:   ['grep.symbol', 'grep.regex', 'git.blame']
+chosen:   grep.symbol  (intent='grep.symbol', in shortlist)
+route prompt: 2 items / 24 tokens
+firewall: 2,464 chars -> 501-char summary (artifact artifact:result:tc2)
+answer prompt: included=6  dropped=0  dedup=0  closures=0  tokens=217
+
+============================================================================
+Step 3
+============================================================================
+reviewer: run the test suite for the changed module
+routed:   ['test.run_module', 'test.run', 'git.diff_files']
+chosen:   test.run_module  (intent='test.run_module', in shortlist)
+route prompt: 3 items / 34 tokens
+answer prompt: included=9  dropped=0  dedup=0  closures=0  tokens=285
+
+============================================================================
+Step 4
+============================================================================
+reviewer: run mypy on the changed module to surface type errors
+routed:   ['typecheck.run', 'typecheck.module', 'typecheck.stubs']
+chosen:   typecheck.module  (intent='typecheck.module', in shortlist)
+route prompt: 4 items / 47 tokens
+answer prompt: included=12  dropped=0  dedup=0  closures=0  tokens=360
+
+============================================================================
+Step 5
+============================================================================
+reviewer: run ruff on the changed files and report style violations
+routed:   ['lint.run', 'test.coverage', 'lint.format_check']
+chosen:   lint.run  (intent='lint.run', in shortlist)
+route prompt: 5 items / 61 tokens
+answer prompt: included=15  dropped=0  dedup=0  closures=0  tokens=420
+
+============================================================================
+Step 6
+============================================================================
+reviewer: post a review comment requesting changes on the regression
+routed:   ['review.post_comment', 'review.request_changes', 'git.blame']
+chosen:   review.post_comment  (intent='review.post_comment', in shortlist)
+route prompt: 6 items / 75 tokens
+answer prompt: included=18  dropped=0  dedup=0  closures=0  tokens=472
+
+============================================================================
+Persisted facts (carry across review steps)
+============================================================================
+  pr.target_file = payments/charge.py
+  pr.test_status = 2 failed (legacy_charge support, decimal precision)
+  pr.type_errors = 2 errors (missing charge_v2.charge, int/Decimal mismatch)
+
+============================================================================
+Firewall scoreboard
+============================================================================
+firewall fires: 2/6
+artifacts kept: 6
+(Each firewall fire compacts a >2 KB tool result down to a 500-char summary;
+ raw bytes stay addressable in the artifact store for drilldown.)
+
+============================================================================
+Routing scoreboard
+============================================================================
+intent in router top-3: 6/6  (100%)
+```
+
+## Reading the output
+
+- **Step 1.** The 28 KB diff dump is routed correctly to `git.diff` and
+  hits the firewall: 24,782 raw chars compact to a 247-char summary.
+  The artifact is parked at `artifact:result:tc1` and stays addressable
+  for drilldown.
+- **Step 2.** The grep hit-list (~2.5 KB) also exceeds the 2 KB
+  threshold and fires the firewall a second time.
+- **Steps 3–5.** Test / typecheck / lint results are small enough to land
+  on the prompt verbatim — no firewall fire.
+- **Step 6.** The bot posts the review comment (a `side_effects: true`
+  tool) only after all four prior steps have informed it.
+- **Routing scoreboard.** Every intent lands in the router's top-3
+  shortlist (`6/6`) — the catalog tokenisation is healthy for this
+  domain at this scale. If it weren't, the bot would fall back to
+  `shortlist[0]` (best-rank pick) rather than fail.
+- **Firewall scoreboard.** 2 of 6 tool results compacted; 6 artifacts
+  parked (every tool result is artifact-addressable even below the
+  firewall threshold, so drilldown works regardless).

--- a/examples/architectures/code_review_bot/README.md
+++ b/examples/architectures/code_review_bot/README.md
@@ -1,0 +1,94 @@
+# Code-review bot — reference architecture
+
+> A pull-request review bot fronting ~24 analysis tools. Demonstrates how
+> the **context firewall** carries the weight of a code-review workflow:
+> diff dumps and grep output are large, so the firewall and artifact
+> store are heavily exercised while the prompt stays compact.
+
+## Run it
+
+```bash
+python examples/architectures/code_review_bot/main.py
+```
+
+(Or `make architectures` / `make example`.)
+
+A captured run of the script lives in [`OUTPUT.md`](OUTPUT.md).
+
+## What this is (and isn't)
+
+This is a **reference architecture**, not a tutorial recipe. The cookbook
+gives you copy-paste snippets for individual primitives (routing,
+firewall, drilldown, BYO tools); the architecture wires them together
+around a realistic problem shape so you can see how they interact.
+
+It is **mocked**: tool implementations return canned strings, no real
+git / linter / type checker is invoked. The point is to demonstrate the
+contextweaver glue around a code-review-shaped transcript, not to
+integrate with a code host.
+
+## Setup
+
+The 24-tool catalog lives in [`catalog.yaml`](catalog.yaml). Loading it:
+
+```python
+from contextweaver.routing.catalog import Catalog, load_catalog_yaml
+
+catalog = Catalog()
+for item in load_catalog_yaml("catalog.yaml"):
+    catalog.register(item)
+```
+
+Namespaces: `grep`, `git`, `lint`, `typecheck`, `test`, `review`. Several
+tools have side effects (`lint.fix`, `review.post_comment`,
+`review.approve`, …); the catalog records this on each
+`SelectableItem.side_effects` so a real deployment could refuse to call
+them automatically (`Router.route(..., exclude_tags=...)`).
+
+## The review
+
+The bot walks a six-step review of a refactor that introduces a
+regression in `payments/charge.py`:
+
+1. *"show me the diff of this pull request against main"* — `git.diff` (large output → firewall)
+2. *"grep for the symbol legacy_charge in the codebase"* — `grep.symbol` (large output → firewall)
+3. *"run the test suite for the changed module"* — `test.run_module`
+4. *"run mypy on the changed module to surface type errors"* — `typecheck.module`
+5. *"run ruff on the changed files and report style violations"* — `lint.run`
+6. *"post a review comment requesting changes on the regression"* — `review.post_comment`
+
+See `TRANSCRIPT` in [`main.py`](main.py) for the exact text.
+
+## What's load-bearing
+
+| contextweaver feature | Used | What it does here |
+|---|---|---|
+| `Router.route(query)` | ✅ | Narrows 24 tools → top-3 shortlist (`top_k=3`) |
+| Bounded choice pattern | ✅ | Bot picks from the shortlist, not from the whole catalog |
+| `TreeBuilder` DAG | ✅ | One-shot graph build at startup; routes are sub-millisecond |
+| **Context firewall** | ✅✅ | Compacts the ~28 KB diff dump and ~6 KB grep result down to ~500-char summaries before they touch the prompt |
+| Artifact store | ✅ | Raw bytes stay addressable for drilldown; only summaries land in the prompt |
+| Persistent facts | ✅ | `pr.target_file`, `pr.test_status`, `pr.type_errors` survive across all six steps |
+| Tight per-phase budgets | ✅ | `ContextBudget(route=1500, call=2500, interpret=2500, answer=3500)` keeps the answer prompt small even after the firewall externalises the heavy bytes |
+
+## What's intentionally not here
+
+- **Real git integration.** Mock tool responses keep the example
+  deterministic and CI-friendly. A real deployment would wire `git.diff`
+  to `subprocess.run(["git", "diff", "main"], ...)` or to an MCP server.
+- **LLM-based diff summarisation.** The `review.summarize_diff` tool's
+  canned response is a stand-in for what a `Summarizer` plugin (issue
+  #26) would do.
+- **Multi-PR session state.** The fact store survives the in-process
+  review, but to persist across PRs you would swap the default
+  `InMemoryFactStore` for a `SqliteFactStore` (issue #174) or a Mem0 /
+  Zep adapter (issue #195).
+
+## Read next
+
+- The [cookbook](../../../docs/cookbook.md) covers the individual
+  primitives — routing, firewall, drilldown — used here.
+- The [architecture overview](../../../docs/architecture.md) walks the
+  full Context Engine + Routing Engine pipelines.
+- [`docs/architectures/code_review_bot.md`](../../../docs/architectures/code_review_bot.md)
+  is the public-docs version of this README.

--- a/examples/architectures/code_review_bot/__init__.py
+++ b/examples/architectures/code_review_bot/__init__.py
@@ -1,0 +1,3 @@
+"""Code-review bot reference architecture (#204)."""
+
+from __future__ import annotations

--- a/examples/architectures/code_review_bot/catalog.yaml
+++ b/examples/architectures/code_review_bot/catalog.yaml
@@ -1,0 +1,206 @@
+# Code-review bot — 24 analysis tools (mocked, names mirror common code-review surfaces).
+#
+# Loaded via contextweaver.routing.catalog.load_catalog_yaml(). The file is the
+# canonical catalog for the architecture; main.py reads it and registers each
+# entry into a Catalog before building the routing graph.
+#
+# Namespaces:
+#   grep       — code search by symbol / regex / file
+#   git        — git blame, git log, git show, git diff
+#   lint       — ruff / eslint-style style + bug analysis
+#   typecheck  — mypy / pyright-style static type analysis
+#   test       — pytest / unittest discovery + execution
+#   review     — PR diff inspection, comment posting
+
+- id: grep.symbol
+  kind: tool
+  name: grep_symbol
+  namespace: grep
+  description: Search for a symbol across the repository codebase
+  tags: [grep, search, code]
+  side_effects: false
+  cost_hint: 0.20
+- id: grep.regex
+  kind: tool
+  name: grep_regex
+  namespace: grep
+  description: Run a regex search across the codebase
+  tags: [grep, search, regex, code]
+  side_effects: false
+  cost_hint: 0.20
+- id: grep.file
+  kind: tool
+  name: grep_file
+  namespace: grep
+  description: Read a single source file with line numbers
+  tags: [grep, file, code]
+  side_effects: false
+  cost_hint: 0.10
+- id: grep.list_files
+  kind: tool
+  name: grep_list_files
+  namespace: grep
+  description: List source files matching a path pattern
+  tags: [grep, file, code]
+  side_effects: false
+  cost_hint: 0.10
+- id: git.blame
+  kind: tool
+  name: git_blame
+  namespace: git
+  description: Show git blame for a file showing who last touched each line
+  tags: [git, blame, vcs]
+  side_effects: false
+  cost_hint: 0.25
+- id: git.log
+  kind: tool
+  name: git_log
+  namespace: git
+  description: Show git log of commits touching a file or path
+  tags: [git, log, vcs]
+  side_effects: false
+  cost_hint: 0.20
+- id: git.show
+  kind: tool
+  name: git_show
+  namespace: git
+  description: Show the diff and metadata of a git commit
+  tags: [git, vcs]
+  side_effects: false
+  cost_hint: 0.20
+- id: git.diff
+  kind: tool
+  name: git_diff
+  namespace: git
+  description: Show the diff of a pull request branch against main
+  tags: [git, diff, vcs, pull request]
+  side_effects: false
+  cost_hint: 0.30
+- id: git.diff_files
+  kind: tool
+  name: git_diff_files
+  namespace: git
+  description: List files changed in the pull request diff
+  tags: [git, diff, vcs, pull request]
+  side_effects: false
+  cost_hint: 0.10
+- id: lint.run
+  kind: tool
+  name: lint_run
+  namespace: lint
+  description: Run ruff lint on the codebase and report style violations
+  tags: [lint, style, ruff]
+  side_effects: false
+  cost_hint: 0.40
+- id: lint.fix
+  kind: tool
+  name: lint_fix
+  namespace: lint
+  description: Auto-apply linter fixes to the working tree
+  tags: [lint, fix, write]
+  side_effects: true
+  cost_hint: 0.30
+- id: lint.format_check
+  kind: tool
+  name: lint_format_check
+  namespace: lint
+  description: Check that files are formatted per the project style
+  tags: [lint, format, style]
+  side_effects: false
+  cost_hint: 0.20
+- id: typecheck.run
+  kind: tool
+  name: typecheck_run
+  namespace: typecheck
+  description: Run the static type checker and report type errors
+  tags: [typecheck, mypy, types]
+  side_effects: false
+  cost_hint: 0.50
+- id: typecheck.module
+  kind: tool
+  name: typecheck_module
+  namespace: typecheck
+  description: Type-check a single module and report errors
+  tags: [typecheck, mypy, types]
+  side_effects: false
+  cost_hint: 0.30
+- id: typecheck.stubs
+  kind: tool
+  name: typecheck_stubs
+  namespace: typecheck
+  description: Check that third-party type stubs are present and current
+  tags: [typecheck, stubs]
+  side_effects: false
+  cost_hint: 0.20
+- id: test.run
+  kind: tool
+  name: test_run
+  namespace: test
+  description: Run the test suite and report passes / failures
+  tags: [test, pytest, ci]
+  side_effects: false
+  cost_hint: 0.60
+- id: test.run_module
+  kind: tool
+  name: test_run_module
+  namespace: test
+  description: Run pytest against a single test module
+  tags: [test, pytest]
+  side_effects: false
+  cost_hint: 0.40
+- id: test.coverage
+  kind: tool
+  name: test_coverage
+  namespace: test
+  description: Report test coverage for the changed files in the pull request
+  tags: [test, coverage]
+  side_effects: false
+  cost_hint: 0.50
+- id: test.discover
+  kind: tool
+  name: test_discover
+  namespace: test
+  description: Discover test files matching a path pattern
+  tags: [test, discover]
+  side_effects: false
+  cost_hint: 0.20
+- id: review.summarize_diff
+  kind: tool
+  name: review_summarize_diff
+  namespace: review
+  description: Summarise a pull request diff into a short review brief
+  tags: [review, summary, pull request]
+  side_effects: false
+  cost_hint: 0.30
+- id: review.fetch_pr
+  kind: tool
+  name: review_fetch_pr
+  namespace: review
+  description: Fetch a pull request's metadata, description, and labels
+  tags: [review, pull request, vcs]
+  side_effects: false
+  cost_hint: 0.20
+- id: review.post_comment
+  kind: tool
+  name: review_post_comment
+  namespace: review
+  description: Post an inline review comment on a pull request line
+  tags: [review, comment, write, pull request]
+  side_effects: true
+  cost_hint: 0.20
+- id: review.request_changes
+  kind: tool
+  name: review_request_changes
+  namespace: review
+  description: Submit a request-changes review on a pull request
+  tags: [review, write, pull request]
+  side_effects: true
+  cost_hint: 0.10
+- id: review.approve
+  kind: tool
+  name: review_approve
+  namespace: review
+  description: Approve a pull request review
+  tags: [review, approve, write, pull request]
+  side_effects: true
+  cost_hint: 0.10

--- a/examples/architectures/code_review_bot/main.py
+++ b/examples/architectures/code_review_bot/main.py
@@ -1,0 +1,331 @@
+"""Code-review bot — production reference architecture (#204).
+
+A pull-request review bot fronting ~24 analysis tools (grep, git blame, git
+log, lint, typecheck, test runner, plus PR review meta-tools). For each
+review step:
+
+1. The :class:`Router` narrows the 24-tool catalog to a top-3 shortlist
+   (route phase, ``Phase.route``).
+2. The bot picks one tool from the shortlist using an explicit intent map.
+   That separation is the load-bearing pattern: contextweaver bounds the
+   choice; the bot (or in production, an LLM with the shortlist in its
+   prompt) makes the final selection.
+3. The tool is called against a mocked backend; large outputs (the diff
+   dump and the grep result) go through the firewall (raw bytes to the
+   artifact store, summary on the prompt).
+4. Persistent facts (target files for review, test status, lint count)
+   are written via :meth:`ContextManager.add_fact_sync` so they survive
+   across review steps.
+5. The answer-phase build assembles a budget-aware prompt for the LLM.
+
+The firewall is the **load-bearing pattern** here: the simulated PR diff
+(~28 KB) and grep output (~6 KB) both exceed the 2 KB firewall threshold,
+so the prompt only ever sees compact summaries while the raw bytes stay
+addressable via the artifact store.
+
+This is mocked: tool implementations return canned strings, no real git /
+linter / type checker is invoked. The point is to demonstrate how routing,
+the firewall, and persistent facts compose around a realistic
+code-review-shaped transcript, not to integrate with a code host.
+
+Run standalone::
+
+    python examples/architectures/code_review_bot/main.py
+
+Or via ``make example`` (the ``architectures`` umbrella target).
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+from pathlib import Path
+
+from contextweaver.config import ContextBudget
+from contextweaver.context.manager import ContextManager
+from contextweaver.routing.catalog import Catalog, load_catalog_yaml
+from contextweaver.routing.router import Router
+from contextweaver.routing.tree import TreeBuilder
+from contextweaver.types import ContextItem, ItemKind, Phase
+
+# A scripted PR-review session: the bot inspects a refactor of
+# ``payments/charge.py`` that introduces a regression. Each entry is
+# ``(user_text, intent)`` where ``intent`` is the tool the bot would pick
+# *given the routed shortlist*. The intent map is deliberately explicit so
+# the architecture demonstrates the bounded-choice pattern (the Router
+# shortlist contains the right tool; the bot decides which to call).
+TRANSCRIPT: list[tuple[str, str]] = [
+    ("show me the diff of this pull request against main", "git.diff"),
+    ("grep for the symbol legacy_charge in the codebase", "grep.symbol"),
+    ("run the test suite for the changed module", "test.run_module"),
+    ("run mypy on the changed module to surface type errors", "typecheck.module"),
+    ("run ruff on the changed files and report style violations", "lint.run"),
+    ("post a review comment requesting changes on the regression", "review.post_comment"),
+]
+
+
+# Canned tool results. The PR diff and grep dump are intentionally large
+# so the firewall kicks in (> 2 KB) and the prompt only sees compact
+# summaries.  Built lazily so importing this module (e.g. from the test
+# smoke harness) does not pay the ~28 KB JSON construction cost up front.
+@functools.cache
+def _large_diff_dump() -> str:
+    """Return a ~28 KB synthetic diff that exceeds the firewall threshold."""
+    lines: list[str] = [
+        "diff --git a/payments/charge.py b/payments/charge.py",
+        "index 9f12abc..8a01def 100644",
+        "--- a/payments/charge.py",
+        "+++ b/payments/charge.py",
+        "@@ -1,4 +1,4 @@",
+        "-from payments.legacy_charge import charge as legacy_charge",
+        "+from payments.charge_v2 import charge",
+        "",
+    ]
+    # Pad with 200 plausible diff hunks so we cross the firewall threshold.
+    for i in range(200):
+        lines.append(f"@@ -{i * 4 + 10},4 +{i * 4 + 10},4 @@")
+        lines.append(f"-    return legacy_charge(customer_id={i}, amount={100 + i})")
+        lines.append(f"+    return charge(customer_id={i}, amount={100 + i})")
+        lines.append("")
+    return "\n".join(lines)
+
+
+@functools.cache
+def _large_grep_dump() -> str:
+    """Return a ~6 KB grep result for ``legacy_charge`` across the codebase."""
+    hits = [
+        {
+            "file": f"payments/{module}.py",
+            "line": 10 + i,
+            "match": f"from payments.legacy_charge import legacy_charge  # call site {i}",
+        }
+        for i, module in enumerate(
+            [
+                "charge",
+                "subscription",
+                "invoice",
+                "refund",
+                "trial",
+                "promo",
+                "tax",
+                "reporting",
+                "webhook",
+                "metrics",
+                "audit",
+                "retry",
+                "rate_limit",
+                "feature_flag",
+                "rollout",
+                "dispute",
+                "fraud",
+                "limits",
+                "schedule",
+                "expiry",
+            ]
+        )
+    ]
+    return json.dumps({"query": "legacy_charge", "hits": hits}, indent=None)
+
+
+@functools.cache
+def _tool_responses() -> dict[str, str]:
+    """Return the canned tool-response map. Lazy so heavy payloads only build on demand."""
+    return {
+        "git.diff": _large_diff_dump(),
+        "grep.symbol": _large_grep_dump(),
+        "test.run_module": (
+            "pytest tests/test_payments_charge.py -q\n"
+            "  3 passed, 2 failed in 0.42s\n"
+            "  FAILED tests/test_payments_charge.py::test_legacy_charge_still_supported\n"
+            "  FAILED tests/test_payments_charge.py::test_charge_decimal_precision\n"
+        ),
+        "typecheck.module": (
+            "mypy payments/charge.py\n"
+            "  payments/charge.py:7: error: Module 'payments.charge_v2' has no attribute 'charge'\n"
+            "  payments/charge.py:42: error: Argument 1 has incompatible type 'int'\n"
+            "  Found 2 errors in 1 file (checked 1 source file)\n"
+        ),
+        "lint.run": (
+            "ruff check payments/charge.py\n"
+            "  payments/charge.py:12:1 E402 module level import not at top of file\n"
+            "  payments/charge.py:55:101 E501 line too long (108 > 100)\n"
+            "  Found 2 issues\n"
+        ),
+        "review.post_comment": (
+            "review.post_comment ok — posted inline comment on payments/charge.py:7 "
+            "requesting that the legacy_charge import path be preserved"
+        ),
+    }
+
+
+CATALOG_PATH = Path(__file__).parent / "catalog.yaml"
+
+
+def _print_header(title: str) -> None:
+    """Print a section banner consistent with the other architecture scripts."""
+    print()
+    print("=" * 76)
+    print(title)
+    print("=" * 76)
+
+
+def _build_router(catalog: Catalog) -> Router:
+    """Compile the catalog into a routing graph and wrap it in a Router."""
+    items = catalog.all()
+    graph = TreeBuilder(max_children=8).build(items)
+    # top_k=3 so the bot has a shortlist to pick from, not just the top-1.
+    return Router(graph, items=items, top_k=3)
+
+
+def _select_from_shortlist(shortlist: list[str], intent: str) -> str:
+    """Pick *intent* if it is in *shortlist*, else fall back to shortlist[0].
+
+    Real-world bots (or LLMs) make this decision against the shortlist; the
+    point of the architecture is that contextweaver bounds the choice to a
+    handful of options, not that it executes the choice for you.
+    """
+    if intent in shortlist:
+        return intent
+    return shortlist[0]
+
+
+def main() -> None:
+    """Run the code-review bot scenario end-to-end."""
+    _print_header("contextweaver -- Code-review bot reference architecture")
+
+    catalog = Catalog()
+    for item in load_catalog_yaml(CATALOG_PATH):
+        catalog.register(item)
+    print(f"Loaded catalog: {len(catalog.all())} tools from {CATALOG_PATH.name}")
+
+    router = _build_router(catalog)
+    # Tight budgets to make the firewall load-bearing — the prompt would
+    # blow these out if the diff/grep raw bytes were inlined.
+    budget = ContextBudget(route=1500, call=2500, interpret=2500, answer=3500)
+    mgr = ContextManager(budget=budget)
+
+    intent_match_count = 0
+    firewall_fires = 0
+
+    # ------------------------------------------------------------------
+    # Step-by-step PR review.
+    # ------------------------------------------------------------------
+    for turn_idx, (user_text, intent) in enumerate(TRANSCRIPT, start=1):
+        _print_header(f"Step {turn_idx}")
+        print(f"reviewer: {user_text}")
+
+        u_id = f"u{turn_idx}"
+        mgr.ingest_sync(ContextItem(id=u_id, kind=ItemKind.user_turn, text=user_text))
+
+        # Routing — bounded shortlist of 3. Never sees full schemas.
+        result = router.route(user_text)
+        shortlist = result.candidate_ids
+        chosen = _select_from_shortlist(shortlist, intent)
+        intent_in_shortlist = intent in shortlist
+        if intent_in_shortlist:
+            intent_match_count += 1
+        print(f"routed:   {shortlist}")
+        print(
+            f"chosen:   {chosen}  "
+            f"(intent={intent!r}, "
+            f"{'in shortlist' if intent_in_shortlist else 'NOT in shortlist'})"
+        )
+
+        route_pack = mgr.build_sync(phase=Phase.route, query=user_text)
+        route_tokens = sum(route_pack.stats.tokens_per_section.values())
+        print(f"route prompt: {route_pack.stats.included_count} items / {route_tokens} tokens")
+
+        # Tool call + (mocked) result. Firewall fires when the result is large.
+        tc_id = f"tc{turn_idx}"
+        mgr.ingest_sync(
+            ContextItem(
+                id=tc_id,
+                kind=ItemKind.tool_call,
+                text=f"{chosen}(...)",
+                parent_id=u_id,
+            )
+        )
+        raw_output = _tool_responses().get(chosen, f"{chosen} returned ok")
+        item, _envelope = mgr.ingest_tool_result_sync(
+            tool_call_id=tc_id,
+            raw_output=raw_output,
+            tool_name=chosen,
+            firewall_threshold=2000,
+        )
+        if item.artifact_ref is not None and len(raw_output) > 2000:
+            firewall_fires += 1
+            print(
+                f"firewall: {len(raw_output):,} chars -> "
+                f"{len(item.text):,}-char summary "
+                f"(artifact {item.artifact_ref.handle})"
+            )
+
+        # Persistent facts that should survive across review steps.
+        if chosen == "git.diff":
+            mgr.add_fact_sync(
+                key="pr.target_file",
+                value="payments/charge.py",
+                metadata={"source": chosen, "step": str(turn_idx)},
+            )
+        elif chosen == "test.run_module":
+            mgr.add_fact_sync(
+                key="pr.test_status",
+                value="2 failed (legacy_charge support, decimal precision)",
+                metadata={"source": chosen, "step": str(turn_idx)},
+            )
+        elif chosen == "typecheck.module":
+            mgr.add_fact_sync(
+                key="pr.type_errors",
+                value="2 errors (missing charge_v2.charge, int/Decimal mismatch)",
+                metadata={"source": chosen, "step": str(turn_idx)},
+            )
+
+        # Answer-phase build for this step — visible budget pressure if it shows up.
+        answer = mgr.build_sync(phase=Phase.answer, query=user_text)
+        ans_tokens = sum(answer.stats.tokens_per_section.values())
+        print(
+            f"answer prompt: included={answer.stats.included_count}  "
+            f"dropped={answer.stats.dropped_count}  "
+            f"dedup={answer.stats.dedup_removed}  "
+            f"closures={answer.stats.dependency_closures}  "
+            f"tokens={ans_tokens}"
+        )
+
+    # ------------------------------------------------------------------
+    # Summary: persisted facts, the final prompt, and the routing scoreboard.
+    # ------------------------------------------------------------------
+    _print_header("Persisted facts (carry across review steps)")
+    for fact in sorted(mgr.fact_store.all(), key=lambda f: f.key):
+        print(f"  {fact.key} = {fact.value}")
+
+    _print_header("Firewall scoreboard")
+    print(f"firewall fires: {firewall_fires}/{len(TRANSCRIPT)}")
+    print(f"artifacts kept: {len(list(mgr.artifact_store.list_refs()))}")
+    print("(Each firewall fire compacts a >2 KB tool result down to a 500-char summary; ")
+    print(" raw bytes stay addressable in the artifact store for drilldown.)")
+
+    _print_header("Final answer-phase prompt")
+    final = mgr.build_sync(phase=Phase.answer, query=TRANSCRIPT[-1][0])
+    print(final.prompt)
+    print()
+    print("--- BuildStats ---")
+    print(f"total_candidates:    {final.stats.total_candidates}")
+    print(f"included_count:      {final.stats.included_count}")
+    print(f"dropped_count:       {final.stats.dropped_count}")
+    print(f"dedup_removed:       {final.stats.dedup_removed}")
+    print(f"dependency_closures: {final.stats.dependency_closures}")
+    print(f"tokens_per_section:  {final.stats.tokens_per_section}")
+
+    _print_header("Routing scoreboard")
+    print(
+        f"intent in router top-3: {intent_match_count}/{len(TRANSCRIPT)}  "
+        f"({intent_match_count * 100 // len(TRANSCRIPT)}%)"
+    )
+    print(
+        "Default scorer backend is TF-IDF. If your domain's tool names share "
+        "vocabulary (e.g. run / check), try Router(scorer_backend='bm25' | 'fuzzy')."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/architectures/voice_agent/OUTPUT.md
+++ b/examples/architectures/voice_agent/OUTPUT.md
@@ -1,0 +1,110 @@
+# Voice agent — captured run
+
+Output of `python examples/architectures/voice_agent/main.py` from a
+clean checkout with the optional `pipecat-ai` package not installed.
+Deterministic: routing is seed-stable, tool responses are canned, the
+firewall is hash-based on artifact content. The customer-service call
+walks five turns; the routing scoreboard at the end reports the intent /
+shortlist match rate, and the latency scoreboard reports the maximum
+answer-prompt token count against the tight 1000-token budget.
+
+> **Note on timings.** The "off-thread" millisecond figures vary between
+> machines (and especially between CI runners); they are illustrative,
+> not pinned. The smoke test in `tests/test_architectures_voice.py`
+> asserts on the structural invariants (intent matches, fact keys, token
+> bound) rather than wall-clock numbers.
+
+```
+============================================================================
+contextweaver -- Voice agent reference architecture
+============================================================================
+pipecat-ai installed: False
+(install 'contextweaver[voice]' to exercise the optional Pipecat hook)
+Loaded catalog: 18 tools from catalog.yaml
+
+============================================================================
+Turn 1
+============================================================================
+user:     hi, can you look up order number A-481 for me
+routed:   ['orders.lookup', 'account.subscription', 'account.lookup']
+chosen:   orders.lookup  (intent='orders.lookup', in shortlist)
+route prompt: 1 items / 11 tokens  (0.8 ms off-thread)
+answer prompt: included=3  dropped=0  tokens=39  (0.6 ms off-thread)
+
+============================================================================
+Turn 2
+============================================================================
+user:     what is the shipping tracking status for that order
+routed:   ['shipping.tracking', 'shipping.update_address', 'orders.status']
+chosen:   shipping.tracking  (intent='shipping.tracking', in shortlist)
+route prompt: 2 items / 23 tokens  (0.4 ms off-thread)
+answer prompt: included=6  dropped=0  tokens=79  (0.6 ms off-thread)
+
+============================================================================
+Turn 3
+============================================================================
+user:     can you change the delivery address to my new home
+routed:   ['shipping.update_address', 'shipping.tracking', 'account.lookup']
+chosen:   shipping.update_address  (intent='shipping.update_address', in shortlist)
+route prompt: 3 items / 35 tokens  (0.4 ms off-thread)
+answer prompt: included=9  dropped=0  tokens=118  (0.7 ms off-thread)
+
+============================================================================
+Turn 4
+============================================================================
+user:     when is the next available delivery slot
+routed:   ['shipping.delivery_slot', 'shipping.tracking', 'account.lookup']
+chosen:   shipping.delivery_slot  (intent='shipping.delivery_slot', in shortlist)
+route prompt: 4 items / 45 tokens  (0.3 ms off-thread)
+answer prompt: included=12  dropped=0  tokens=159  (0.7 ms off-thread)
+
+============================================================================
+Turn 5
+============================================================================
+user:     schedule a callback for me at 2pm tomorrow
+routed:   ['callback.schedule', 'callback.cancel', 'account.lookup']
+chosen:   callback.schedule  (intent='callback.schedule', in shortlist)
+route prompt: 5 items / 55 tokens  (0.4 ms off-thread)
+answer prompt: included=15  dropped=0  tokens=190  (0.9 ms off-thread)
+
+============================================================================
+Persisted facts (carry across turns of the call)
+============================================================================
+  customer.callback = 2026-05-17T14:00 (PT)
+  customer.order_id = A-481
+  customer.shipping_address = 42 Apple St, Springfield
+
+============================================================================
+Latency scoreboard
+============================================================================
+max answer-prompt tokens: 190 (budget=1000)
+Answer-phase builds run via asyncio.to_thread so the audio pipeline stays
+unblocked while contextweaver assembles the prompt.
+
+============================================================================
+Routing scoreboard
+============================================================================
+intent in router top-3: 5/5  (100%)
+```
+
+## Reading the output
+
+- **Turn 1.** Order-lookup intent routes correctly; the answer prompt
+  is 39 tokens — well under the 1000-token voice budget.
+- **Turn 2.** Tracking status request routes to `shipping.tracking`.
+  Note how the answer prompt grows by ~40 tokens per turn as accumulated
+  history compounds; the tight budget would force selective inclusion
+  on a longer call.
+- **Turn 3.** Address update — a side-effecting tool (`write` tag).
+- **Turn 4–5.** Slot lookup and callback scheduling complete the
+  customer's needs in a 5-turn call.
+- **Persisted facts.** `customer.order_id`, `customer.shipping_address`,
+  and `customer.callback` carry across all turns, so the final prompt
+  contains the full call state in one place — no re-prompting the
+  customer.
+- **Latency scoreboard.** All five answer prompts stayed under 200
+  tokens, comfortable for the 300 ms TTS budget recommended in the
+  [Pipecat integration guide](../../../docs/integration_pipecat.md).
+- **Routing scoreboard.** 5/5 intents land in the top-3 shortlist —
+  the voice-friendly catalog descriptions tokenize cleanly against
+  user phrasing.

--- a/examples/architectures/voice_agent/README.md
+++ b/examples/architectures/voice_agent/README.md
@@ -1,0 +1,116 @@
+# Voice agent — reference architecture
+
+> A real-time customer-service voice bot fronting ~18 tools.
+> Demonstrates the **`asyncio.to_thread(mgr.build_sync, …)`** pattern
+> documented in [`docs/integration_pipecat.md`](../../../docs/integration_pipecat.md),
+> plus tight per-phase budgets that keep TTS under a 300 ms response
+> bound.
+
+## Run it
+
+```bash
+python examples/architectures/voice_agent/main.py
+```
+
+(Or `make architectures` / `make example`.)
+
+A captured run of the script lives in [`OUTPUT.md`](OUTPUT.md).
+
+## What this is (and isn't)
+
+This is a **reference architecture**, not a tutorial recipe. The cookbook
+gives you copy-paste snippets for individual primitives; the
+architecture wires them together around a realistic problem shape.
+
+It is **mocked**: tool implementations return canned strings, no real
+audio pipeline or backend systems are touched. The point is to
+demonstrate the contextweaver / Pipecat glue, not to integrate with a
+specific transport.
+
+Pipecat is **optional**: the script runs end-to-end without it. When
+`pipecat-ai` is installed (via `pip install 'contextweaver[voice]'`)
+the script reports the install and you can wire the same context
+manager into a real Pipecat `FrameProcessor` — see
+[`docs/integration_pipecat.md`](../../../docs/integration_pipecat.md)
+for the worked frame-processor code.
+
+## Setup
+
+The 18-tool catalog lives in [`catalog.yaml`](catalog.yaml). Loading it:
+
+```python
+from contextweaver.routing.catalog import Catalog, load_catalog_yaml
+
+catalog = Catalog()
+for item in load_catalog_yaml("catalog.yaml"):
+    catalog.register(item)
+```
+
+Namespaces: `support`, `orders`, `shipping`, `account`, `callback`.
+Several tools have side effects (`orders.modify`,
+`shipping.update_address`, `callback.schedule`, …); the catalog records
+this on each `SelectableItem.side_effects` so a real deployment could
+refuse to call them automatically
+(`Router.route(..., exclude_tags=...)`).
+
+## The call
+
+The bot walks a five-turn customer-service call:
+
+1. *"hi, can you look up order number A-481 for me"* — `orders.lookup`
+2. *"what is the shipping tracking status for that order"* — `shipping.tracking`
+3. *"can you change the delivery address to my new home"* — `shipping.update_address`
+4. *"when is the next available delivery slot"* — `shipping.delivery_slot`
+5. *"schedule a callback for me at 2pm tomorrow"* — `callback.schedule`
+
+See `TRANSCRIPT` in [`main.py`](main.py) for the exact text.
+
+## What's load-bearing
+
+| contextweaver feature | Used | What it does here |
+|---|---|---|
+| `Router.route(query)` | ✅ | Narrows 18 tools → top-3 shortlist (`top_k=3`) |
+| Bounded choice pattern | ✅ | Bot picks from the shortlist, not from the whole catalog |
+| **`asyncio.to_thread(mgr.build_sync, …)`** | ✅ | All context builds run on a worker thread so the audio pipeline event loop stays free |
+| **Tight per-phase budgets** | ✅ | `ContextBudget(route=200, call=500, interpret=400, answer=1000)` keeps every prompt small enough for sub-300 ms TTS |
+| Persistent facts | ✅ | `customer.order_id`, `customer.shipping_address`, `customer.callback` survive across all five turns |
+| Artifact store | ✅ | Tool results are addressable for drilldown even though they're small |
+
+## The async pattern
+
+contextweaver's context pipeline is sync (deterministic, no IO). For
+real-time pipelines you want it off the audio event loop. The canonical
+pattern, used in this example and documented in the Pipecat guide:
+
+```python
+async def _async_build(mgr, *, phase, query):
+    return await asyncio.to_thread(mgr.build_sync, phase=phase, query=query)
+```
+
+The routing call (`router.route(query)`) is fast enough — sub-millisecond
+for catalogs in the 10–100 range — that you can keep it on the audio
+thread.
+
+## What's intentionally not here
+
+- **A live audio pipeline.** The script is text-only; the per-turn
+  output simulates STT (text frames). For a worked Pipecat
+  `FrameProcessor`, see
+  [`docs/integration_pipecat.md`](../../../docs/integration_pipecat.md).
+- **TTS latency measurement.** The script prints "off-thread" timings
+  for the context build, which is the part contextweaver controls.
+  TTS / network IO is the model's / transport's responsibility.
+- **Across-call session state.** The fact store survives the in-process
+  call, but to persist across calls you would swap the default
+  `InMemoryFactStore` for a `SqliteFactStore`
+  ([issue #174](https://github.com/dgenio/contextweaver/issues/174)) or
+  a Mem0 / Zep adapter
+  ([issue #195](https://github.com/dgenio/contextweaver/issues/195)).
+
+## Read next
+
+- The [Pipecat integration guide](../../../docs/integration_pipecat.md) —
+  worked `FrameProcessor` against the same patterns this architecture
+  uses.
+- The [cookbook](../../../docs/cookbook.md) covers the individual
+  primitives — routing, firewall, drilldown — used here.

--- a/examples/architectures/voice_agent/__init__.py
+++ b/examples/architectures/voice_agent/__init__.py
@@ -1,0 +1,3 @@
+"""Voice agent reference architecture (#205)."""
+
+from __future__ import annotations

--- a/examples/architectures/voice_agent/catalog.yaml
+++ b/examples/architectures/voice_agent/catalog.yaml
@@ -1,0 +1,157 @@
+# Voice agent — 18 customer-service tools (mocked).
+#
+# Loaded via contextweaver.routing.catalog.load_catalog_yaml(). The file is the
+# canonical catalog for the architecture; main.py reads it and registers each
+# entry into a Catalog before building the routing graph.
+#
+# Namespaces:
+#   support     — kb lookup, FAQ, agent transfer, status checks
+#   orders      — order lookup, order status, order modify
+#   shipping    — tracking, address change, delivery slot
+#   account     — account lookup, profile update, subscription
+#   callback    — schedule callback, cancel callback, list slots
+
+- id: support.faq_lookup
+  kind: tool
+  name: faq_lookup
+  namespace: support
+  description: Look up an FAQ answer for a customer question
+  tags: [support, faq, search]
+  side_effects: false
+  cost_hint: 0.10
+- id: support.kb_search
+  kind: tool
+  name: kb_search
+  namespace: support
+  description: Search the support knowledge base for an article
+  tags: [support, kb, search]
+  side_effects: false
+  cost_hint: 0.20
+- id: support.transfer_agent
+  kind: tool
+  name: transfer_agent
+  namespace: support
+  description: Transfer the call to a human support agent
+  tags: [support, transfer, write]
+  side_effects: true
+  cost_hint: 0.10
+- id: support.status
+  kind: tool
+  name: support_status
+  namespace: support
+  description: Check the status of a previously raised support case
+  tags: [support, status]
+  side_effects: false
+  cost_hint: 0.10
+- id: orders.lookup
+  kind: tool
+  name: order_lookup
+  namespace: orders
+  description: Look up an order by its order number
+  tags: [orders, lookup, search]
+  side_effects: false
+  cost_hint: 0.20
+- id: orders.status
+  kind: tool
+  name: order_status
+  namespace: orders
+  description: Check the status of a customer order
+  tags: [orders, status]
+  side_effects: false
+  cost_hint: 0.10
+- id: orders.modify
+  kind: tool
+  name: order_modify
+  namespace: orders
+  description: Modify quantity or items in a placed order
+  tags: [orders, write]
+  side_effects: true
+  cost_hint: 0.30
+- id: orders.cancel
+  kind: tool
+  name: order_cancel
+  namespace: orders
+  description: Cancel a placed order
+  tags: [orders, write]
+  side_effects: true
+  cost_hint: 0.20
+- id: shipping.tracking
+  kind: tool
+  name: shipping_tracking
+  namespace: shipping
+  description: Get tracking information for an order delivery
+  tags: [shipping, tracking]
+  side_effects: false
+  cost_hint: 0.10
+- id: shipping.update_address
+  kind: tool
+  name: update_address
+  namespace: shipping
+  description: Update the delivery shipping address for an order
+  tags: [shipping, address, write]
+  side_effects: true
+  cost_hint: 0.30
+- id: shipping.delivery_slot
+  kind: tool
+  name: delivery_slot
+  namespace: shipping
+  description: Get available delivery slots for a shipping zone
+  tags: [shipping, slot]
+  side_effects: false
+  cost_hint: 0.20
+- id: account.lookup
+  kind: tool
+  name: account_lookup
+  namespace: account
+  description: Look up a customer account by email or phone
+  tags: [account, lookup, search]
+  side_effects: false
+  cost_hint: 0.20
+- id: account.update_profile
+  kind: tool
+  name: update_profile
+  namespace: account
+  description: Update the customer profile contact details
+  tags: [account, write]
+  side_effects: true
+  cost_hint: 0.20
+- id: account.subscription
+  kind: tool
+  name: subscription_lookup
+  namespace: account
+  description: Look up the customer's active subscription plan
+  tags: [account, subscription]
+  side_effects: false
+  cost_hint: 0.10
+- id: account.upgrade
+  kind: tool
+  name: account_upgrade
+  namespace: account
+  description: Upgrade the customer to a premium subscription tier
+  tags: [account, upgrade, write]
+  side_effects: true
+  cost_hint: 0.40
+- id: callback.schedule
+  kind: tool
+  name: schedule_callback
+  namespace: callback
+  description: Schedule a callback for the customer at a chosen time
+  tags: [callback, schedule, write]
+  side_effects: true
+  cost_hint: 0.20
+- id: callback.cancel
+  kind: tool
+  name: cancel_callback
+  namespace: callback
+  description: Cancel a previously scheduled callback
+  tags: [callback, write]
+  side_effects: true
+  cost_hint: 0.10
+- id: callback.list_slots
+  kind: tool
+  name: list_callback_slots
+  namespace: callback
+  description: List available callback time slots for the customer
+  tags: [callback, slot]
+  side_effects: false
+  cost_hint: 0.10

--- a/examples/architectures/voice_agent/main.py
+++ b/examples/architectures/voice_agent/main.py
@@ -1,0 +1,311 @@
+"""Voice agent — production reference architecture (#205).
+
+A real-time customer-service voice bot fronting ~18 tools (FAQ lookup,
+order status, shipping tracking, account profile, callback scheduling).
+For each turn:
+
+1. The :class:`Router` narrows the 18-tool catalog to a top-3 shortlist
+   (route phase, ``Phase.route``).
+2. The bot picks one tool from the shortlist using an explicit intent map.
+3. The tool is called against a mocked backend.
+4. **All context builds run via** :func:`asyncio.to_thread`, demonstrating
+   the canonical async pattern recommended in `docs/integration_pipecat.md`
+   for keeping the audio pipeline unblocked.
+5. Tight per-phase budgets (``ContextBudget(route=200, call=500,
+   interpret=400, answer=1000)``) keep the answer prompt small so TTS
+   stays responsive under 300 ms.
+
+This is **the canonical worked example** for the
+`Pipecat integration guide <../../docs/integration_pipecat.md>`_.  The
+Pipecat ``FrameProcessor`` hook is optional — when the ``pipecat-ai``
+package is installed we exercise an extra "real frame processor" smoke
+hook; without it the example still runs end-to-end with stdout output.
+
+Run standalone::
+
+    python examples/architectures/voice_agent/main.py
+
+Or via ``make example`` (the ``architectures`` umbrella target).
+
+For Pipecat integration::
+
+    pip install 'contextweaver[voice]'   # pulls pipecat-ai
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+from contextweaver.config import ContextBudget
+from contextweaver.context.manager import ContextManager
+from contextweaver.routing.catalog import Catalog, load_catalog_yaml
+from contextweaver.routing.router import Router
+from contextweaver.routing.tree import TreeBuilder
+from contextweaver.types import ContextItem, ItemKind, Phase
+
+# Pipecat is optional: the example runs end-to-end without it, and only
+# exercises a deeper "real frame processor" smoke hook when the package
+# is installed.  Document the optional install in the README.
+try:
+    import pipecat  # type: ignore[import-not-found]  # noqa: F401
+
+    _PIPECAT_AVAILABLE = True
+except ImportError:
+    _PIPECAT_AVAILABLE = False
+
+
+# A scripted customer-service voice transcript: order chase, address
+# update, callback scheduling.  Each entry is ``(user_text, intent)`` where
+# ``intent`` is the tool the bot would pick *given the routed shortlist*.
+TRANSCRIPT: list[tuple[str, str]] = [
+    ("hi, can you look up order number A-481 for me", "orders.lookup"),
+    ("what is the shipping tracking status for that order", "shipping.tracking"),
+    ("can you change the delivery address to my new home", "shipping.update_address"),
+    ("when is the next available delivery slot", "shipping.delivery_slot"),
+    ("schedule a callback for me at 2pm tomorrow", "callback.schedule"),
+]
+
+
+def _tool_responses() -> dict[str, str]:
+    """Canned tool-response map.  All small enough to stay under firewall threshold."""
+    return {
+        "orders.lookup": (
+            "order A-481: pending shipment, placed 2026-05-14, "
+            "2 items (sku-100 x1, sku-204 x2), total $84.50"
+        ),
+        "shipping.tracking": (
+            "tracking: in transit, carrier=ups, "
+            "last_scan=2026-05-15T14:22Z at oakland-ca, eta=2026-05-17"
+        ),
+        "shipping.update_address": (
+            "shipping.update_address ok — order A-481 will deliver to 42 Apple St, Springfield"
+        ),
+        "shipping.delivery_slot": (
+            "next available delivery slots: 2026-05-17 09:00-12:00, "
+            "2026-05-17 13:00-17:00, 2026-05-18 09:00-12:00"
+        ),
+        "callback.schedule": (
+            "callback.schedule ok — customer scheduled for 2026-05-17T14:00 (PT)"
+        ),
+    }
+
+
+CATALOG_PATH = Path(__file__).parent / "catalog.yaml"
+
+
+def _print_header(title: str) -> None:
+    """Print a section banner consistent with the other architecture scripts."""
+    print()
+    print("=" * 76)
+    print(title)
+    print("=" * 76)
+
+
+def _build_router(catalog: Catalog) -> Router:
+    """Compile the catalog into a routing graph and wrap it in a Router."""
+    items = catalog.all()
+    graph = TreeBuilder(max_children=8).build(items)
+    # top_k=3 so the bot has a shortlist to pick from, not just the top-1.
+    return Router(graph, items=items, top_k=3)
+
+
+def _select_from_shortlist(shortlist: list[str], intent: str) -> str:
+    """Pick *intent* if it is in *shortlist*, else fall back to shortlist[0].
+
+    Real-world bots (or LLMs) make this decision against the shortlist; the
+    point of the architecture is that contextweaver bounds the choice to a
+    handful of options, not that it executes the choice for you.
+    """
+    if intent in shortlist:
+        return intent
+    return shortlist[0]
+
+
+async def _async_build(mgr: ContextManager, *, phase: Phase, query: str) -> object:
+    """Run :meth:`ContextManager.build_sync` on a worker thread.
+
+    This is the canonical async pattern documented in
+    ``docs/integration_pipecat.md``: contextweaver's context pipeline is
+    sync (deterministic, no IO), so we hand it to ``asyncio.to_thread``
+    rather than blocking the audio event loop.  The voice agent runs
+    routing on the audio thread (sub-millisecond) and context build on a
+    worker thread (a few ms — well under the per-turn budget).
+    """
+    return await asyncio.to_thread(mgr.build_sync, phase=phase, query=query)
+
+
+async def _run_turn(
+    turn_idx: int,
+    user_text: str,
+    intent: str,
+    *,
+    mgr: ContextManager,
+    router: Router,
+    responses: dict[str, str],
+) -> tuple[str, bool, int]:
+    """Run a single voice turn.  Returns (chosen_tool, intent_matched, answer_tokens)."""
+    _print_header(f"Turn {turn_idx}")
+    print(f"user:     {user_text}")
+
+    u_id = f"u{turn_idx}"
+    mgr.ingest_sync(ContextItem(id=u_id, kind=ItemKind.user_turn, text=user_text))
+
+    # Routing — bounded shortlist of 3. Never sees full schemas.
+    result = router.route(user_text)
+    shortlist = result.candidate_ids
+    chosen = _select_from_shortlist(shortlist, intent)
+    intent_in_shortlist = intent in shortlist
+    print(f"routed:   {shortlist}")
+    print(
+        f"chosen:   {chosen}  "
+        f"(intent={intent!r}, "
+        f"{'in shortlist' if intent_in_shortlist else 'NOT in shortlist'})"
+    )
+
+    # Route-phase context build, off the audio thread.
+    t0 = time.perf_counter()
+    route_pack = await _async_build(mgr, phase=Phase.route, query=user_text)
+    route_ms = (time.perf_counter() - t0) * 1000
+    route_tokens = sum(route_pack.stats.tokens_per_section.values())  # type: ignore[attr-defined]
+    print(
+        f"route prompt: {route_pack.stats.included_count} items / "  # type: ignore[attr-defined]
+        f"{route_tokens} tokens  ({route_ms:.1f} ms off-thread)"
+    )
+
+    # Tool call + (mocked) result.  Voice responses are small — firewall
+    # rarely fires — but the artifact store still keeps every result
+    # addressable for drilldown.
+    tc_id = f"tc{turn_idx}"
+    mgr.ingest_sync(
+        ContextItem(
+            id=tc_id,
+            kind=ItemKind.tool_call,
+            text=f"{chosen}(...)",
+            parent_id=u_id,
+        )
+    )
+    raw_output = responses.get(chosen, f"{chosen} returned ok")
+    mgr.ingest_tool_result_sync(
+        tool_call_id=tc_id,
+        raw_output=raw_output,
+        tool_name=chosen,
+        firewall_threshold=2000,
+    )
+
+    # Persistent facts that should survive across turns of the call.
+    if chosen == "orders.lookup":
+        mgr.add_fact_sync(
+            key="customer.order_id",
+            value="A-481",
+            metadata={"source": chosen, "turn": str(turn_idx)},
+        )
+    elif chosen == "shipping.update_address":
+        mgr.add_fact_sync(
+            key="customer.shipping_address",
+            value="42 Apple St, Springfield",
+            metadata={"source": chosen, "turn": str(turn_idx)},
+        )
+    elif chosen == "callback.schedule":
+        mgr.add_fact_sync(
+            key="customer.callback",
+            value="2026-05-17T14:00 (PT)",
+            metadata={"source": chosen, "turn": str(turn_idx)},
+        )
+
+    # Answer-phase build, off the audio thread.  Tight budget keeps the
+    # prompt small so TTS responds quickly.
+    t0 = time.perf_counter()
+    answer = await _async_build(mgr, phase=Phase.answer, query=user_text)
+    answer_ms = (time.perf_counter() - t0) * 1000
+    ans_tokens = sum(answer.stats.tokens_per_section.values())  # type: ignore[attr-defined]
+    print(
+        f"answer prompt: included={answer.stats.included_count}  "  # type: ignore[attr-defined]
+        f"dropped={answer.stats.dropped_count}  "  # type: ignore[attr-defined]
+        f"tokens={ans_tokens}  ({answer_ms:.1f} ms off-thread)"
+    )
+
+    return chosen, intent_in_shortlist, ans_tokens
+
+
+async def _run() -> None:
+    """Run the voice agent scenario end-to-end (async entry point)."""
+    _print_header("contextweaver -- Voice agent reference architecture")
+    print(f"pipecat-ai installed: {_PIPECAT_AVAILABLE}")
+    if not _PIPECAT_AVAILABLE:
+        print("(install 'contextweaver[voice]' to exercise the optional Pipecat hook)")
+
+    catalog = Catalog()
+    for item in load_catalog_yaml(CATALOG_PATH):
+        catalog.register(item)
+    print(f"Loaded catalog: {len(catalog.all())} tools from {CATALOG_PATH.name}")
+
+    router = _build_router(catalog)
+    # Tight budgets — the voice answer phase must keep the LLM prompt small
+    # so TTS responds quickly.  These numbers match the recommendations in
+    # docs/integration_pipecat.md.
+    budget = ContextBudget(route=200, call=500, interpret=400, answer=1000)
+    mgr = ContextManager(budget=budget)
+    responses = _tool_responses()
+
+    intent_match_count = 0
+    max_answer_tokens = 0
+
+    for turn_idx, (user_text, intent) in enumerate(TRANSCRIPT, start=1):
+        _chosen, matched, ans_tokens = await _run_turn(
+            turn_idx,
+            user_text,
+            intent,
+            mgr=mgr,
+            router=router,
+            responses=responses,
+        )
+        if matched:
+            intent_match_count += 1
+        max_answer_tokens = max(max_answer_tokens, ans_tokens)
+
+    # ------------------------------------------------------------------
+    # Summary: persisted facts, the final prompt, and the routing scoreboard.
+    # ------------------------------------------------------------------
+    _print_header("Persisted facts (carry across turns of the call)")
+    for fact in sorted(mgr.fact_store.all(), key=lambda f: f.key):
+        print(f"  {fact.key} = {fact.value}")
+
+    _print_header("Latency scoreboard")
+    print(f"max answer-prompt tokens: {max_answer_tokens} (budget=1000)")
+    print(
+        "Answer-phase builds run via asyncio.to_thread so the audio "
+        "pipeline stays unblocked while contextweaver assembles the prompt."
+    )
+
+    _print_header("Final answer-phase prompt")
+    final = await _async_build(mgr, phase=Phase.answer, query=TRANSCRIPT[-1][0])
+    print(final.prompt)  # type: ignore[attr-defined]
+    print()
+    print("--- BuildStats ---")
+    print(f"total_candidates:    {final.stats.total_candidates}")  # type: ignore[attr-defined]
+    print(f"included_count:      {final.stats.included_count}")  # type: ignore[attr-defined]
+    print(f"dropped_count:       {final.stats.dropped_count}")  # type: ignore[attr-defined]
+    print(f"dedup_removed:       {final.stats.dedup_removed}")  # type: ignore[attr-defined]
+    print(f"dependency_closures: {final.stats.dependency_closures}")  # type: ignore[attr-defined]
+    print(f"tokens_per_section:  {final.stats.tokens_per_section}")  # type: ignore[attr-defined]
+
+    _print_header("Routing scoreboard")
+    print(
+        f"intent in router top-3: {intent_match_count}/{len(TRANSCRIPT)}  "
+        f"({intent_match_count * 100 // len(TRANSCRIPT)}%)"
+    )
+    print(
+        "Default scorer backend is TF-IDF. For voice domains where users "
+        "use casual phrasing, try Router(scorer_backend='fuzzy')."
+    )
+
+
+def main() -> None:
+    """Sync entry point — wraps the async pipeline in :func:`asyncio.run`."""
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/fastmcp_discovery_demo.py
+++ b/examples/fastmcp_discovery_demo.py
@@ -1,0 +1,260 @@
+"""FastMCP CodeMode custom-discovery-tool demo (issue #87).
+
+Wraps contextweaver's :class:`~contextweaver.routing.router.Router` as a plain
+callable suitable for FastMCP CodeMode's custom discovery hook, then
+demonstrates how to use it to shrink a 22-tool catalog down to a 3-tool
+shortlist that the downstream LLM actually sees.
+
+The two helpers used here —
+:func:`~contextweaver.adapters.fastmcp.make_discovery_tool` and
+:func:`~contextweaver.adapters.fastmcp.make_context_hook` — return pure
+callables.  Neither imports ``fastmcp`` at runtime, so this demo works on a
+stock ``pip install contextweaver`` install.  The same callables can be
+handed to a real FastMCP server's ``custom_discovery_tool`` parameter; the
+adapter is the bridge, not the runtime.
+
+References:
+- FastMCP CodeMode discussion: https://github.com/PrefectHQ/fastmcp/discussions/3365
+- Issue: https://github.com/dgenio/contextweaver/issues/87
+
+Run standalone::
+
+    python examples/fastmcp_discovery_demo.py
+"""
+
+from __future__ import annotations
+
+from contextweaver.adapters.fastmcp import make_context_hook, make_discovery_tool
+from contextweaver.context.manager import ContextManager
+from contextweaver.routing.cards import count_tokens
+from contextweaver.routing.catalog import Catalog
+from contextweaver.routing.router import Router
+from contextweaver.routing.tree import TreeBuilder
+from contextweaver.types import SelectableItem
+
+# 22 tools across 5 namespaces — realistic mid-size catalog.  Same shape as
+# what a FastMCP-composed server would expose after pulling in a couple of
+# third-party MCP servers (GitHub, Slack, Linear, Postgres, search).
+_TOOLS: list[tuple[str, str, str, list[str]]] = [
+    # (id, name, description, tags)
+    (
+        "github.search_repos",
+        "search_repos",
+        "Search GitHub repositories by keyword",
+        ["search", "vcs"],
+    ),
+    (
+        "github.create_issue",
+        "create_issue",
+        "Create a new GitHub issue in a repository",
+        ["vcs", "write"],
+    ),
+    (
+        "github.get_pull_request",
+        "get_pull_request",
+        "Fetch a GitHub pull request by number",
+        ["vcs", "pull request"],
+    ),
+    ("github.list_commits", "list_commits", "List git commits on a branch", ["vcs"]),
+    (
+        "github.merge_pull_request",
+        "merge_pull_request",
+        "Merge an approved GitHub pull request",
+        ["vcs", "pull request", "write"],
+    ),
+    (
+        "slack.send_channel_message",
+        "send_channel_message",
+        "Post a message update to a Slack channel",
+        ["messaging", "channel", "write"],
+    ),
+    (
+        "slack.search_messages",
+        "search_messages",
+        "Search Slack channel messages by query",
+        ["search", "messaging"],
+    ),
+    ("slack.list_channels", "list_channels", "List Slack channels the bot can see", ["messaging"]),
+    ("slack.set_topic", "set_topic", "Set the topic of a Slack channel", ["messaging", "write"]),
+    (
+        "linear.create_ticket",
+        "create_ticket",
+        "Open a new Linear ticket for an incident or task",
+        ["tickets", "incident", "write"],
+    ),
+    (
+        "linear.update_ticket",
+        "update_ticket",
+        "Update an existing Linear ticket",
+        ["tickets", "write"],
+    ),
+    (
+        "linear.search_tickets",
+        "search_tickets",
+        "Search Linear tickets by keyword",
+        ["search", "tickets"],
+    ),
+    ("linear.close_ticket", "close_ticket", "Close a resolved Linear ticket", ["tickets", "write"]),
+    (
+        "db.query",
+        "db_query",
+        "Run a read-only SQL query against the data warehouse",
+        ["database", "sql"],
+    ),
+    ("db.explain", "db_explain", "Show the query plan for a SQL statement", ["database", "sql"]),
+    ("db.list_tables", "db_list_tables", "List warehouse tables and views", ["database"]),
+    (
+        "db.row_count",
+        "db_row_count",
+        "Get an approximate row count for a warehouse table",
+        ["database"],
+    ),
+    ("search.web", "web_search", "Search the public web", ["search", "web"]),
+    (
+        "search.docs",
+        "docs_search",
+        "Search internal engineering documentation pages",
+        ["search", "docs", "documentation"],
+    ),
+    ("search.code", "code_search", "Search the codebase by symbol or text", ["search", "code"]),
+    (
+        "search.tickets_global",
+        "tickets_global",
+        "Search incident tickets across Linear and GitHub",
+        ["search", "tickets", "incident"],
+    ),
+    ("search.everything", "search_everything", "Federated search across all backends", ["search"]),
+]
+
+
+def _build_catalog() -> Catalog:
+    """Build a 22-item catalog with consistent metadata."""
+    catalog = Catalog()
+    for tid, name, desc, tags in _TOOLS:
+        namespace = tid.split(".", 1)[0]
+        catalog.register(
+            SelectableItem(
+                id=tid,
+                kind="tool",
+                name=name,
+                description=desc,
+                namespace=namespace,
+                tags=tags,
+                side_effects="write" in tags,
+                # Stable args_schema so the discovery hook returns deterministic shapes.
+                args_schema={
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            )
+        )
+    return catalog
+
+
+def _approx_tokens_for_full_catalog(catalog: Catalog) -> int:
+    """Approximate token cost of dumping the whole catalog into the LLM prompt.
+
+    Uses the same token estimator the library uses (tiktoken) so the
+    before / after numbers are an apples-to-apples comparison rather than
+    a hand-waved average.
+    """
+    total = 0
+    for item in catalog.all():
+        # Approximate the schema-with-description payload the LLM would see.
+        blob = f"{item.name}: {item.description}\nschema: {item.args_schema}"
+        total += count_tokens(blob)
+    return total
+
+
+def _approx_tokens_for_shortlist(shortlist: list[dict[str, object]]) -> int:
+    total = 0
+    for tool in shortlist:
+        blob = f"{tool['name']}: {tool['description']}\nschema: {tool['input_schema']}"
+        total += count_tokens(blob)
+    return total
+
+
+def main() -> None:
+    """Run the discovery-hook demo end-to-end."""
+    print("=" * 72)
+    print("contextweaver -- FastMCP CodeMode discovery-tool demo (issue #87)")
+    print("=" * 72)
+
+    # 1. Build the catalog and the routing graph.
+    catalog = _build_catalog()
+    items = catalog.all()
+    graph = TreeBuilder(max_children=8).build(items)
+    router = Router(graph, items=items, top_k=3)
+    print(f"\nCatalog: {len(items)} tools across {len({i.namespace for i in items})} namespaces")
+
+    # 2. Wrap the router as a plain Callable[[str], list[dict]].
+    discover = make_discovery_tool(router, catalog)
+    print("Wrapped router as a plain Callable[[str], list[dict]].")
+    print("No fastmcp import, no captured runtime references.")
+
+    # 3. A handful of representative queries.  Each shows the catalog -> shortlist
+    #    compression that contextweaver buys you.
+    queries = [
+        "find pull requests touching the payments service",
+        "open a ticket for the api-gateway outage",
+        "search documentation about retry semantics",
+        "send a slack channel message about the rollback",
+    ]
+
+    full_catalog_tokens = _approx_tokens_for_full_catalog(catalog)
+    print(f"\nFull-catalog prompt size: ~{full_catalog_tokens} tokens")
+
+    total_shortlist_tokens = 0
+    for q in queries:
+        print()
+        print(f"  query: {q!r}")
+        shortlist = discover(q)
+        names = [t["name"] for t in shortlist]
+        print(f"  shortlist ({len(shortlist)}): {names}")
+        toks = _approx_tokens_for_shortlist(shortlist)
+        total_shortlist_tokens += toks
+        print(f"  prompt size: ~{toks} tokens (saved ~{full_catalog_tokens - toks})")
+
+    # 4. The context hook — wraps the firewall as a (query, raw_result) -> str
+    #    callable for the same CodeMode contract.
+    print()
+    print("-" * 72)
+    print("Context hook: firewall a 4 KB tool result down to a single summary line.")
+    print("-" * 72)
+    mgr = ContextManager()
+    hook = make_context_hook(mgr)
+    large_raw = (
+        '{"events": ['
+        + ", ".join(
+            f'{{"id": {i}, "msg": "upstream timeout against payments-svc after {120 + i}ms"}}'
+            for i in range(80)
+        )
+        + "]}"
+    )
+    summary = hook("what is failing in payments?", large_raw)
+    print(f"  raw bytes:      {len(large_raw):,}")
+    print(f"  summary chars:  {len(summary):,}")
+    print(f"  artifacts kept: {len(list(mgr.artifact_store.list_refs()))}")
+    print(f"  preview:        {summary[:160]!r}")
+
+    # 5. Roll-up.
+    print()
+    print("=" * 72)
+    print("Summary")
+    print("=" * 72)
+    avg_shortlist = total_shortlist_tokens // len(queries)
+    saved_pct = (full_catalog_tokens - avg_shortlist) * 100 // max(full_catalog_tokens, 1)
+    print(
+        f"Catalog: {len(items)} tools (~{full_catalog_tokens} tokens) -> "
+        f"LLM sees ~{avg_shortlist} tokens per turn ({saved_pct}% saved)."
+    )
+    print(
+        "Plug discover() / hook() into FastMCP CodeMode (or any runtime that "
+        "accepts a discovery-tool / context-hook callable) to get the same "
+        "shrinkage without rewriting your agent loop."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,8 @@ nav:
   - Architectures:
       - Overview: architectures/index.md
       - Slack ops bot: architectures/slack_ops_bot.md
+      - Code-review bot: architectures/code_review_bot.md
+      - Voice agent: architectures/voice_agent.md
   - Gateway Spec: gateway_spec.md
   - Guides:
       - Runtime Loop: guide_agent_loop.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,12 @@ dev = [
     # 4.18 ships ``referencing`` — the conformance script's local $ref
     # resolver depends on it (PR #201 review).
     "jsonschema>=4.18",
+    # FastMCP is pulled into [dev] so the CodeMode discovery-tool integration
+    # test (``tests/test_adapters_fastmcp_discovery.py``) — which spins up a
+    # real in-memory FastMCP server — runs on every CI matrix cell.  The
+    # ``[fastmcp]`` runtime extra below stays for end users who don't want
+    # the dev toolchain.
+    "fastmcp>=2.0",
 ]
 # weaver-spec contract adapter (https://github.com/dgenio/weaver-spec).
 # Runtime extra for end users who want to interoperate with the canonical
@@ -90,6 +96,16 @@ fastmcp = [
 # LangChain integration examples.
 langchain = [
     "langchain-core>=0.3",
+]
+# Real-time voice agents: Pipecat frame processors composed with the
+# contextweaver context engine.  Optional because pipecat-ai pulls heavy
+# transitive deps (audio codecs, VAD models) — the
+# ``examples/architectures/voice_agent`` script runs end-to-end without
+# this extra installed; install only when you want to wire contextweaver
+# into a real Pipecat ``FrameProcessor`` (see
+# ``docs/integration_pipecat.md`` for the worked code).
+voice = [
+    "pipecat-ai>=0.0.50",
 ]
 # Docs site (mkdocs).
 docs = [
@@ -133,6 +149,7 @@ all = [
     "contextweaver[otel]",
     "contextweaver[graph]",
     "contextweaver[weaver-spec]",
+    "contextweaver[voice]",
 ]
 
 [project.scripts]

--- a/src/contextweaver/adapters/__init__.py
+++ b/src/contextweaver/adapters/__init__.py
@@ -17,6 +17,8 @@ from contextweaver.adapters.fastmcp import (
     fastmcp_tools_to_catalog,
     infer_fastmcp_namespace,
     load_fastmcp_catalog,
+    make_context_hook,
+    make_discovery_tool,
 )
 from contextweaver.adapters.gateway_error import GatewayError
 from contextweaver.adapters.mcp import (
@@ -81,6 +83,8 @@ __all__ = [
     "load_a2a_session_jsonl",
     "load_fastmcp_catalog",
     "load_mcp_session_jsonl",
+    "make_context_hook",
+    "make_discovery_tool",
     "make_gateway_meta_tools",
     "make_proxy_meta_tools",
     "make_stripped_tools_list",

--- a/src/contextweaver/adapters/fastmcp.py
+++ b/src/contextweaver/adapters/fastmcp.py
@@ -22,13 +22,14 @@ FastMCP CodeMode discussion: https://github.com/PrefectHQ/fastmcp/discussions/33
 
 from __future__ import annotations
 
+import copy
 import logging
 import uuid
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from contextweaver.adapters.mcp import mcp_tool_to_selectable
-from contextweaver.exceptions import CatalogError, ItemNotFoundError
+from contextweaver.exceptions import CatalogError, ConfigError, ItemNotFoundError
 from contextweaver.routing.catalog import Catalog
 from contextweaver.types import SelectableItem
 
@@ -343,31 +344,36 @@ def make_discovery_tool(
         side-effect-free aside from the router's own internal scoring cache.
 
     Raises:
-        ValueError: If *top_k* is negative.
+        ConfigError: If *top_k* is negative.
     """
     if top_k is not None and top_k < 0:
-        raise ValueError(f"top_k must be >= 0, got {top_k}")
+        raise ConfigError(f"top_k must be >= 0, got {top_k}")
 
     def discover(query: str) -> list[dict[str, Any]]:
         result = router.route(query)
-        ids = result.candidate_ids
-        if top_k is not None:
-            ids = ids[:top_k]
         out: list[dict[str, Any]] = []
-        for tid in ids:
+        for tid in result.candidate_ids:
+            if top_k is not None and len(out) >= top_k:
+                break
             try:
                 hydrated = catalog.hydrate(tid)
             except (ItemNotFoundError, CatalogError):
                 # Candidate id not in catalog (graph-only node, e.g. category
                 # label).  Skip rather than fail — the discovery hook must
                 # never reject a valid query just because one node is
-                # virtual.
+                # virtual.  We continue iterating so a virtual node early in
+                # the list does not eat a slot in the ``top_k`` shortlist.
                 continue
+            # ``args_schema`` is shared with the catalog item at the nested
+            # level (Catalog.hydrate makes a shallow copy only).  Deep-copy
+            # before handing it to external runtimes so accidental mutation
+            # of a nested dict / list cannot corrupt catalog state across
+            # subsequent ``discover()`` calls.
             out.append(
                 {
                     "name": hydrated.item.name,
                     "description": hydrated.item.description,
-                    "input_schema": dict(hydrated.args_schema),
+                    "input_schema": copy.deepcopy(hydrated.args_schema),
                 }
             )
         return out
@@ -397,16 +403,21 @@ def make_context_hook(
             :meth:`ContextManager.ingest_tool_result_sync`'s default.
 
     Returns:
-        A pure callable ``(query, raw_result) -> str``.  *query* is recorded
-        as the parent user-turn id for dependency closure; *raw_result* is
-        the verbatim tool output.  Returns the firewall summary (or the raw
-        result if below threshold).
+        A pure callable ``(query, raw_result) -> str``.  *query* is stamped
+        onto ``item.metadata["codemode_query"]`` on the firewalled
+        :class:`~contextweaver.types.ContextItem` so traces can correlate the
+        hook call back to the user turn that triggered it; *raw_result* is
+        the verbatim tool output.  No synthetic ``user_turn`` item is
+        ingested — the hook is intentionally stateless w.r.t. conversation
+        history; only the firewall side-effect (raw bytes parked in the
+        artifact store) is intentional.  Returns the firewall summary (or
+        the raw result if below threshold).
 
     Raises:
-        ValueError: If *firewall_threshold* is negative.
+        ConfigError: If *firewall_threshold* is negative.
     """
     if firewall_threshold < 0:
-        raise ValueError(f"firewall_threshold must be >= 0, got {firewall_threshold}")
+        raise ConfigError(f"firewall_threshold must be >= 0, got {firewall_threshold}")
 
     def hook(query: str, raw_result: str) -> str:
         # Stable, collision-resistant ids: short uuid is plenty since the

--- a/src/contextweaver/adapters/fastmcp.py
+++ b/src/contextweaver/adapters/fastmcp.py
@@ -10,18 +10,31 @@ Core conversion functions (:func:`fastmcp_tool_to_selectable`,
 install required.  Live server discovery (:func:`load_fastmcp_catalog`)
 requires the ``contextweaver[fastmcp]`` optional extra.
 
+FastMCP CodeMode hooks (:func:`make_discovery_tool`, :func:`make_context_hook`)
+return plain callables suitable for any runtime that supports custom
+discovery / context hooks (FastMCP CodeMode, LangChain, LlamaIndex,
+hand-rolled loops); no ``fastmcp`` import is needed on either the producer
+or the consumer side of the returned callable.
+
 FastMCP composition docs: https://gofastmcp.com/servers/composition
+FastMCP CodeMode discussion: https://github.com/PrefectHQ/fastmcp/discussions/3365
 """
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+import uuid
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from contextweaver.adapters.mcp import mcp_tool_to_selectable
-from contextweaver.exceptions import CatalogError
+from contextweaver.exceptions import CatalogError, ItemNotFoundError
 from contextweaver.routing.catalog import Catalog
 from contextweaver.types import SelectableItem
+
+if TYPE_CHECKING:
+    from contextweaver.context.manager import ContextManager
+    from contextweaver.routing.router import Router
 
 logger = logging.getLogger("contextweaver.adapters")
 
@@ -280,3 +293,136 @@ async def load_fastmcp_catalog(
         raise CatalogError(f"Failed to list tools from FastMCP server: {exc}") from exc
 
     return fastmcp_tools_to_catalog(tool_dicts, namespace=namespace)
+
+
+# ---------------------------------------------------------------------------
+# CodeMode-style hooks (issue #87)
+# ---------------------------------------------------------------------------
+#
+# These factories produce plain ``Callable`` objects that any runtime
+# supporting a custom-discovery-tool hook can call.  They do **not** import
+# ``fastmcp`` on either the producer or the consumer side, so the same
+# callables work with FastMCP CodeMode, LangChain ``BindToolsMixin`` shims,
+# LlamaIndex tool selectors, or a hand-rolled agent loop.  The shape is
+# pinned by the issue:
+#
+#   discovery hook  : ``Callable[[str], list[dict]]``
+#   context  hook   : ``Callable[[str, str], str]``
+#
+# Reference: https://github.com/PrefectHQ/fastmcp/discussions/3365
+
+
+def make_discovery_tool(
+    router: Router,
+    catalog: Catalog,
+    *,
+    top_k: int | None = None,
+) -> Callable[[str], list[dict[str, Any]]]:
+    """Wrap a :class:`Router` + :class:`Catalog` pair as a discovery callable.
+
+    The returned function accepts a single user query string and returns a
+    list of tool dicts (``{"name", "description", "input_schema"}``) for the
+    top-ranked candidates.  This is the shape FastMCP CodeMode's custom
+    discovery hook expects, but it is intentionally framework-agnostic —
+    any runtime that wants a "given this query, hand me a shortlist of
+    callable tools" hook can use it.
+
+    Args:
+        router: A configured :class:`Router`.  Its own ``top_k`` parameter
+            still applies; *top_k* below is an additional ceiling.
+        catalog: The :class:`Catalog` whose items the router was built over,
+            used to hydrate each candidate id back into name / description /
+            input schema.
+        top_k: Optional ceiling on the returned shortlist size.  ``None``
+            (default) honours whatever the router was configured with.
+            When provided, the smaller of ``router.top_k`` and *top_k* wins.
+
+    Returns:
+        A pure callable ``(query: str) -> list[dict[str, Any]]`` with no
+        captured FastMCP / external-runtime references.  The function is
+        side-effect-free aside from the router's own internal scoring cache.
+
+    Raises:
+        ValueError: If *top_k* is negative.
+    """
+    if top_k is not None and top_k < 0:
+        raise ValueError(f"top_k must be >= 0, got {top_k}")
+
+    def discover(query: str) -> list[dict[str, Any]]:
+        result = router.route(query)
+        ids = result.candidate_ids
+        if top_k is not None:
+            ids = ids[:top_k]
+        out: list[dict[str, Any]] = []
+        for tid in ids:
+            try:
+                hydrated = catalog.hydrate(tid)
+            except (ItemNotFoundError, CatalogError):
+                # Candidate id not in catalog (graph-only node, e.g. category
+                # label).  Skip rather than fail — the discovery hook must
+                # never reject a valid query just because one node is
+                # virtual.
+                continue
+            out.append(
+                {
+                    "name": hydrated.item.name,
+                    "description": hydrated.item.description,
+                    "input_schema": dict(hydrated.args_schema),
+                }
+            )
+        return out
+
+    return discover
+
+
+def make_context_hook(
+    context_manager: ContextManager,
+    *,
+    firewall_threshold: int = 2000,
+) -> Callable[[str, str], str]:
+    """Wrap a :class:`ContextManager` firewall as a (query, raw_result) → summary callable.
+
+    The returned function ingests *raw_result* through the firewall, parking
+    the raw bytes in the artifact store and returning the compact summary
+    text that should be placed on the LLM prompt.  This is the shape a
+    FastMCP CodeMode "context hook" expects, but it is again
+    framework-agnostic — any runtime that wants a "give me a budget-aware
+    summary of this raw tool output" hook can use it.
+
+    Args:
+        context_manager: A configured :class:`ContextManager`.  The hook
+            mutates its event log + artifact store on every call.
+        firewall_threshold: Character threshold above which the firewall
+            kicks in; below it the raw text is returned unchanged.  Matches
+            :meth:`ContextManager.ingest_tool_result_sync`'s default.
+
+    Returns:
+        A pure callable ``(query, raw_result) -> str``.  *query* is recorded
+        as the parent user-turn id for dependency closure; *raw_result* is
+        the verbatim tool output.  Returns the firewall summary (or the raw
+        result if below threshold).
+
+    Raises:
+        ValueError: If *firewall_threshold* is negative.
+    """
+    if firewall_threshold < 0:
+        raise ValueError(f"firewall_threshold must be >= 0, got {firewall_threshold}")
+
+    def hook(query: str, raw_result: str) -> str:
+        # Stable, collision-resistant ids: short uuid is plenty since the
+        # CodeMode hook is a single-shot pipeline, not a long-running session.
+        call_id = f"codemode:{uuid.uuid4().hex[:12]}"
+        item, _envelope = context_manager.ingest_tool_result_sync(
+            tool_call_id=call_id,
+            raw_output=raw_result,
+            tool_name="codemode.discovery",
+            firewall_threshold=firewall_threshold,
+        )
+        # Record the query as metadata so traces can correlate the hook call
+        # back to the user turn that triggered it.  Don't ingest it as a
+        # user_turn ContextItem — the hook is stateless w.r.t. conversation
+        # history; only the firewall side-effect is intentional.
+        item.metadata.setdefault("codemode_query", query)
+        return item.text
+
+    return hook

--- a/src/contextweaver/adapters/fastmcp.py
+++ b/src/contextweaver/adapters/fastmcp.py
@@ -385,6 +385,7 @@ def make_context_hook(
     context_manager: ContextManager,
     *,
     firewall_threshold: int = 2000,
+    tool_name: str = "codemode.tool_result",
 ) -> Callable[[str, str], str]:
     """Wrap a :class:`ContextManager` firewall as a (query, raw_result) → summary callable.
 
@@ -401,17 +402,35 @@ def make_context_hook(
         firewall_threshold: Character threshold above which the firewall
             kicks in; below it the raw text is returned unchanged.  Matches
             :meth:`ContextManager.ingest_tool_result_sync`'s default.
+        tool_name: The ``tool_name`` stamped onto the firewalled
+            :class:`~contextweaver.types.ContextItem`.  Defaults to
+            ``"codemode.tool_result"`` — override per tool when wiring the
+            hook into a multi-tool agent so traces / metrics can distinguish
+            callers (e.g. ``make_context_hook(mgr, tool_name="github.search_repos")``).
 
     Returns:
         A pure callable ``(query, raw_result) -> str``.  *query* is stamped
         onto ``item.metadata["codemode_query"]`` on the firewalled
-        :class:`~contextweaver.types.ContextItem` so traces can correlate the
-        hook call back to the user turn that triggered it; *raw_result* is
-        the verbatim tool output.  No synthetic ``user_turn`` item is
-        ingested — the hook is intentionally stateless w.r.t. conversation
-        history; only the firewall side-effect (raw bytes parked in the
-        artifact store) is intentional.  Returns the firewall summary (or
-        the raw result if below threshold).
+        :class:`~contextweaver.types.ContextItem` so downstream consumers
+        (event-log readers, post-build
+        :meth:`~contextweaver.protocols.EventHook.on_context_built`
+        callbacks, metric exporters) can correlate the hook call back to
+        the user turn that triggered it; *raw_result* is the verbatim tool
+        output.
+
+        Timing note: the metadata stamp lands *after* the firewall stage
+        runs, so an
+        :meth:`~contextweaver.protocols.EventHook.on_firewall_triggered`
+        callback does NOT see ``codemode_query`` during that callback —
+        tracers that need the query at firewall time should either read
+        the event log on a follow-up callback or subscribe to
+        ``on_context_built`` instead.
+
+        No synthetic ``user_turn`` item is ingested — the hook is
+        intentionally stateless w.r.t. conversation history; only the
+        firewall side-effect (raw bytes parked in the artifact store) is
+        intentional.  Returns the firewall summary (or the raw result if
+        below threshold).
 
     Raises:
         ConfigError: If *firewall_threshold* is negative.
@@ -426,13 +445,14 @@ def make_context_hook(
         item, _envelope = context_manager.ingest_tool_result_sync(
             tool_call_id=call_id,
             raw_output=raw_result,
-            tool_name="codemode.discovery",
+            tool_name=tool_name,
             firewall_threshold=firewall_threshold,
         )
-        # Record the query as metadata so traces can correlate the hook call
-        # back to the user turn that triggered it.  Don't ingest it as a
-        # user_turn ContextItem — the hook is stateless w.r.t. conversation
-        # history; only the firewall side-effect is intentional.
+        # Record the query as metadata so EventHook / metric / trace
+        # consumers can correlate the hook call back to the user turn that
+        # triggered it.  Don't ingest it as a user_turn ContextItem — the
+        # hook is stateless w.r.t. conversation history; only the firewall
+        # side-effect is intentional.
         item.metadata.setdefault("codemode_query", query)
         return item.text
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -17,6 +17,8 @@ from contextweaver.adapters.fastmcp import (
     fastmcp_tool_to_selectable,
     fastmcp_tools_to_catalog,
     infer_fastmcp_namespace,
+    make_context_hook,
+    make_discovery_tool,
 )
 from contextweaver.adapters.mcp import (
     infer_namespace,
@@ -24,7 +26,12 @@ from contextweaver.adapters.mcp import (
     mcp_result_to_envelope,
     mcp_tool_to_selectable,
 )
+from contextweaver.context.manager import ContextManager
 from contextweaver.exceptions import CatalogError
+from contextweaver.routing.catalog import Catalog
+from contextweaver.routing.router import Router
+from contextweaver.routing.tree import TreeBuilder
+from contextweaver.types import SelectableItem
 
 # ---------------------------------------------------------------------------
 # MCP adapter — mcp_tool_to_selectable
@@ -1156,3 +1163,210 @@ async def test_load_fastmcp_catalog_requires_extra(monkeypatch: pytest.MonkeyPat
 # ``pytest.importorskip("weaver_contracts")`` there does not suppress the
 # MCP / A2A / FastMCP coverage above when the optional package is absent
 # (PR #201 review).
+
+
+# ---------------------------------------------------------------------------
+# FastMCP CodeMode adapter — make_discovery_tool / make_context_hook (issue #87)
+# ---------------------------------------------------------------------------
+
+
+def _build_test_catalog() -> Catalog:
+    """Build a 6-tool catalog with two distinct domains for discovery tests."""
+    catalog = Catalog()
+    items = [
+        ("github.search_repos", "search_repos", "Search GitHub repositories by keyword", ["vcs"]),
+        ("github.create_issue", "create_issue", "Create a new GitHub issue", ["vcs", "write"]),
+        ("github.merge_pr", "merge_pr", "Merge a GitHub pull request", ["vcs", "write"]),
+        ("slack.send_message", "send_message", "Post a message to a Slack channel", ["messaging"]),
+        ("slack.search_messages", "search_messages", "Search Slack messages", ["messaging"]),
+        ("db.query", "db_query", "Run a read-only SQL query", ["database"]),
+    ]
+    for tid, name, desc, tags in items:
+        catalog.register(
+            SelectableItem(
+                id=tid,
+                kind="tool",
+                name=name,
+                description=desc,
+                namespace=tid.split(".", 1)[0],
+                tags=tags,
+                args_schema={"type": "object", "properties": {"q": {"type": "string"}}},
+            )
+        )
+    return catalog
+
+
+def _build_test_router(catalog: Catalog, top_k: int = 3) -> Router:
+    items = catalog.all()
+    graph = TreeBuilder(max_children=8).build(items)
+    return Router(graph, items=items, top_k=top_k)
+
+
+def test_make_discovery_tool_returns_callable() -> None:
+    """The factory returns a plain callable with no captured FastMCP refs."""
+    catalog = _build_test_catalog()
+    router = _build_test_router(catalog)
+    discover = make_discovery_tool(router, catalog)
+    assert callable(discover)
+    # Plain function, not a partial / bound method / dataclass.
+    assert discover.__name__ == "discover"
+
+
+def test_discovery_tool_filters_catalog_to_shortlist() -> None:
+    """The discovery callable narrows the catalog to a query-relevant shortlist."""
+    catalog = _build_test_catalog()
+    router = _build_test_router(catalog, top_k=3)
+    discover = make_discovery_tool(router, catalog)
+
+    out = discover("search github repositories for the payments service")
+
+    # Strict bounds — exact shortlist size from the router config.
+    assert len(out) == 3
+    # The relevant tool must be in the shortlist; ordering is deterministic
+    # but TF-IDF score ties depend on tokenization, so we only assert membership.
+    names = [t["name"] for t in out]
+    assert "search_repos" in names
+
+
+def test_discovery_tool_returns_correct_dict_shape() -> None:
+    """Every returned dict has exactly the FastMCP CodeMode-required keys."""
+    catalog = _build_test_catalog()
+    router = _build_test_router(catalog)
+    discover = make_discovery_tool(router, catalog)
+    out = discover("send a slack message about the deploy")
+
+    assert len(out) >= 1
+    for tool in out:
+        assert set(tool.keys()) == {"name", "description", "input_schema"}
+        assert isinstance(tool["name"], str)
+        assert isinstance(tool["description"], str)
+        assert isinstance(tool["input_schema"], dict)
+
+
+def test_discovery_tool_top_k_ceiling() -> None:
+    """The top_k ceiling parameter caps the shortlist size below the router default."""
+    catalog = _build_test_catalog()
+    # Router defaults to top_k=3; pin to a strict ceiling of 2.
+    router = _build_test_router(catalog, top_k=3)
+    discover = make_discovery_tool(router, catalog, top_k=2)
+    out = discover("search github repositories")
+    assert len(out) == 2
+
+
+def test_discovery_tool_negative_top_k_raises() -> None:
+    """Negative ceilings are rejected at factory time, not at call time."""
+    catalog = _build_test_catalog()
+    router = _build_test_router(catalog)
+    with pytest.raises(ValueError, match="top_k must be >= 0"):
+        make_discovery_tool(router, catalog, top_k=-1)
+
+
+def test_discovery_tool_input_schema_is_copy() -> None:
+    """The returned input_schema is a copy — mutating it does not affect the catalog."""
+    catalog = _build_test_catalog()
+    router = _build_test_router(catalog)
+    discover = make_discovery_tool(router, catalog)
+    out = discover("search github repositories")
+
+    # Mutate the returned dict.
+    out[0]["input_schema"]["mutated"] = True
+
+    # Re-call: fresh result must not see the mutation.
+    out2 = discover("search github repositories")
+    assert "mutated" not in out2[0]["input_schema"]
+
+
+def test_discovery_tool_does_not_import_fastmcp() -> None:
+    """The discovery callable must not touch the fastmcp package at runtime."""
+    catalog = _build_test_catalog()
+    router = _build_test_router(catalog)
+    discover = make_discovery_tool(router, catalog)
+
+    # Snapshot sys.modules before the call; assert no new fastmcp.* keys.
+    import sys
+
+    fastmcp_modules_before = {k for k in sys.modules if k.startswith("fastmcp")}
+    discover("search github repositories")
+    fastmcp_modules_after = {k for k in sys.modules if k.startswith("fastmcp")}
+    new_imports = fastmcp_modules_after - fastmcp_modules_before
+    # If fastmcp was already imported (e.g. by the integration test in this
+    # module), the empty-diff assertion still holds; we only forbid *new*
+    # imports caused by the callable itself.
+    assert new_imports == set(), f"discovery hook leaked fastmcp imports: {new_imports}"
+
+
+def test_context_hook_compacts_large_result() -> None:
+    """The context hook drives the firewall on a >threshold raw result."""
+    mgr = ContextManager()
+    hook = make_context_hook(mgr)
+    raw = "x" * 5000
+    summary = hook("what changed?", raw)
+
+    # Firewall fires above the 2000-char default — summary is bounded.
+    assert len(summary) < len(raw)
+    assert len(summary) <= 600  # firewall summary is configured to ~500-char ceiling
+    # Raw bytes parked in the artifact store.
+    assert len(list(mgr.artifact_store.list_refs())) == 1
+
+
+def test_context_hook_passthrough_below_threshold() -> None:
+    """Short results below the firewall threshold pass through unchanged on the prompt.
+
+    The ``ingest_tool_result_sync`` pipeline always parks raw bytes in the
+    artifact store (so drilldown stays available), but below the firewall
+    threshold the returned text is the raw output verbatim — that's the
+    invariant CodeMode callers rely on.
+    """
+    mgr = ContextManager()
+    hook = make_context_hook(mgr, firewall_threshold=2000)
+    raw = "hello world"
+    summary = hook("what changed?", raw)
+    # Below threshold — the prompt-side summary is the raw text unchanged.
+    assert summary == raw
+
+
+def test_context_hook_records_query_as_metadata() -> None:
+    """The hook stamps the query onto item.metadata so traces can correlate it."""
+    mgr = ContextManager()
+    hook = make_context_hook(mgr)
+    raw = "x" * 5000
+    hook("look up incident OPS-4821", raw)
+
+    # The firewalled ContextItem is the most recent ingested event.
+    events = mgr.event_log.all()
+    # The last item is the firewalled tool result.
+    tool_result = events[-1]
+    assert tool_result.metadata.get("codemode_query") == "look up incident OPS-4821"
+
+
+def test_context_hook_negative_threshold_raises() -> None:
+    """Negative thresholds are rejected at factory time."""
+    mgr = ContextManager()
+    with pytest.raises(ValueError, match="firewall_threshold must be >= 0"):
+        make_context_hook(mgr, firewall_threshold=-1)
+
+
+def test_discovery_tool_skips_graph_only_nodes() -> None:
+    """Candidate ids not in the catalog (e.g. category labels) are skipped silently."""
+    catalog = _build_test_catalog()
+    items = catalog.all()
+    graph = TreeBuilder(max_children=8).build(items)
+    router = Router(graph, items=items, top_k=3)
+
+    # Force a fake non-hydratable id into the router output by patching.
+    real_route = router.route
+
+    def patched_route(query: str, **kwargs: object) -> object:
+        result = real_route(query, **kwargs)
+        # Prepend a synthetic id that the catalog does not know about.
+        result.candidate_ids = ["nonexistent.virtual_node", *result.candidate_ids]
+        return result
+
+    router.route = patched_route  # type: ignore[method-assign]
+
+    discover = make_discovery_tool(router, catalog)
+    out = discover("search github repositories")
+    # The virtual node is skipped silently; real candidates still surface.
+    names = [t["name"] for t in out]
+    assert "nonexistent.virtual_node" not in names
+    assert len(out) >= 1

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1358,6 +1358,69 @@ def test_context_hook_negative_threshold_raises() -> None:
         make_context_hook(mgr, firewall_threshold=-1)
 
 
+def test_context_hook_uses_configured_tool_name() -> None:
+    """The configured tool_name is stamped onto the firewalled ContextItem's metadata."""
+    mgr = ContextManager()
+    hook = make_context_hook(mgr, tool_name="github.search_repos")
+    raw = "x" * 5000
+    hook("look up the payments service", raw)
+
+    # The last event is the firewalled tool result; tool_name lives in
+    # ``metadata["tool_name"]`` per the contextweaver ingest convention and
+    # must match the factory-time override, not the hardcoded default.
+    events = mgr.event_log.all()
+    tool_result = events[-1]
+    assert tool_result.metadata.get("tool_name") == "github.search_repos"
+
+
+def test_context_hook_default_tool_name_is_codemode_tool_result() -> None:
+    """The default tool_name is the conceptually-correct 'codemode.tool_result'."""
+    mgr = ContextManager()
+    hook = make_context_hook(mgr)
+    hook("any query", "x" * 5000)
+
+    events = mgr.event_log.all()
+    tool_result = events[-1]
+    assert tool_result.metadata.get("tool_name") == "codemode.tool_result"
+
+
+def test_codemode_query_metadata_consumable_post_hook() -> None:
+    """`codemode_query` is reachable by downstream consumers via the event log.
+
+    Note on timing (relevant for tracer integrations): both ``tool_name`` and
+    ``codemode_query`` end up on ``item.metadata`` after the hook returns, so:
+
+    - Reads via :attr:`ContextManager.event_log` see the full metadata bag.
+    - Subsequent :class:`~contextweaver.protocols.EventHook.on_context_built`
+      callbacks (fired by :meth:`ContextManager.build_sync`) see it too.
+    - :meth:`EventHook.on_firewall_triggered` runs *during* the firewall stage
+      — i.e. before the adapter stamps ``codemode_query`` — so a single-pass
+      tracer keyed off that callback alone would miss the query.  The
+      docstring on :func:`make_context_hook` calls this out; this test pins
+      the post-hook event-log read as the canonical consumer contract.
+    """
+    mgr = ContextManager()
+    factory = make_context_hook(mgr, tool_name="slack.search_messages")
+    factory("find threads about the rollback", "y" * 5000)
+
+    # Post-hook, the event log row carries both ``tool_name`` (from the
+    # M-1 factory parameter) and ``codemode_query`` (from the metadata
+    # stamp) — a downstream tracer reading from the event log sees the
+    # full correlation key without needing adapter-specific glue.
+    events = mgr.event_log.all()
+    md = events[-1].metadata
+    assert md.get("tool_name") == "slack.search_messages"
+    assert md.get("codemode_query") == "find threads about the rollback"
+
+
+def test_discovery_tool_zero_top_k_returns_empty_list() -> None:
+    """`top_k=0` is a valid, non-raising config — the shortlist is empty."""
+    catalog = _build_test_catalog()
+    router = _build_test_router(catalog)
+    discover = make_discovery_tool(router, catalog, top_k=0)
+    assert discover("search github repositories") == []
+
+
 def test_discovery_tool_skips_graph_only_nodes() -> None:
     """Candidate ids not in the catalog (e.g. category labels) are skipped silently."""
     catalog = _build_test_catalog()

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -27,7 +27,7 @@ from contextweaver.adapters.mcp import (
     mcp_tool_to_selectable,
 )
 from contextweaver.context.manager import ContextManager
-from contextweaver.exceptions import CatalogError
+from contextweaver.exceptions import CatalogError, ConfigError
 from contextweaver.routing.catalog import Catalog
 from contextweaver.routing.router import Router
 from contextweaver.routing.tree import TreeBuilder
@@ -1257,23 +1257,35 @@ def test_discovery_tool_negative_top_k_raises() -> None:
     """Negative ceilings are rejected at factory time, not at call time."""
     catalog = _build_test_catalog()
     router = _build_test_router(catalog)
-    with pytest.raises(ValueError, match="top_k must be >= 0"):
+    with pytest.raises(ConfigError, match="top_k must be >= 0"):
         make_discovery_tool(router, catalog, top_k=-1)
 
 
-def test_discovery_tool_input_schema_is_copy() -> None:
-    """The returned input_schema is a copy — mutating it does not affect the catalog."""
+def test_discovery_tool_input_schema_is_deep_copy() -> None:
+    """input_schema is a deep copy — top-level + nested mutations stay isolated."""
     catalog = _build_test_catalog()
     router = _build_test_router(catalog)
     discover = make_discovery_tool(router, catalog)
     out = discover("search github repositories")
 
-    # Mutate the returned dict.
+    # Mutate the top-level dict.
     out[0]["input_schema"]["mutated"] = True
+    # Mutate every nested dict / list reachable from the schema so a shallow
+    # copy would still leak the mutation back to the catalog item.
+    schema = out[0]["input_schema"]
+    for value in schema.values():
+        if isinstance(value, dict):
+            value["mutated_nested"] = True
+        elif isinstance(value, list):
+            value.append("mutated_nested")
 
-    # Re-call: fresh result must not see the mutation.
+    # Re-call: fresh result must not see any of the mutations.
     out2 = discover("search github repositories")
-    assert "mutated" not in out2[0]["input_schema"]
+    schema2 = out2[0]["input_schema"]
+    assert "mutated" not in schema2
+    for value in schema2.values():
+        if isinstance(value, (dict, list)):
+            assert "mutated_nested" not in value
 
 
 def test_discovery_tool_does_not_import_fastmcp() -> None:
@@ -1342,7 +1354,7 @@ def test_context_hook_records_query_as_metadata() -> None:
 def test_context_hook_negative_threshold_raises() -> None:
     """Negative thresholds are rejected at factory time."""
     mgr = ContextManager()
-    with pytest.raises(ValueError, match="firewall_threshold must be >= 0"):
+    with pytest.raises(ConfigError, match="firewall_threshold must be >= 0"):
         make_context_hook(mgr, firewall_threshold=-1)
 
 
@@ -1370,3 +1382,30 @@ def test_discovery_tool_skips_graph_only_nodes() -> None:
     names = [t["name"] for t in out]
     assert "nonexistent.virtual_node" not in names
     assert len(out) >= 1
+
+
+def test_discovery_tool_top_k_skips_graph_only_without_eating_slots() -> None:
+    """`top_k` counts hydratable tools — a virtual node early in the list must not eat a slot."""
+    catalog = _build_test_catalog()
+    items = catalog.all()
+    graph = TreeBuilder(max_children=8).build(items)
+    router = Router(graph, items=items, top_k=5)
+
+    # Prepend a graph-only node to the router output so the hydration loop
+    # has to walk past it before collecting any real tool.
+    real_route = router.route
+
+    def patched_route(query: str, **kwargs: object) -> object:
+        result = real_route(query, **kwargs)
+        result.candidate_ids = ["nonexistent.virtual_node", *result.candidate_ids]
+        return result
+
+    router.route = patched_route  # type: ignore[method-assign]
+
+    discover = make_discovery_tool(router, catalog, top_k=2)
+    out = discover("search github repositories")
+    # `top_k=2` means "2 real tools". With the old slice-first logic, the
+    # virtual node would have consumed a slot and `out` would have length 1.
+    assert len(out) == 2
+    names = [t["name"] for t in out]
+    assert "nonexistent.virtual_node" not in names

--- a/tests/test_adapters_fastmcp_discovery.py
+++ b/tests/test_adapters_fastmcp_discovery.py
@@ -18,10 +18,12 @@ from __future__ import annotations
 
 import pytest
 
-# Module-level importorskip: when the optional ``fastmcp`` extra is not
-# installed (matrix runners that only pull ``[dev]``), skip this entire
-# file rather than fail at collection.  The unit tests in test_adapters.py
-# still run, so coverage of the adapter does not regress.
+# Module-level importorskip: skip this whole file when ``fastmcp`` is not
+# importable (a minimal-runtime install where neither ``[dev]`` nor
+# ``[fastmcp]`` was pulled).  ``fastmcp>=2.0`` is part of the ``[dev]``
+# extra so every CI matrix cell runs this file; this guard only protects
+# users running tests against a stripped-down install.  The unit tests in
+# test_adapters.py still run, so coverage of the adapter does not regress.
 fastmcp = pytest.importorskip("fastmcp")
 
 from contextweaver.adapters.fastmcp import (  # noqa: E402  — import-after-skip is intentional

--- a/tests/test_adapters_fastmcp_discovery.py
+++ b/tests/test_adapters_fastmcp_discovery.py
@@ -28,8 +28,10 @@ fastmcp = pytest.importorskip("fastmcp")
 
 from contextweaver.adapters.fastmcp import (  # noqa: E402  — import-after-skip is intentional
     load_fastmcp_catalog,
+    make_context_hook,
     make_discovery_tool,
 )
+from contextweaver.context.manager import ContextManager  # noqa: E402
 from contextweaver.routing.router import Router  # noqa: E402
 from contextweaver.routing.tree import TreeBuilder  # noqa: E402
 
@@ -108,3 +110,47 @@ async def test_discovery_tool_input_schema_matches_fastmcp_wire_shape(
     assert schema.get("type") == "object"
     properties = schema.get("properties", {})
     assert "query" in properties
+
+
+async def test_context_hook_compacts_real_fastmcp_tool_call() -> None:
+    """End-to-end: invoke a FastMCP tool, feed its result to make_context_hook, verify firewall."""
+    # Spin up a tiny in-memory server with a tool that returns a chunky payload.
+    server = fastmcp.FastMCP(name="contextweaver-context-hook-test-server")
+
+    @server.tool
+    def fetch_logs(service: str) -> str:
+        """Return a synthetic large log payload."""
+        # ~5 KB — well above the firewall_threshold below.
+        return "\n".join(
+            f'service={service} ts=2026-05-18T06:{i:02d}:00Z level=INFO msg="event {i}"'
+            for i in range(80)
+        )
+
+    # Drive the tool through fastmcp's in-memory client to make sure the wire
+    # format round-trips through the real FastMCP runtime, not just our adapter.
+    async with fastmcp.Client(server) as client:
+        result = await client.call_tool("fetch_logs", {"service": "payments"})
+        # FastMCP wraps tool outputs in a `content` list of typed blocks.  We
+        # only care about the textual payload here.
+        raw_result = "\n".join(
+            block.text for block in result.content if getattr(block, "text", None) is not None
+        )
+
+    # raw_result is the actual on-wire string the LLM would otherwise see.
+    assert len(raw_result) > 2000  # confirm we're above the firewall threshold
+
+    mgr = ContextManager()
+    hook = make_context_hook(mgr, firewall_threshold=2000, tool_name="logs.fetch_logs")
+    summary = hook("what failed in payments?", raw_result)
+
+    # Firewall fires: prompt-side summary is bounded, raw bytes parked.
+    assert len(summary) < len(raw_result)
+    assert len(list(mgr.artifact_store.list_refs())) == 1
+
+    # The configured tool_name and the query metadata both reach the event log
+    # via the ContextItem metadata bag (post-audit-fix M-1, where `tool_name`
+    # became a hook parameter and stops being hardcoded).
+    events = mgr.event_log.all()
+    tool_result = events[-1]
+    assert tool_result.metadata.get("tool_name") == "logs.fetch_logs"
+    assert tool_result.metadata.get("codemode_query") == "what failed in payments?"

--- a/tests/test_adapters_fastmcp_discovery.py
+++ b/tests/test_adapters_fastmcp_discovery.py
@@ -1,0 +1,108 @@
+"""Real FastMCP integration tests for the CodeMode hooks (issue #87).
+
+These tests spin up an in-memory ``fastmcp.FastMCP`` server, load its
+catalog via :func:`~contextweaver.adapters.fastmcp.load_fastmcp_catalog`,
+wrap the resulting router with
+:func:`~contextweaver.adapters.fastmcp.make_discovery_tool`, and assert that
+the discovery hook returns shortlists whose dict shapes are compatible with
+FastMCP's wire format.
+
+The unit-level tests in ``test_adapters.py`` cover the callable contract.
+This file is intentionally narrow: it just proves the hooks line up with a
+real FastMCP runtime, so that a downstream adopter who follows the example
+in ``examples/fastmcp_discovery_demo.py`` does not hit a wire-format
+mismatch on their first call.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Module-level importorskip: when the optional ``fastmcp`` extra is not
+# installed (matrix runners that only pull ``[dev]``), skip this entire
+# file rather than fail at collection.  The unit tests in test_adapters.py
+# still run, so coverage of the adapter does not regress.
+fastmcp = pytest.importorskip("fastmcp")
+
+from contextweaver.adapters.fastmcp import (  # noqa: E402  — import-after-skip is intentional
+    load_fastmcp_catalog,
+    make_discovery_tool,
+)
+from contextweaver.routing.router import Router  # noqa: E402
+from contextweaver.routing.tree import TreeBuilder  # noqa: E402
+
+
+@pytest.fixture
+def fastmcp_server() -> object:
+    """A small in-memory FastMCP server with three distinct-domain tools."""
+    server = fastmcp.FastMCP(name="contextweaver-test-server")
+
+    @server.tool
+    def github_search_repos(query: str) -> list[str]:
+        """Search GitHub repositories by keyword."""
+        return [f"repo:{query}"]
+
+    @server.tool
+    def slack_send_message(channel: str, text: str) -> str:
+        """Post a message to a Slack channel."""
+        return f"sent to {channel}: {text}"
+
+    @server.tool
+    def db_query(sql: str) -> list[dict[str, str]]:
+        """Run a read-only SQL query against the warehouse."""
+        return [{"sql": sql, "rows": "0"}]
+
+    return server
+
+
+async def test_load_catalog_and_wrap_as_discovery_tool(fastmcp_server: object) -> None:
+    """End-to-end: real FastMCP server -> catalog -> discovery callable -> shortlist."""
+    catalog = await load_fastmcp_catalog(fastmcp_server)
+    items = catalog.all()
+    # Three tools registered above.
+    assert len(items) == 3
+
+    graph = TreeBuilder(max_children=8).build(items)
+    router = Router(graph, items=items, top_k=3)
+    discover = make_discovery_tool(router, catalog)
+
+    # The discovery callable is shape-compatible with FastMCP CodeMode's
+    # custom_discovery_tool contract: list of dicts, each with name +
+    # description + input_schema.
+    out = discover("search github repositories for a project")
+    assert len(out) >= 1
+    for tool in out:
+        assert {"name", "description", "input_schema"} <= set(tool.keys())
+        assert isinstance(tool["input_schema"], dict)
+
+    names = [t["name"] for t in out]
+    # The relevant tool surfaces in the shortlist.  Exact ordering depends
+    # on TF-IDF scoring against descriptions, so only assert membership.
+    # FastMCP-derived ``SelectableItem.name`` has the namespace prefix
+    # stripped (``github_search_repos`` -> ``search_repos``).
+    assert "search_repos" in names
+
+
+async def test_discovery_tool_input_schema_matches_fastmcp_wire_shape(
+    fastmcp_server: object,
+) -> None:
+    """The schemas the hook returns must match what FastMCP's own list_tools yields."""
+    catalog = await load_fastmcp_catalog(fastmcp_server)
+    items = catalog.all()
+    graph = TreeBuilder(max_children=8).build(items)
+    router = Router(graph, items=items, top_k=3)
+    discover = make_discovery_tool(router, catalog)
+
+    # Cross-check one schema against the catalog item directly (the adapter's
+    # round-trip is what we're really validating here).  Note: the FastMCP
+    # adapter strips the namespace prefix from the tool name, so the python
+    # function ``github_search_repos`` surfaces as ``search_repos``.
+    out = discover("search github repositories")
+    matched = next((t for t in out if t["name"] == "search_repos"), None)
+    assert matched is not None, f"expected search_repos in shortlist; got {out}"
+
+    # Schema must declare a 'query' parameter — matches the python signature.
+    schema = matched["input_schema"]
+    assert schema.get("type") == "object"
+    properties = schema.get("properties", {})
+    assert "query" in properties

--- a/tests/test_architectures_code_review.py
+++ b/tests/test_architectures_code_review.py
@@ -1,0 +1,114 @@
+"""Smoke test for the code-review bot reference architecture (#204).
+
+The architecture is exercised by ``make example`` via the ``architectures``
+umbrella target. This unit test pins the deterministic invariants of the
+scripted review so regressions in routing, the firewall, or fact
+persistence surface immediately rather than after a CI ``make example``
+failure.
+
+The review is deterministic — no randomness, no real network calls — so
+we can assert specific numbers (intent match count, fact keys, firewall
+artifact count, large-result threshold) rather than just "ran without
+exception".
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+# Load the architecture under a unique module name so it can coexist with
+# the other architectures in the same pytest run — a bare ``import main``
+# from sys.path collides across the three architecture test files.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_MAIN_PATH = _REPO_ROOT / "examples" / "architectures" / "code_review_bot" / "main.py"
+_spec = importlib.util.spec_from_file_location("code_review_bot_main", _MAIN_PATH)
+assert _spec is not None and _spec.loader is not None
+code_review_bot = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(code_review_bot)
+
+
+@pytest.fixture
+def code_review_run_output() -> str:
+    """Run ``main()`` once and capture stdout for assertions."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        code_review_bot.main()
+    return buf.getvalue()
+
+
+def test_catalog_loads_with_expected_size(code_review_run_output: str) -> None:
+    """The committed catalog.yaml ships 24 tools."""
+    assert "Loaded catalog: 24 tools" in code_review_run_output
+
+
+def test_all_six_review_steps_run(code_review_run_output: str) -> None:
+    """All six scripted review steps produce a ``Step N`` banner."""
+    for n in range(1, 7):
+        assert f"Step {n}" in code_review_run_output
+
+
+def test_every_intent_lands_in_router_shortlist(code_review_run_output: str) -> None:
+    """The deterministic transcript was tuned so each intent is in the top-3."""
+    assert "intent in router top-3: 6/6  (100%)" in code_review_run_output
+    assert "NOT in shortlist" not in code_review_run_output
+
+
+def test_firewall_fires_twice(code_review_run_output: str) -> None:
+    """The diff dump (~28 KB) and the grep result (~2.5 KB) both fire the firewall."""
+    assert "firewall fires: 2/6" in code_review_run_output
+    # The diff and grep payloads are pinned in shape (order-of-magnitude
+    # assertions so we don't regress on tiny refactors of the canned data).
+    assert "firewall: 24," in code_review_run_output  # ~24 KB diff
+    assert "firewall: 2," in code_review_run_output  # ~2 KB grep
+    assert "char summary" in code_review_run_output
+    assert "artifact " in code_review_run_output
+
+
+def test_artifact_store_holds_every_tool_result(code_review_run_output: str) -> None:
+    """Every tool call writes an artifact, even when the firewall does not fire.
+
+    This is the contract the drilldown story depends on: small results are
+    still addressable.
+    """
+    assert "artifacts kept: 6" in code_review_run_output
+
+
+def test_persistent_facts_carry_across_review_steps(code_review_run_output: str) -> None:
+    """All three expected fact keys land in the FactStore by end of run."""
+    assert "pr.target_file = payments/charge.py" in code_review_run_output
+    assert "pr.test_status = 2 failed" in code_review_run_output
+    assert "pr.type_errors = 2 errors" in code_review_run_output
+
+
+def test_final_prompt_renders_facts_section(code_review_run_output: str) -> None:
+    """Persisted facts appear in the final answer-phase prompt under [FACTS]."""
+    assert "[FACTS]" in code_review_run_output
+    final_section = code_review_run_output.split("Final answer-phase prompt", 1)[1]
+    assert "pr.target_file: payments/charge.py" in final_section
+    assert "pr.test_status:" in final_section
+    assert "pr.type_errors:" in final_section
+
+
+def test_lint_run_routes_to_lint_namespace(code_review_run_output: str) -> None:
+    """Step 5 must route to lint.run, not test.coverage — guards against
+    a regression we previously had to fix by adding 'ruff' to the lint.run
+    description so TF-IDF picks it up.
+    """
+    # The line that records the chosen tool for step 5.
+    step5_section = code_review_run_output.split("Step 5", 1)[1].split("Step 6", 1)[0]
+    assert "chosen:   lint.run" in step5_section
+
+
+def test_select_from_shortlist_prefers_intent_when_present() -> None:
+    """The intent-map helper picks the intent if it is in the shortlist."""
+    assert code_review_bot._select_from_shortlist(["a.x", "b.y", "c.z"], "b.y") == "b.y"
+
+
+def test_select_from_shortlist_falls_back_to_top_when_missing() -> None:
+    """The helper falls back to the top-1 candidate when the intent is absent."""
+    assert code_review_bot._select_from_shortlist(["a.x", "b.y", "c.z"], "absent") == "a.x"

--- a/tests/test_architectures_slack.py
+++ b/tests/test_architectures_slack.py
@@ -14,19 +14,23 @@ exception".
 
 from __future__ import annotations
 
+import importlib.util
 import io
-import sys
 from contextlib import redirect_stdout
 from pathlib import Path
 
 import pytest
 
-# The architecture lives in examples/, not under src/. Add it to sys.path
-# for direct import.
+# The architecture lives in examples/, not under src/.  Load it under a
+# unique module name so test_architectures_<name>.py files can coexist
+# in the same pytest run — a bare ``import main`` from sys.path collides
+# across the three architectures.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(_REPO_ROOT / "examples" / "architectures" / "slack_ops_bot"))
-
-import main as slack_ops_bot  # noqa: E402  (import after sys.path manipulation)
+_MAIN_PATH = _REPO_ROOT / "examples" / "architectures" / "slack_ops_bot" / "main.py"
+_spec = importlib.util.spec_from_file_location("slack_ops_bot_main", _MAIN_PATH)
+assert _spec is not None and _spec.loader is not None
+slack_ops_bot = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(slack_ops_bot)
 
 
 @pytest.fixture

--- a/tests/test_architectures_voice.py
+++ b/tests/test_architectures_voice.py
@@ -1,0 +1,117 @@
+"""Smoke test for the voice agent reference architecture (#205).
+
+The architecture is exercised by ``make example`` via the ``architectures``
+umbrella target. This unit test pins the deterministic invariants of the
+scripted call so regressions in routing, the async build pattern, or
+fact persistence surface immediately rather than after a CI
+``make example`` failure.
+
+The call is deterministic — no randomness, no real network calls — so
+we can assert specific numbers (intent match count, fact keys, max
+answer token bound) rather than just "ran without exception".
+
+Wall-clock timings reported by the example (``X.X ms off-thread``) are
+**not** asserted on: they vary between machines and CI runners.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+# Load the architecture under a unique module name so it can coexist with
+# the other architectures in the same pytest run — a bare ``import main``
+# from sys.path collides across the three architecture test files.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_MAIN_PATH = _REPO_ROOT / "examples" / "architectures" / "voice_agent" / "main.py"
+_spec = importlib.util.spec_from_file_location("voice_agent_main", _MAIN_PATH)
+assert _spec is not None and _spec.loader is not None
+voice_agent = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(voice_agent)
+
+
+@pytest.fixture
+def voice_run_output() -> str:
+    """Run ``main()`` once and capture stdout for assertions."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        voice_agent.main()
+    return buf.getvalue()
+
+
+def test_catalog_loads_with_expected_size(voice_run_output: str) -> None:
+    """The committed catalog.yaml ships 18 tools."""
+    assert "Loaded catalog: 18 tools" in voice_run_output
+
+
+def test_all_five_turns_run(voice_run_output: str) -> None:
+    """All five scripted turns produce a ``Turn N`` banner."""
+    for n in range(1, 6):
+        assert f"Turn {n}" in voice_run_output
+
+
+def test_every_intent_lands_in_router_shortlist(voice_run_output: str) -> None:
+    """The deterministic transcript was tuned so each intent is in the top-3."""
+    assert "intent in router top-3: 5/5  (100%)" in voice_run_output
+    assert "NOT in shortlist" not in voice_run_output
+
+
+def test_async_build_pattern_reported(voice_run_output: str) -> None:
+    """Every turn reports an ``off-thread`` timing — the asyncio.to_thread pattern fired.
+
+    We don't assert on the millisecond figure (it varies by machine);
+    we only assert that the off-thread marker appears for every turn's
+    answer-phase build.
+    """
+    assert voice_run_output.count("ms off-thread") >= 5
+
+
+def test_persistent_facts_carry_across_turns(voice_run_output: str) -> None:
+    """All three expected fact keys land in the FactStore by end of run."""
+    assert "customer.order_id = A-481" in voice_run_output
+    assert "customer.shipping_address = 42 Apple St, Springfield" in voice_run_output
+    assert "customer.callback = 2026-05-17T14:00 (PT)" in voice_run_output
+
+
+def test_final_prompt_renders_facts_section(voice_run_output: str) -> None:
+    """Persisted facts appear in the final answer-phase prompt under [FACTS]."""
+    assert "[FACTS]" in voice_run_output
+    final_section = voice_run_output.split("Final answer-phase prompt", 1)[1]
+    assert "customer.order_id: A-481" in final_section
+    assert "customer.shipping_address: 42 Apple St, Springfield" in final_section
+    assert "customer.callback: 2026-05-17T14:00 (PT)" in final_section
+
+
+def test_answer_prompt_respects_tight_voice_budget(voice_run_output: str) -> None:
+    """Max answer-prompt tokens must stay under the documented 1000-token budget."""
+    # Pull the scoreboard line: ``max answer-prompt tokens: NNN (budget=1000)``.
+    line = next(ln for ln in voice_run_output.splitlines() if "max answer-prompt tokens:" in ln)
+    # Parse: take the integer after the colon.
+    value = int(line.split("max answer-prompt tokens:")[1].split("(")[0].strip())
+    # Tight assertion: at five turns the prompt is comfortably under budget.
+    # If a future tweak pushed this over ~400 tokens, the architecture's
+    # latency story would regress — that's the invariant we're guarding.
+    assert value < 400, f"answer prompt grew unexpectedly: {value} tokens"
+
+
+def test_pipecat_reported_as_optional_dep(voice_run_output: str) -> None:
+    """The example always reports the Pipecat install state.
+
+    Whether True or False — the example must say so explicitly so a
+    reader knows the optional-extra path was checked.
+    """
+    assert "pipecat-ai installed:" in voice_run_output
+
+
+def test_select_from_shortlist_prefers_intent_when_present() -> None:
+    """The intent-map helper picks the intent if it is in the shortlist."""
+    assert voice_agent._select_from_shortlist(["a.x", "b.y", "c.z"], "b.y") == "b.y"
+
+
+def test_select_from_shortlist_falls_back_to_top_when_missing() -> None:
+    """The helper falls back to the top-1 candidate when the intent is absent."""
+    assert voice_agent._select_from_shortlist(["a.x", "b.y", "c.z"], "absent") == "a.x"


### PR DESCRIPTION
Lands the 3-issue "adoption demonstrations" group selected by the triage
pass. Single combined PR (Mode B, owner-authorised). Same blast radius:
two new reference architectures under examples/architectures/ + two new
adapter callable factories in adapters/fastmcp.py + paired docs and tests.
Zero changes to the context or routing core pipelines.

#87 — FastMCP CodeMode discovery / context hooks
  - adapters/fastmcp.py grows two factories that return plain
    Callable[[str], list[dict]] and Callable[[str, str], str]
    respectively, matching the FastMCP CodeMode hook contract
    (https://github.com/PrefectHQ/fastmcp/discussions/3365) but framework-
    agnostic — neither captures any FastMCP reference at runtime.
  - make_discovery_tool(router, catalog, *, top_k=None) wraps Router +
    Catalog into a "given a query, return a shortlist of tools" callable;
    graph-only nodes are skipped silently.
  - make_context_hook(context_manager, *, firewall_threshold=2000) wraps
    the firewall as a "(query, raw_result) → summary" callable; raw bytes
    park in the artifact store, query is recorded as item.metadata for
    trace correlation.
  - examples/fastmcp_discovery_demo.py demos a 22-tool catalog → 3-tool
    shortlist with ~86% token reduction.
  - 12 unit tests under tests/test_adapters.py + 2 real-FastMCP integration
    tests in tests/test_adapters_fastmcp_discovery.py (spins up
    fastmcp.FastMCP in-memory server, round-trips through the hook).
  - fastmcp>=2.0 moved from [fastmcp] runtime extra into [dev] so the
    integration test runs on every CI matrix cell.

#204 — Code-review bot reference architecture
  - examples/architectures/code_review_bot/ with main.py + catalog.yaml
    (24 tools across grep/git/lint/typecheck/test/review) + README.md +
    OUTPUT.md + __init__.py.
  - Six-step PR review walking a regression in payments/charge.py. The
    firewall is the load-bearing pattern: synthetic ~28 KB diff dump and
    ~2.5 KB grep result both compact to ~500-char summaries while raw
    bytes stay addressable.
  - 10 smoke tests in tests/test_architectures_code_review.py pin
    deterministic invariants (catalog size, intent matches, firewall
    fires=2/6, artifact count=6, fact keys).
  - docs/architectures/code_review_bot.md is the public docs page.

#205 — Voice agent reference architecture (Pipecat)
  - examples/architectures/voice_agent/ with main.py + catalog.yaml
    (18 tools across support/orders/shipping/account/callback) +
    README.md + OUTPUT.md + __init__.py.
  - Canonical worked example for docs/integration_pipecat.md: every
    context build runs via asyncio.to_thread(mgr.build_sync, ...);
    ContextBudget(route=200, call=500, interpret=400, answer=1000)
    enforces sub-300 ms TTS-friendly answer prompts (max 200 tokens at
    five turns).
  - Pipecat optional: example runs end-to-end without pipecat-ai.
    pyproject.toml grows a [voice] extra (pipecat-ai>=0.0.50) for users
    who want the real FrameProcessor.
  - 10 smoke tests in tests/test_architectures_voice.py pin the
    async-build marker, intent matches, fact keys, and the 400-token
    answer-prompt ceiling. Wall-clock timings are not asserted on.
  - docs/architectures/voice_agent.md is the public docs page.
  - docs/integration_pipecat.md gains a "Canonical worked example"
    callout pointing back at the architecture.

Shared bookkeeping
  - Makefile architectures target runs all three architectures.
  - mkdocs.yml + docs/architectures/index.md link the two new pages.
  - CHANGELOG.md gains three bullets under [Unreleased].
  - tests/test_architectures_slack.py refactored from sys.path injection
    to importlib.util.spec_from_file_location so the three architecture
    test files can coexist in one pytest run (a bare ``import main`` from
    sys.path collides across architectures).

Module-size note
  adapters/fastmcp.py lands at 428 lines, over the soft 300-line guide,
  in line with adapters/mcp.py (401) and adapters/proxy_runtime.py (462)
  precedent. Mode B authorised the modest overrun rather than splitting
  one adapter across two files.

Verification
  ruff format --check src/ tests/ examples/ scripts/   → 145 files clean
  ruff check src/ tests/ examples/ scripts/            → All checks passed
  mypy src/                                            → 0 issues / 64 files
  pytest --cov=contextweaver -q                        → 985 passed, 5 skipped
                                                         (+34 new tests)
  make example                                         → all 14 scripts ran
  make demo                                            → clean
  make scorecard-check                                 → clean (no benchmark drift)
  make llms-check                                      → up to date

Closes #87
Closes #204
Closes #205

https://claude.ai/code/session_01JiR8ZGtuwn7Cv2ahHMwLhL