### PR TITLE
chore: add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web (remote container).
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Install the package in editable mode with the dev extra. This pulls in the
+# core runtime deps plus pytest, pytest-asyncio, pytest-cov, ruff, mypy,
+# pre-commit, weaver_contracts, and jsonschema — everything the Makefile's
+# fmt / lint / type / test targets require.
+python3 -m pip install --quiet --user -e ".[dev]"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,5 +23,17 @@
       "mcp__mcp-registry__list_connectors",
       "mcp__mcp-registry__search_mcp_registry"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
Installs the package editable with the [dev] extra on web session
start so ruff / mypy / pytest are ready before the agent runs.