### PR TITLE
fix(benchmarks,scripts): rescue 2 Copilot fixes from duplicate PR #229

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alongside the existing README headline (already updated in 0.4.0) and the
   `context-engineering` keyword in `pyproject.toml`.
 
+### Fixed
+
+- **`--backends` typo validation in benchmark harness** (PR #235). Typos
+  like `--backends tifdf` now exit via `parser.error()` (code 2) instead of
+  propagating to `Router` init as a `ConfigError` traceback.
+- **Skipped-row rendering in benchmark delta script** (PR #235). Matrix
+  cells with `status != "ok"` (e.g. `"skipped: rapidfuzz not installed"`)
+  now render as `_skipped_ (reason)` instead of being treated as a
+  zero-metric regression with false-positive ⚠️ markers.
+
 ## [0.4.0] - 2026-05-16
 
 ### Added

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -551,6 +551,7 @@ def _print_matrix_table(cells: list[MatrixCell], k: int) -> None:
 
 
 _DEFAULT_MATRIX_BACKENDS = "tfidf,bm25,fuzzy"
+_SUPPORTED_BACKENDS = frozenset({"tfidf", "bm25", "fuzzy"})
 _DEFAULT_MATRIX_SIZES = "100,500,1000"
 
 
@@ -619,7 +620,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "Default is enabled; the naive_delta block is additive to each context row."
         ),
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    # Fail fast on typos like `--backends tifdf,bm25` rather than letting the
+    # bad name reach Router init and surface as a ConfigError traceback.
+    requested = set(_csv_str_list(args.backends))
+    unknown = sorted(requested - _SUPPORTED_BACKENDS)
+    if unknown:
+        parser.error(
+            f"unsupported --backends value(s): {', '.join(unknown)}. "
+            f"Choose from: {', '.join(sorted(_SUPPORTED_BACKENDS))}."
+        )
+    return args
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/benchmark_delta.py
+++ b/scripts/benchmark_delta.py
@@ -137,13 +137,16 @@ def _render_matrix_section(base: dict[str, Any], head: dict[str, Any]) -> str:
         b = base_idx.get((backend, size), {})
         h = head_idx.get((backend, size), b)
         # Skip-cells carry zeroed metrics by design (e.g. fuzzy with no
-        # rapidfuzz). Treating them as accuracy/latency regressions would
-        # produce false-positive ⚠️ markers on every PR; emit a single
-        # "skipped" row that surfaces the reason text instead.
-        head_status = str(h.get("status", ""))
-        base_status = str(b.get("status", ""))
-        if head_status or base_status:
-            reason = head_status or base_status
+        # rapidfuzz, status="skipped: ..."). Treating them as accuracy/
+        # latency regressions would produce false-positive ⚠️ markers on
+        # every PR; emit a single "skipped" row that surfaces the reason
+        # instead. Real cells carry status="ok" (the MatrixCell default in
+        # benchmarks/benchmark.py), so the gate is status != "ok",
+        # aligning with scripts/render_scorecard.py's existing convention.
+        head_status = str(h.get("status", "ok"))
+        base_status = str(b.get("status", "ok"))
+        if head_status != "ok" or base_status != "ok":
+            reason = head_status if head_status != "ok" else base_status
             lines.append(f"| {backend} | {size} | _skipped_ ({reason}) | — | — |")
             continue
         br = float(b.get("recall_at_k", 0.0))

--- a/scripts/benchmark_delta.py
+++ b/scripts/benchmark_delta.py
@@ -136,6 +136,16 @@ def _render_matrix_section(base: dict[str, Any], head: dict[str, Any]) -> str:
     for backend, size in keys:
         b = base_idx.get((backend, size), {})
         h = head_idx.get((backend, size), b)
+        # Skip-cells carry zeroed metrics by design (e.g. fuzzy with no
+        # rapidfuzz). Treating them as accuracy/latency regressions would
+        # produce false-positive ⚠️ markers on every PR; emit a single
+        # "skipped" row that surfaces the reason text instead.
+        head_status = str(h.get("status", ""))
+        base_status = str(b.get("status", ""))
+        if head_status or base_status:
+            reason = head_status or base_status
+            lines.append(f"| {backend} | {size} | _skipped_ ({reason}) | — | — |")
+            continue
         br = float(b.get("recall_at_k", 0.0))
         hr = float(h.get("recall_at_k", 0.0))
         bm = float(b.get("mrr", 0.0))

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -14,7 +14,13 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "benchmarks"))
 
-from benchmark import _make_catalog, _precision_at_k, _recall_at_k, _reciprocal_rank
+from benchmark import (
+    _make_catalog,
+    _parse_args,
+    _precision_at_k,
+    _recall_at_k,
+    _reciprocal_rank,
+)
 
 # Synthetic variant IDs always end with .vN (e.g. billing.charge_customer.v2).
 # Natural IDs never match this pattern (billing.invoices.void contains .v but not .vN at end).
@@ -70,3 +76,22 @@ def test_make_catalog_size_1000_has_synthetic() -> None:
     items = _make_catalog(1000)
     assert len(items) == 1000
     assert any(_SYNTHETIC_PAT.search(item.id) for item in items)
+
+
+def test_parse_args_rejects_unknown_backend() -> None:
+    """Typos in --backends should exit code 2 (argparse convention), not crash later."""
+    with pytest.raises(SystemExit) as exc_info:
+        _parse_args(["--matrix", "--backends", "tfidf,tifdf"])
+    assert exc_info.value.code == 2
+
+
+def test_parse_args_accepts_all_supported_backends() -> None:
+    """All three documented backends pass validation."""
+    args = _parse_args(["--matrix", "--backends", "tfidf,bm25,fuzzy"])
+    assert args.backends == "tfidf,bm25,fuzzy"
+
+
+def test_parse_args_accepts_subset_of_backends() -> None:
+    """A subset of supported backends is also valid."""
+    args = _parse_args(["--matrix", "--backends", "tfidf"])
+    assert args.backends == "tfidf"

--- a/tests/test_benchmark_delta.py
+++ b/tests/test_benchmark_delta.py
@@ -1,0 +1,87 @@
+"""Regression tests for scripts/benchmark_delta.py.
+
+Covers the matrix-delta path that needs to handle ``status``-bearing
+("skipped") cells from `benchmarks/benchmark.py --matrix` without
+treating their zeroed metrics as a real accuracy/latency regression
+(would emit false-positive ⚠️ markers on every PR).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from benchmark_delta import _render_matrix_section  # noqa: E402
+
+
+def _payload(matrix_rows: list[dict[str, object]]) -> dict[str, object]:
+    return {"routing_matrix": matrix_rows}
+
+
+def test_matrix_delta_renders_skipped_row_for_status_bearing_cell() -> None:
+    """A skipped cell on head renders as ``_skipped_`` with the reason, not a regression."""
+    base = _payload(
+        [
+            {
+                "backend": "fuzzy",
+                "catalog_size": 100,
+                "recall_at_k": 0.45,
+                "mrr": 0.3,
+                "latency_ms_p99": 1.0,
+            }
+        ]
+    )
+    head = _payload(
+        [
+            {
+                "backend": "fuzzy",
+                "catalog_size": 100,
+                "recall_at_k": 0.0,
+                "mrr": 0.0,
+                "latency_ms_p99": 0.0,
+                "status": "skipped: rapidfuzz not installed",
+            }
+        ]
+    )
+    out = _render_matrix_section(base, head)
+    assert "_skipped_" in out
+    assert "skipped: rapidfuzz not installed" in out
+    # No ⚠️ — the zeroed metrics must not be reported as a regression.
+    assert "⚠️" not in out
+
+
+def test_matrix_delta_real_cells_still_render_metrics() -> None:
+    """Status-less cells still produce a full recall/MRR/latency row."""
+    base = _payload(
+        [
+            {
+                "backend": "tfidf",
+                "catalog_size": 100,
+                "recall_at_k": 0.5,
+                "mrr": 0.4,
+                "latency_ms_p99": 1.0,
+            }
+        ]
+    )
+    head = _payload(
+        [
+            {
+                "backend": "tfidf",
+                "catalog_size": 100,
+                "recall_at_k": 0.5,
+                "mrr": 0.4,
+                "latency_ms_p99": 1.0,
+            }
+        ]
+    )
+    out = _render_matrix_section(base, head)
+    # Numeric markers present, no skipped marker, no regression marker.
+    assert "_skipped_" not in out
+    assert "0.5000" in out
+
+
+def test_matrix_delta_empty_payload_returns_empty_string() -> None:
+    """No matrix rows in either side → no section emitted."""
+    assert _render_matrix_section({}, {}) == ""

--- a/tests/test_benchmark_delta.py
+++ b/tests/test_benchmark_delta.py
@@ -52,8 +52,16 @@ def test_matrix_delta_renders_skipped_row_for_status_bearing_cell() -> None:
     assert "⚠️" not in out
 
 
-def test_matrix_delta_real_cells_still_render_metrics() -> None:
-    """Status-less cells still produce a full recall/MRR/latency row."""
+def test_matrix_delta_ok_cells_render_metrics() -> None:
+    """Cells with the canonical ``status="ok"`` must render full metrics.
+
+    Regression: an earlier version of `_render_matrix_section` checked
+    `if head_status or base_status`, which matched every real cell
+    (``MatrixCell.status`` defaults to ``"ok"``) and suppressed every
+    metric row. The benchmark-delta bot comment on PR #235 caught this
+    in production. The gate is now `status != "ok"`, aligned with
+    `scripts/render_scorecard.py`.
+    """
     base = _payload(
         [
             {
@@ -62,6 +70,7 @@ def test_matrix_delta_real_cells_still_render_metrics() -> None:
                 "recall_at_k": 0.5,
                 "mrr": 0.4,
                 "latency_ms_p99": 1.0,
+                "status": "ok",
             }
         ]
     )
@@ -73,13 +82,43 @@ def test_matrix_delta_real_cells_still_render_metrics() -> None:
                 "recall_at_k": 0.5,
                 "mrr": 0.4,
                 "latency_ms_p99": 1.0,
+                "status": "ok",
             }
         ]
     )
     out = _render_matrix_section(base, head)
-    # Numeric markers present, no skipped marker, no regression marker.
+    # Numeric markers present; no skipped marker for "ok" cells.
     assert "_skipped_" not in out
     assert "0.5000" in out
+
+
+def test_matrix_delta_missing_status_treated_as_ok() -> None:
+    """Backwards-compatibility: a cell with no `status` field still renders metrics."""
+    base = _payload(
+        [
+            {
+                "backend": "bm25",
+                "catalog_size": 100,
+                "recall_at_k": 0.3,
+                "mrr": 0.2,
+                "latency_ms_p99": 5.0,
+            }
+        ]
+    )
+    head = _payload(
+        [
+            {
+                "backend": "bm25",
+                "catalog_size": 100,
+                "recall_at_k": 0.3,
+                "mrr": 0.2,
+                "latency_ms_p99": 5.0,
+            }
+        ]
+    )
+    out = _render_matrix_section(base, head)
+    assert "_skipped_" not in out
+    assert "0.3000" in out
 
 
 def test_matrix_delta_empty_payload_returns_empty_string() -> None:


### PR DESCRIPTION
## Summary

Re-applies the two Copilot-suggested fixes from [PR #229](https://github.com/dgenio/contextweaver/pull/229)'s review-fix commit that remained applicable on top of main after the duplicate [PR #228](https://github.com/dgenio/contextweaver/pull/228) merged. The other four Copilot-suggested fixes from #229 turned out to already be correct on main via #228's implementation.

PR #229 itself is a structural duplicate of merged PR #228 (both branches independently implemented the same #207-#215 issue group). A direct rebase surfaces 12+ files in deep conflict because the same logical work was implemented differently on each branch. Recommend closing #229 as a duplicate (see the comment posted there).

## Changes

**1. `benchmarks/benchmark.py` — `--backends` typo validation** (PR #229 Copilot #5)

Typos like `--backends tfidf,tifdf` previously reached `Router(scorer_backend=)` and surfaced as a `ConfigError` traceback. Now `_parse_args` validates against `_SUPPORTED_BACKENDS = {tfidf, bm25, fuzzy}` and exits via `parser.error()` with argparse's standard code-2 convention.

Tests added in `tests/test_benchmark.py`:
- `test_parse_args_rejects_unknown_backend` — code-2 exit on typo
- `test_parse_args_accepts_all_supported_backends`
- `test_parse_args_accepts_subset_of_backends`

**2. `scripts/benchmark_delta.py` — skipped-row rendering** (PR #229 Copilot #4)

When `benchmarks/benchmark.py --matrix` emits a `(backend, size)` cell with `status: "skipped: rapidfuzz not installed"` (zeroed metrics by design), the previous delta script treated those zeroes as a real accuracy/latency regression and emitted ⚠️ markers on every PR. Now `_render_matrix_section` short-circuits on a non-empty `status` and emits a single `_skipped_ (<reason>)` row.

Tests added in new `tests/test_benchmark_delta.py`:
- `test_matrix_delta_renders_skipped_row_for_status_bearing_cell` — pins no ⚠️ on skipped cells
- `test_matrix_delta_real_cells_still_render_metrics` — status-less cells unchanged
- `test_matrix_delta_empty_payload_returns_empty_string` — empty-input safety

## What did NOT need re-applying (already correct on main via #228)

| PR #229 Copilot # | Concern | Already-on-main status |
|---|---|---|
| #8 | int casts on `naive_tokens` / `cw_tokens` | `scripts/baseline_naive.py:141-142` already emits ints |
| #7 | dead `if default_row is not None and not default_row.is_default: pass` branch | Main's `sweep_scoring.py` never had it |
| #2 / #3 | matrix/per_namespace location in README + CHANGELOG | Main's `benchmarks/README.md:136` already says "additive top-level keys" |
| #1 | `_DELIM_CHARS` missing underscore | Was a false positive in PR #229 (acknowledged in the original review-fix commit) |
| #6 | `sweep_scoring.py` size | Acknowledged in PR #229 as following the existing `scripts/` precedent |

## Verification

```
ruff format src/ tests/ examples/ scripts/   →  clean
ruff check  src/ tests/ examples/ scripts/   →  All checks passed
mypy src/                                    →  Success: 0 issues / 72 source files
pytest -q                                    →  1011 passed, 5 skipped (+ 6 new regression tests)
make example                                 →  clean
make demo                                    →  Demo complete
make scorecard-check                         →  clean
```

## Related

- Closes the rescue-path for the abandoned PR #229's review-fix commit (`7afea33`)
- Recommend closing PR #229 as a duplicate of merged PR #228

---
_Generated by [Claude Code](https://claude.ai/code/session_011L83qkeg4Tnrvgv842GEuG)_