### PR TITLE
feat(routing,context,adapters): explicit pipeline + embedding backend + history-aware routing (#8, #27, #56)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,11 @@ It prepares context and routes tools but never calls models or executes tools.
 | `routing/registry.py` | `EngineRegistry` and bundled `TfIdfRetriever` / `NoOpReranker` / `JaccardClusteringEngine` defaults (issue #47) |
 | `routing/trace.py` | `RouteTrace` + `TraceStep` structured routing audit (issue #51) |
 | `routing/explanation.py` | `RouteResult.explanation()` Markdown / dict rendering (issue #226) |
+| `routing/pipeline.py` | `RoutingPipeline` composer — explicit retrieve → rerank → navigate → pack stages (issue #56) |
+| `routing/navigator.py` | `BeamSearchNavigator` (lifted from `router.py`) + `rank_collected` (issue #56) |
+| `routing/packer.py` | `DefaultCardPacker` wrapping `make_choice_cards` for the pipeline pack stage (issue #56) |
+| `routing/history.py` | `RouteHistory` dataclass + `adjust_scores` (history-aware re-routing, issue #27) |
+| `extras/embeddings.py` | `SentenceTransformerBackend` + `HybridEmbeddingRetriever` behind the `[embeddings]` extra (issue #8) |
 | `_schema_gen.py` | Dataclass → JSON Schema (Draft 2020-12) generator + `make schemas-check` engine (issue #225) |
 | `routing/tool_id.py` | Canonical `tool_id` grammar (`parse_tool_id` / `format_tool_id` / `compute_hash8`) per `docs/gateway_spec.md` §1 |
 | `routing/path.py` | `tool_browse` path-navigation grammar (`parse_path` / `resolve_path`) per `docs/gateway_spec.md` §3 |
@@ -66,6 +71,14 @@ It prepares context and routes tools but never calls models or executes tools.
 **Routing Engine** — 4 stages:
 
 1. `Catalog` → 2. `TreeBuilder` → 3. `Router` (beam search) → 4. `ChoiceCards`
+
+The `Router` itself composes a four-stage `RoutingPipeline` internally
+(retrieve → rerank → navigate → pack, issue #56).  Each stage is
+swappable via the `EngineRegistry` or by passing a custom
+`RoutingPipeline` to `Router(pipeline=...)`.  History-aware re-routing
+(`Router.route(history=...)`, issue #27) and the optional embedding
+retriever (`Router(embedding_backend=...)`, issue #8) plug into this
+same pipeline contract.
 
 For full pipeline descriptions and design rationale, see [docs/agent-context/architecture.md](docs/agent-context/architecture.md).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Explicit routing pipeline** (#56). The monolithic `Router.route()` is
+  refactored into four named, swappable stages: *retrieve* → *rerank* →
+  *navigate* → *pack*.  New `RoutingPipeline` composer
+  (`routing/pipeline.py`) plus `Navigator` (`routing/navigator.py`) and
+  `CardPacker` (`routing/packer.py`) protocols + bundled defaults
+  (`BeamSearchNavigator`, `DefaultCardPacker`).  `Router` continues to
+  expose its full public API unchanged and now delegates internally via
+  the new `Router.pipeline` property.  Default pipeline output is
+  byte-identical to the pre-refactor implementation (verified by the
+  existing 50+ `tests/test_router.py` regression gate and
+  `make scorecard-check`).
+- **Optional embedding-based retrieval backend** (#8). New
+  `EmbeddingBackend` protocol in `protocols.py`; new
+  `[embeddings]` extra (`pip install 'contextweaver[embeddings]'`)
+  wires `SentenceTransformerBackend` and `HybridEmbeddingRetriever` in
+  `contextweaver/extras/embeddings.py`.  `Router(embedding_backend=...)`
+  combines the embedding signal with TF-IDF (70/30 weighted sum by
+  default) so exact-id / exact-tag lexical hits keep their floor.
+  Zero-dependency default path is unchanged.
+- **History-aware re-routing** (#27 Phase 1).  `Router.route(...,
+  history=RouteHistory(...))` deprioritises already-called tools
+  (repeat-penalty multiplier), boosts candidates whose `description`
+  resembles the most recent tool-result summary, and surfaces per-item
+  score deltas on the new `RouteResult.history_adjustments` field.
+  `ContextManager.build_route_prompt` auto-constructs the history from
+  the event log unless `history_from_log=False` is set.
+- **Tool-dependency metadata on `SelectableItem`** (#27 Phase 2).  New
+  optional `depends_on` / `provides` / `requires` fields drive a
+  dependency-satisfaction boost and an unsatisfied-`depends_on`
+  penalty in history-aware routing.  All three default to `None` and
+  are omitted from `to_dict()` when unset, so existing catalogs
+  round-trip unchanged.  `Catalog.validate_dependencies()` returns
+  human-readable warnings for `depends_on` references to unknown
+  tool ids.  `schemas/catalog.schema.json` regenerated.
 - **`BuildStats.report()` and `BuildStats.report_dict()`** (#106). New
   diagnostic-report surface on `BuildStats`: pure-data string rendering
   (`"text"` or `"rich"` Rich-markup format) plus a versioned dict for

--- a/docs/schemas/v0/catalog.schema.json
+++ b/docs/schemas/v0/catalog.schema.json
@@ -16,6 +16,19 @@
       "cost_hint": {
         "type": "number"
       },
+      "depends_on": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
       "description": {
         "type": "string"
       },
@@ -51,6 +64,32 @@
           {
             "additionalProperties": {},
             "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "provides": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "requires": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           {
             "type": "null"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,10 +115,19 @@ cli = []
 retrieval = [
     "rapidfuzz>=3.0",
 ]
-# Approximate-nearest-neighbour backends. Reserved for future embedding-based
-# routing (#8). No functional code references these yet.
+# Approximate-nearest-neighbour backends. Reserved; the in-tree embedding
+# retriever (#8) does an exhaustive O(N) similarity scan and is enough for
+# catalogs under ~10k items.  Wire hnswlib in via a follow-up issue when the
+# fitted-corpus size justifies an indexed search.
 ann = [
     "hnswlib>=0.8",
+]
+# Embedding-based retrieval backend (#8). Activates
+# :class:`contextweaver.extras.embeddings.SentenceTransformerBackend` and the
+# Router's ``embedding_backend=`` kwarg.  Heavy: pulls torch via
+# sentence-transformers, so it stays optional.
+embeddings = [
+    "sentence-transformers>=2.0",
 ]
 # OpenTelemetry tracing + metrics export with native GenAI semantic
 # conventions (#224).  Pinned at >=1.27 because the
@@ -137,6 +146,7 @@ graph = [
 all = [
     "contextweaver[retrieval]",
     "contextweaver[ann]",
+    "contextweaver[embeddings]",
     "contextweaver[otel]",
     "contextweaver[graph]",
     "contextweaver[weaver-spec]",
@@ -188,6 +198,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "opentelemetry.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "sentence_transformers"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/schemas/catalog.schema.json
+++ b/schemas/catalog.schema.json
@@ -16,6 +16,19 @@
       "cost_hint": {
         "type": "number"
       },
+      "depends_on": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
       "description": {
         "type": "string"
       },
@@ -51,6 +64,32 @@
           {
             "additionalProperties": {},
             "type": "object"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "provides": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "requires": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           {
             "type": "null"

--- a/src/contextweaver/__init__.py
+++ b/src/contextweaver/__init__.py
@@ -49,12 +49,15 @@ from contextweaver.exceptions import (
 from contextweaver.metrics import MetricsCollector, MetricsHook
 from contextweaver.profiles import Mode, ProfileConfig, RoutingConfig
 from contextweaver.protocols import (
+    CardPacker,
     ClusteringEngine,
+    EmbeddingBackend,
     EpisodicStore,
     EventHook,
     Extractor,
     FactStore,
     Labeler,
+    Navigator,
     RedactionHook,
     Reranker,
     Retriever,
@@ -72,9 +75,13 @@ from contextweaver.routing.catalog import (
 )
 from contextweaver.routing.graph import ChoiceGraph
 from contextweaver.routing.graph_node import ChoiceNode
+from contextweaver.routing.history import RouteHistory
 from contextweaver.routing.labeler import KeywordLabeler
 from contextweaver.routing.manifest import GraphManifest, compute_catalog_hash
+from contextweaver.routing.navigator import BeamSearchNavigator
 from contextweaver.routing.normalizer import CatalogNormalizer, NormalizationReport
+from contextweaver.routing.packer import DefaultCardPacker
+from contextweaver.routing.pipeline import RoutingPipeline
 from contextweaver.routing.registry import (
     EngineRegistry,
     JaccardClusteringEngine,
@@ -142,12 +149,15 @@ __all__ = [
     "RoutingConfig",
     "ScoringConfig",
     # protocols
+    "CardPacker",
     "ClusteringEngine",
+    "EmbeddingBackend",
     "EpisodicStore",
     "EventHook",
     "Extractor",
     "FactStore",
     "Labeler",
+    "Navigator",
     "RedactionHook",
     "Reranker",
     "Retriever",
@@ -181,19 +191,23 @@ __all__ = [
     "MetricsCollector",
     "MetricsHook",
     # routing engine
+    "BeamSearchNavigator",
     "Catalog",
     "CatalogNormalizer",
     "ChoiceGraph",
     "ChoiceNode",
+    "DefaultCardPacker",
     "EngineRegistry",
     "GraphManifest",
     "JaccardClusteringEngine",
     "KeywordLabeler",
     "NoOpReranker",
     "NormalizationReport",
+    "RouteHistory",
     "RouteResult",
     "RouteTrace",
     "Router",
+    "RoutingPipeline",
     "TfIdfRetriever",
     "TraceStep",
     "TreeBuilder",

--- a/src/contextweaver/context/manager.py
+++ b/src/contextweaver/context/manager.py
@@ -780,9 +780,17 @@ class ContextManager:
 
         The summary is the most recent ``tool_result`` body truncated to
         500 characters — the same heuristic suggested in the issue body.
-        ``called_tool_ids`` is the union of every ``tool_result``'s
-        ``parent_id`` (the originating tool call) so the history reads as
-        "tools whose result we already have", not "events in the log".
+        ``called_tool_ids`` is derived from each ``tool_result``'s
+        originating tool call's ``function_name`` metadata — the canonical
+        catalog item id.  Resolution order:
+
+        1. ``tool_result.metadata["function_name"]`` (Gemini adapter sets
+           this directly on the result).
+        2. Resolve the parent ``tool_call`` item via
+           ``event_log.get(parent_id)`` and read its
+           ``metadata["function_name"]`` (OpenAI / Anthropic adapters).
+        3. Fallback: use ``parent_id`` verbatim (backward-compatible for
+           simple event logs where ``parent_id`` *is* the tool id).
         """
         from contextweaver.routing.history import RouteHistory as _RouteHistory
 
@@ -793,7 +801,7 @@ class ContextManager:
         called_ids: list[str] = []
         seen: set[str] = set()
         for item in tool_results:
-            tid = item.parent_id or item.id
+            tid = self._resolve_tool_id_from_result(item)
             if tid in seen:
                 continue
             seen.add(tid)
@@ -805,6 +813,29 @@ class ContextManager:
             last_result_summary=summary,
             step_number=len(called_ids) + 1,
         )
+
+    def _resolve_tool_id_from_result(self, item: ContextItem) -> str:
+        """Derive the catalog tool id from a tool_result ContextItem.
+
+        Resolution order:
+        1. item.metadata["function_name"] (set by Gemini adapter)
+        2. Parent tool_call item's metadata["function_name"] (OpenAI/Anthropic)
+        3. Fallback to parent_id (backward-compat for simple logs)
+        """
+        meta = item.metadata or {}
+        fn = meta.get("function_name")
+        if isinstance(fn, str) and fn:
+            return fn
+        parent_id = item.parent_id or item.id
+        try:
+            parent = self._event_log.get(parent_id)
+            parent_meta = parent.metadata or {}
+            parent_fn = parent_meta.get("function_name")
+            if isinstance(parent_fn, str) and parent_fn:
+                return parent_fn
+        except Exception:  # noqa: BLE001 — ItemNotFoundError or any store issue
+            pass
+        return parent_id
 
     # ------------------------------------------------------------------
     # Call-phase prompt (schema injection)

--- a/src/contextweaver/context/manager.py
+++ b/src/contextweaver/context/manager.py
@@ -56,6 +56,7 @@ _MAX_FACT_CHARS: int = 2000
 if TYPE_CHECKING:
     from contextweaver.envelope import ChoiceCard
     from contextweaver.routing.catalog import Catalog
+    from contextweaver.routing.history import RouteHistory
     from contextweaver.routing.router import Router, RouteResult
 
 logger = logging.getLogger("contextweaver.context")
@@ -689,6 +690,9 @@ class ContextManager:
         query: str,
         router: Router,
         budget_tokens: int | None = None,
+        *,
+        history: RouteHistory | None = None,
+        history_from_log: bool = True,
     ) -> tuple[ContextPack, list[ChoiceCard], RouteResult]:
         """Route, build context, and assemble a prompt with choice cards.
 
@@ -701,13 +705,25 @@ class ContextManager:
             query: User query string.
             router: The :class:`Router` to use for tool routing.
             budget_tokens: Optional budget override.
+            history: Optional pre-built :class:`RouteHistory` (issue #27).
+                When ``None`` and *history_from_log* is ``True``, the
+                manager auto-constructs one from its event log.
+            history_from_log: When ``True`` (default) and *history* is
+                ``None``, build a :class:`RouteHistory` from the event log
+                — already-called tools are deprioritised on subsequent
+                routing calls in the same session.  Set to ``False`` to
+                preserve pre-#27 stateless routing.
 
         Returns:
             A 3-tuple ``(pack, cards, route_result)``.
         """
         from contextweaver.routing.cards import make_choice_cards, render_cards_text
 
-        route_result = router.route(query)
+        if history is None and history_from_log:
+            history = self._build_route_history_from_log()
+        route_result = (
+            router.route(query, history=history) if history is not None else router.route(query)
+        )
 
         # Build choice cards from route results
         cards = make_choice_cards(
@@ -741,9 +757,54 @@ class ContextManager:
         query: str,
         router: Router,
         budget_tokens: int | None = None,
+        *,
+        history: RouteHistory | None = None,
+        history_from_log: bool = True,
     ) -> tuple[ContextPack, list[ChoiceCard], RouteResult]:
         """Synchronous alias for :meth:`build_route_prompt`."""
-        return self.build_route_prompt(goal, query, router, budget_tokens)
+        return self.build_route_prompt(
+            goal,
+            query,
+            router,
+            budget_tokens,
+            history=history,
+            history_from_log=history_from_log,
+        )
+
+    def _build_route_history_from_log(self) -> RouteHistory | None:
+        """Construct a :class:`RouteHistory` from the event log (issue #27).
+
+        Returns ``None`` when the log contains no ``tool_result`` entries
+        (the very first routing call in a session) so the router runs in
+        pre-#27 stateless mode.
+
+        The summary is the most recent ``tool_result`` body truncated to
+        500 characters — the same heuristic suggested in the issue body.
+        ``called_tool_ids`` is the union of every ``tool_result``'s
+        ``parent_id`` (the originating tool call) so the history reads as
+        "tools whose result we already have", not "events in the log".
+        """
+        from contextweaver.routing.history import RouteHistory as _RouteHistory
+
+        items = self._event_log.all()
+        tool_results = [i for i in items if i.kind == ItemKind.tool_result]
+        if not tool_results:
+            return None
+        called_ids: list[str] = []
+        seen: set[str] = set()
+        for item in tool_results:
+            tid = item.parent_id or item.id
+            if tid in seen:
+                continue
+            seen.add(tid)
+            called_ids.append(tid)
+        last = tool_results[-1]
+        summary = (last.text or "")[:500] or None
+        return _RouteHistory(
+            called_tool_ids=called_ids,
+            last_result_summary=summary,
+            step_number=len(called_ids) + 1,
+        )
 
     # ------------------------------------------------------------------
     # Call-phase prompt (schema injection)

--- a/src/contextweaver/extras/__init__.py
+++ b/src/contextweaver/extras/__init__.py
@@ -9,6 +9,9 @@ Currently shipped:
 
 - :mod:`contextweaver.extras.otel` — OpenTelemetry tracing + metrics
   (``contextweaver[otel]``).
+- :mod:`contextweaver.extras.embeddings` — sentence-transformers embedding
+  backend + hybrid embedding/TF-IDF retriever (``contextweaver[embeddings]``,
+  issue #8).
 """
 
 from __future__ import annotations

--- a/src/contextweaver/extras/embeddings.py
+++ b/src/contextweaver/extras/embeddings.py
@@ -9,8 +9,9 @@ Gated behind the ``contextweaver[embeddings]`` extra:
 The default install never imports this module; it is loaded lazily by
 :class:`~contextweaver.routing.router.Router` only when an
 ``embedding_backend=`` argument is supplied.  Importing this module
-without the ``sentence-transformers`` dependency raises ``ImportError``
-with the exact install hint above — matching the convention used by
+succeeds without ``sentence-transformers``; only instantiating
+:class:`SentenceTransformerBackend` raises ``ImportError`` with the
+exact install hint above — matching the convention used by
 :mod:`contextweaver.extras.otel`.
 
 What is shipped here:
@@ -158,13 +159,20 @@ class HybridEmbeddingRetriever:
         embedding_weight: float = 0.7,
     ) -> None:
         if not 0.0 <= embedding_weight <= 1.0:
-            raise ValueError(f"embedding_weight must be in [0.0, 1.0], got {embedding_weight}")
+            from contextweaver.exceptions import ConfigError
+
+            raise ConfigError(f"embedding_weight must be in [0.0, 1.0], got {embedding_weight}")
         self._backend = backend
         self._embedding_weight = embedding_weight
         self._tfidf_weight = 1.0 - embedding_weight
         self._corpus_size = 0
         self._corpus_vecs: list[list[float]] = []
         self._tfidf = TfIdfScorer()
+        # LRU-1 cache: avoid re-embedding the same query when score_one is
+        # called repeatedly with the same query (e.g., _result_similarity_map
+        # in Router).  Keyed by query string; invalidated on new query.
+        self._cached_query: str | None = None
+        self._cached_emb_scores: list[float] = []
 
     @property
     def backend(self) -> EmbeddingBackend:
@@ -180,6 +188,9 @@ class HybridEmbeddingRetriever:
         self._corpus_size = len(corpus)
         self._corpus_vecs = self._backend.embed(corpus)
         self._tfidf.fit(corpus)
+        # Invalidate embedding score cache on corpus change.
+        self._cached_query = None
+        self._cached_emb_scores = []
 
     def search(self, query: str, top_k: int) -> list[tuple[int, float]]:
         """Return up to *top_k* ``(index, hybrid_score)`` pairs sorted by score desc."""
@@ -203,13 +214,24 @@ class HybridEmbeddingRetriever:
         return self._embedding_weight * emb + self._tfidf_weight * tfidf
 
     def _embedding_scores(self, query: str) -> list[float]:
-        """Per-corpus-document similarity to *query* using :attr:`backend`."""
+        """Per-corpus-document similarity to *query* using :attr:`backend`.
+
+        Uses an LRU-1 cache so repeated calls with the same query (the
+        common case in :meth:`score_one` loops) pay only one embedding
+        pass.
+        """
+        if query == self._cached_query:
+            return self._cached_emb_scores
         if not self._corpus_vecs:
             return []
         q_vec = self._backend.embed([query])
         if not q_vec:
-            return [0.0] * self._corpus_size
-        return self._backend.similarity(q_vec[0], self._corpus_vecs)
+            scores = [0.0] * self._corpus_size
+        else:
+            scores = self._backend.similarity(q_vec[0], self._corpus_vecs)
+        self._cached_query = query
+        self._cached_emb_scores = scores
+        return scores
 
 
 def _dot(a: list[float], b: list[float]) -> float:

--- a/src/contextweaver/extras/embeddings.py
+++ b/src/contextweaver/extras/embeddings.py
@@ -1,0 +1,230 @@
+"""Optional embedding-based retrieval backend (issue #8).
+
+Gated behind the ``contextweaver[embeddings]`` extra:
+
+.. code-block:: bash
+
+    pip install 'contextweaver[embeddings]'
+
+The default install never imports this module; it is loaded lazily by
+:class:`~contextweaver.routing.router.Router` only when an
+``embedding_backend=`` argument is supplied.  Importing this module
+without the ``sentence-transformers`` dependency raises ``ImportError``
+with the exact install hint above — matching the convention used by
+:mod:`contextweaver.extras.otel`.
+
+What is shipped here:
+
+- :class:`SentenceTransformerBackend` — concrete
+  :class:`~contextweaver.protocols.EmbeddingBackend` implementation backed
+  by `sentence-transformers <https://www.sbert.net/>`_.
+- :class:`HybridEmbeddingRetriever` — :class:`~contextweaver.protocols.Retriever`
+  adapter that uses an embedding backend for primary scoring and the
+  in-tree TF-IDF scorer as a secondary lexical signal (weighted sum).
+
+Determinism note: embedding inference may be non-deterministic across
+hardware (CPU vs GPU, model version, BLAS backend).  When the routing
+engine is configured with an :class:`~contextweaver.protocols.EmbeddingBackend`,
+the deterministic-by-default guarantee shifts from the engine to the
+backend; pin the model version + an embedding cache for byte-exact
+reproducibility.
+
+Privacy: this module never sends item bodies over the network — the
+sentence-transformers backend loads weights locally and embeds in-process.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+from contextweaver._utils import TfIdfScorer
+
+if TYPE_CHECKING:
+    from contextweaver.protocols import EmbeddingBackend
+
+
+_INSTALL_HINT = (
+    "contextweaver.extras.embeddings requires the [embeddings] extra: "
+    "pip install 'contextweaver[embeddings]'"
+)
+
+
+try:  # pragma: no cover - exercised in the integration test path
+    from sentence_transformers import SentenceTransformer
+except ImportError:  # pragma: no cover - exercised in the default-install path
+    SentenceTransformer = None
+
+
+class SentenceTransformerBackend:
+    """:class:`~contextweaver.protocols.EmbeddingBackend` backed by sentence-transformers.
+
+    Args:
+        model_name: Hugging Face model id.  ``"all-MiniLM-L6-v2"`` is the
+            default — a small (~80 MB), fast, and broadly competitive
+            English model.
+        normalize_embeddings: When ``True`` (default), the underlying
+            model emits unit-norm vectors so :meth:`similarity` can use
+            a fast dot product.
+        batch_size: Internal batch size for :meth:`embed`.  Larger
+            batches use more memory but improve throughput on GPU.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "all-MiniLM-L6-v2",
+        *,
+        normalize_embeddings: bool = True,
+        batch_size: int = 32,
+    ) -> None:
+        if SentenceTransformer is None:
+            raise ImportError(_INSTALL_HINT)
+        self._model_name = model_name
+        self._normalize = normalize_embeddings
+        self._batch_size = batch_size
+        self._model: Any = SentenceTransformer(model_name)
+
+    @property
+    def model_name(self) -> str:
+        """The Hugging Face model id loaded by this backend."""
+        return self._model_name
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Return one embedding vector per entry in *texts*.
+
+        Empty input returns an empty list (zero-batch shortcut).
+        """
+        if not texts:
+            return []
+        encoded = self._model.encode(
+            texts,
+            batch_size=self._batch_size,
+            convert_to_numpy=True,
+            normalize_embeddings=self._normalize,
+            show_progress_bar=False,
+        )
+        # sentence-transformers returns a numpy.ndarray; cast row-wise to
+        # plain python lists so this module never leaks numpy into the
+        # protocol surface.
+        return [[float(x) for x in row] for row in encoded]
+
+    def similarity(
+        self,
+        query_vec: list[float],
+        corpus_vecs: list[list[float]],
+    ) -> list[float]:
+        """Cosine similarity (or dot product when both sides are unit-norm)."""
+        if self._normalize:
+            return [_dot(query_vec, v) for v in corpus_vecs]
+        q_norm = _norm(query_vec)
+        if q_norm == 0.0:
+            return [0.0] * len(corpus_vecs)
+        out: list[float] = []
+        for v in corpus_vecs:
+            v_norm = _norm(v)
+            if v_norm == 0.0:
+                out.append(0.0)
+                continue
+            out.append(_dot(query_vec, v) / (q_norm * v_norm))
+        return out
+
+
+class HybridEmbeddingRetriever:
+    """:class:`~contextweaver.protocols.Retriever` combining embeddings + TF-IDF.
+
+    Issue #8 acceptance criterion: "when an embedding backend is provided,
+    Router uses it for initial candidate scoring, with TF-IDF as a
+    secondary signal."  This retriever realises that contract with a
+    weighted sum so the embedding backend is the *primary* signal while
+    the lexical TF-IDF score keeps exact-id / exact-tag hits from being
+    drowned out.
+
+    Args:
+        backend: Any :class:`EmbeddingBackend` implementation.
+        embedding_weight: Weight on the embedding similarity component
+            (default 0.7).  Must be in ``[0.0, 1.0]``.  The TF-IDF weight
+            is ``1.0 - embedding_weight``.
+
+    Determinism: identical (corpus, query) → identical scores **for a
+    given backend instance**.  Re-instantiating a stateful backend with
+    a different model version or device will produce different scores —
+    this is a known limitation called out in the module docstring.
+    """
+
+    def __init__(
+        self,
+        backend: EmbeddingBackend,
+        *,
+        embedding_weight: float = 0.7,
+    ) -> None:
+        if not 0.0 <= embedding_weight <= 1.0:
+            raise ValueError(f"embedding_weight must be in [0.0, 1.0], got {embedding_weight}")
+        self._backend = backend
+        self._embedding_weight = embedding_weight
+        self._tfidf_weight = 1.0 - embedding_weight
+        self._corpus_size = 0
+        self._corpus_vecs: list[list[float]] = []
+        self._tfidf = TfIdfScorer()
+
+    @property
+    def backend(self) -> EmbeddingBackend:
+        """The wrapped :class:`EmbeddingBackend`."""
+        return self._backend
+
+    def fit(self, corpus: list[str]) -> None:
+        """Embed *corpus* once and fit the secondary TF-IDF scorer.
+
+        Re-calling :meth:`fit` recomputes both sides; the previous corpus
+        is discarded.
+        """
+        self._corpus_size = len(corpus)
+        self._corpus_vecs = self._backend.embed(corpus)
+        self._tfidf.fit(corpus)
+
+    def search(self, query: str, top_k: int) -> list[tuple[int, float]]:
+        """Return up to *top_k* ``(index, hybrid_score)`` pairs sorted by score desc."""
+        if self._corpus_size == 0:
+            return []
+        emb_scores = self._embedding_scores(query)
+        scored: list[tuple[int, float]] = []
+        for i in range(self._corpus_size):
+            tfidf = self._tfidf.score(query, i)
+            score = self._embedding_weight * emb_scores[i] + self._tfidf_weight * tfidf
+            scored.append((i, score))
+        scored.sort(key=lambda x: (-x[1], x[0]))
+        return scored[: max(0, top_k)]
+
+    def score_one(self, query: str, index: int) -> float:
+        """Return the hybrid score for the document at *index*."""
+        if not 0 <= index < self._corpus_size:
+            return 0.0
+        emb = self._embedding_scores(query)[index]
+        tfidf = self._tfidf.score(query, index)
+        return self._embedding_weight * emb + self._tfidf_weight * tfidf
+
+    def _embedding_scores(self, query: str) -> list[float]:
+        """Per-corpus-document similarity to *query* using :attr:`backend`."""
+        if not self._corpus_vecs:
+            return []
+        q_vec = self._backend.embed([query])
+        if not q_vec:
+            return [0.0] * self._corpus_size
+        return self._backend.similarity(q_vec[0], self._corpus_vecs)
+
+
+def _dot(a: list[float], b: list[float]) -> float:
+    """Dot product of two equal-length lists.  Returns 0.0 on length mismatch."""
+    if len(a) != len(b):
+        return 0.0
+    return sum(x * y for x, y in zip(a, b, strict=False))
+
+
+def _norm(v: list[float]) -> float:
+    """L2 norm."""
+    return math.sqrt(sum(x * x for x in v))
+
+
+__all__ = [
+    "HybridEmbeddingRetriever",
+    "SentenceTransformerBackend",
+]

--- a/src/contextweaver/protocols.py
+++ b/src/contextweaver/protocols.py
@@ -388,10 +388,11 @@ class CardPacker(Protocol):
     """Pluggable card-rendering stage of the routing pipeline.
 
     A packer turns a ranked list of items into :class:`ChoiceCard` instances
-    (and optionally a rendered text block) within a token budget.  The
-    bundled default :class:`~contextweaver.routing.packer.DefaultCardPacker`
-    wraps :func:`contextweaver.routing.cards.make_choice_cards` +
-    :func:`contextweaver.routing.cards.render_cards_text`.
+    within a token budget.  The bundled default
+    :class:`~contextweaver.routing.packer.DefaultCardPacker` wraps
+    :func:`contextweaver.routing.cards.make_choice_cards`.  Text rendering
+    is a separate concern handled by callers (e.g.,
+    :func:`~contextweaver.routing.cards.render_cards_text`).
     """
 
     def pack(

--- a/src/contextweaver/protocols.py
+++ b/src/contextweaver/protocols.py
@@ -13,6 +13,7 @@ prefer the historical path.
 from __future__ import annotations
 
 import logging as _logging
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import tiktoken as _tiktoken
@@ -23,7 +24,8 @@ from contextweaver.store.protocols import EventLog as EventLog
 from contextweaver.store.protocols import FactStore as FactStore
 
 if TYPE_CHECKING:
-    from contextweaver.envelope import ContextPack
+    from contextweaver.envelope import ChoiceCard, ContextPack
+    from contextweaver.routing.graph import ChoiceGraph
     from contextweaver.types import ContextItem, SelectableItem
 
 
@@ -298,5 +300,164 @@ class ClusteringEngine(Protocol):
         ``"cluster_000"``) and values are the items assigned to that
         cluster.  Implementations may return fewer than *k* clusters
         when the data is degenerate.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Navigator (issue #56)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class Navigator(Protocol):
+    """Pluggable graph-navigation stage of the routing pipeline.
+
+    A navigator walks a :class:`~contextweaver.routing.graph.ChoiceGraph`
+    and returns scored leaf items.  The bundled default
+    :class:`~contextweaver.routing.navigator.BeamSearchNavigator` performs
+    bounded beam search with a per-node :class:`Retriever` scorer; alternative
+    implementations may use exhaustive search, A*, learned policies, or skip
+    navigation entirely (single-level catalogs).
+
+    Implementations must be deterministic in
+    :class:`~contextweaver.profiles.Mode` ``strict``: identical inputs
+    must yield identical outputs.  Tie-break by ID, never by insertion order.
+    """
+
+    def navigate(
+        self,
+        query: str,
+        graph: ChoiceGraph,
+        active_items: dict[str, SelectableItem],
+        scorer: Retriever,
+        doc_id_to_idx: dict[str, int],
+        *,
+        all_item_ids: set[str] | None = None,
+        debug: bool = False,
+    ) -> NavigationResult:
+        """Walk *graph* and return scored ``(item_id, score, path)`` tuples.
+
+        Args:
+            query: The scoring query (already augmented by context hints).
+            graph: The choice graph to walk.
+            active_items: Post-filter catalog (``exclude_*`` / ``allowed_*``
+                applied upstream).  Only IDs in this dict are eligible for
+                collection.
+            scorer: The :class:`Retriever` used to score individual nodes.
+            doc_id_to_idx: Map of doc id → index in *scorer*'s fitted
+                corpus.  Nodes outside this map fall back to id-token
+                Jaccard inside the navigator (see ``BeamSearchNavigator``).
+            all_item_ids: Optional full pre-filter set of catalog item IDs.
+                Used to distinguish leaves (catalog items) from internal
+                graph nodes — preserves the issue #112 / #22 pre-filter
+                behaviour exactly.  ``None`` falls back to ``set(active_items)``.
+            debug: When ``True``, the returned
+                :class:`NavigationResult` populates ``steps`` with per-depth
+                beam expansions (for ``RouteTrace``).
+
+        Returns:
+            A :class:`NavigationResult` carrying the collected item map
+            (``id -> (score, path)``) plus optional debug trace steps.
+        """
+        ...
+
+
+@dataclass
+class NavigationResult:
+    """Output of a :class:`Navigator`.
+
+    Attributes:
+        collected: Map of ``item_id`` → ``(score, path)``.  Untrimmed —
+            ranking and ``top_k`` truncation happen in the pipeline.
+        steps: Per-depth beam-expansion records.  Empty unless the caller
+            passed ``debug=True``.
+    """
+
+    collected: dict[str, tuple[float, list[str]]] = field(default_factory=dict)
+    steps: list[Any] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# CardPacker (issue #56)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class CardPacker(Protocol):
+    """Pluggable card-rendering stage of the routing pipeline.
+
+    A packer turns a ranked list of items into :class:`ChoiceCard` instances
+    (and optionally a rendered text block) within a token budget.  The
+    bundled default :class:`~contextweaver.routing.packer.DefaultCardPacker`
+    wraps :func:`contextweaver.routing.cards.make_choice_cards` +
+    :func:`contextweaver.routing.cards.render_cards_text`.
+    """
+
+    def pack(
+        self,
+        items: list[SelectableItem],
+        scores: dict[str, float],
+        *,
+        budget_tokens: int | None = None,
+    ) -> list[ChoiceCard]:
+        """Render *items* as :class:`ChoiceCard` instances within budget.
+
+        Args:
+            items: Ranked items (best first).
+            scores: Map of ``item_id`` → score.  Used to populate
+                :attr:`ChoiceCard.score`.
+            budget_tokens: Optional soft budget.  Implementations may
+                truncate the list when the cumulative card token estimate
+                would exceed *budget_tokens*; ``None`` disables the cap.
+
+        Returns:
+            A list of :class:`ChoiceCard` in ranked order.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# EmbeddingBackend (issue #8)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class EmbeddingBackend(Protocol):
+    """Pluggable embedding backend for similarity-based routing.
+
+    Activated by passing an ``embedding_backend`` to
+    :class:`~contextweaver.routing.router.Router` (or by registering an
+    embedding-backed :class:`Retriever` in the
+    :class:`~contextweaver.routing.registry.EngineRegistry`).  The default
+    install ships TF-IDF + BM25 only and has no embedding dependency —
+    embedding backends arrive via the ``contextweaver[embeddings]`` extra.
+
+    Embedding backends may be non-deterministic across runtime/hardware
+    boundaries (e.g. GPU vs CPU sentence-transformers); callers that need
+    bit-exact reproducibility should pin the backend's model version and
+    embedding cache.  The routing engine's deterministic-by-default
+    guarantee applies only when an embedding backend is **not** supplied.
+    """
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        """Return a unit-norm-ish embedding for each text in *texts*.
+
+        Implementations should batch internally where possible.  Vectors
+        do not need to be exactly L2-normalised — :meth:`similarity` is
+        responsible for any normalisation it relies on.
+        """
+        ...
+
+    def similarity(
+        self,
+        query_vec: list[float],
+        corpus_vecs: list[list[float]],
+    ) -> list[float]:
+        """Return one similarity score per corpus vector.
+
+        Higher means more similar.  Cosine similarity is the canonical
+        choice; implementations may use dot product when vectors are
+        already L2-normalised.
         """
         ...

--- a/src/contextweaver/routing/catalog.py
+++ b/src/contextweaver/routing/catalog.py
@@ -98,6 +98,27 @@ class Catalog:
             key=lambda i: i.id,
         )
 
+    def validate_dependencies(self) -> list[str]:
+        """Return human-readable warnings about ``depends_on`` references (issue #27).
+
+        Returns one warning per item whose ``depends_on`` references a tool
+        id that is not registered in this catalog.  An empty list means the
+        dependency graph closes within the catalog.
+
+        Returns:
+            Sorted list of warning strings.  Empty when no issues found.
+        """
+        warnings: list[str] = []
+        known = set(self._items)
+        for item_id in sorted(self._items):
+            item = self._items[item_id]
+            if not item.depends_on:
+                continue
+            for dep in item.depends_on:
+                if dep not in known:
+                    warnings.append(f"Item {item_id!r} depends_on unknown tool id {dep!r}")
+        return warnings
+
     def to_dict(self) -> dict[str, Any]:
         """Serialise to a JSON-compatible dict."""
         return {"items": [item.to_dict() for item in self.all()]}

--- a/src/contextweaver/routing/history.py
+++ b/src/contextweaver/routing/history.py
@@ -1,0 +1,191 @@
+"""History-aware re-routing helpers (issue #27, Phase 1).
+
+Carries the execution-history signal the router needs to deprioritise
+already-called tools and boost tools whose ``requires`` are satisfied by
+``provides`` of previously-called tools.
+
+The data class is deliberately small and JSON-friendly: it round-trips
+through :meth:`to_dict` / :meth:`from_dict` and contains no references
+to the routing graph or the event log itself.  The
+:class:`~contextweaver.context.manager.ContextManager` builds one from
+its event log inside :meth:`build_route_prompt`; downstream callers may
+build one by hand.
+
+Determinism guarantee: identical ``(query, history, items, graph)`` inputs
+produce identical adjustments and identical routing output.  Adjustments
+are computed in :func:`adjust_scores` and reported back to the caller via
+:attr:`RouteResult.history_adjustments` so the decision surface stays
+inspectable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from contextweaver.types import SelectableItem
+
+
+#: Default penalty multiplier applied to ``score`` of an already-called tool.
+#: Same magnitude as the one suggested in the issue body so the existing
+#: integration test pattern (``r1.candidate_ids[0] not in r2.candidate_ids[:3]``)
+#: holds out of the box.
+DEFAULT_REPEAT_PENALTY: float = 0.5
+
+#: Default weight applied to the ``last_result_summary`` similarity boost.
+DEFAULT_RESULT_BOOST_WEIGHT: float = 0.3
+
+#: Default boost added when a tool's ``requires`` are fully satisfied by
+#: ``provides`` of already-called tools.
+DEFAULT_DEPENDENCY_SATISFIED_BOOST: float = 0.2
+
+#: Default penalty subtracted when a tool's ``depends_on`` references a
+#: tool that has not yet been called.
+DEFAULT_DEPENDENCY_UNSATISFIED_PENALTY: float = 0.2
+
+
+@dataclass
+class RouteHistory:
+    """Execution-history signal for history-aware re-routing.
+
+    Attributes:
+        called_tool_ids: Tools already invoked in this session, in call
+            order.  Order is **not** semantically meaningful — only
+            membership matters for the repeat-penalty rule.
+        last_result_summary: Summary of the most recent tool output
+            (typically :attr:`~contextweaver.envelope.ResultEnvelope.summary`
+            truncated).  ``None`` when no tool has been called yet.
+        step_number: 1-based index of the agent step that is about to call
+            :meth:`Router.route`.  Equal to ``len(called_tool_ids) + 1``
+            when constructed automatically.
+        repeat_penalty: Multiplier applied to scores of already-called
+            tools (default :data:`DEFAULT_REPEAT_PENALTY`).
+        result_boost_weight: Weight applied to the similarity between
+            *last_result_summary* and each candidate (default
+            :data:`DEFAULT_RESULT_BOOST_WEIGHT`).
+    """
+
+    called_tool_ids: list[str] = field(default_factory=list)
+    last_result_summary: str | None = None
+    step_number: int = 1
+    repeat_penalty: float = DEFAULT_REPEAT_PENALTY
+    result_boost_weight: float = DEFAULT_RESULT_BOOST_WEIGHT
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible dict representation."""
+        return {
+            "called_tool_ids": list(self.called_tool_ids),
+            "last_result_summary": self.last_result_summary,
+            "step_number": self.step_number,
+            "repeat_penalty": self.repeat_penalty,
+            "result_boost_weight": self.result_boost_weight,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RouteHistory:
+        """Reconstruct from a previously-serialised dict.
+
+        Missing keys fall back to dataclass defaults — so older payloads
+        round-trip cleanly when the schema is extended in future versions.
+        """
+        return cls(
+            called_tool_ids=list(data.get("called_tool_ids", [])),
+            last_result_summary=data.get("last_result_summary"),
+            step_number=int(data.get("step_number", 1)),
+            repeat_penalty=float(data.get("repeat_penalty", DEFAULT_REPEAT_PENALTY)),
+            result_boost_weight=float(data.get("result_boost_weight", DEFAULT_RESULT_BOOST_WEIGHT)),
+        )
+
+
+def _collect_provides(
+    called_tool_ids: list[str],
+    items: dict[str, SelectableItem],
+) -> set[str]:
+    """Return the union of ``provides`` capabilities of already-called tools.
+
+    Tools without a ``provides`` field (or with ``provides=None``) contribute
+    nothing.  Unknown ``called_tool_ids`` (not present in *items*) are
+    silently skipped so the function tolerates a stale history.
+    """
+    out: set[str] = set()
+    for tid in called_tool_ids:
+        item = items.get(tid)
+        if item is None or not item.provides:
+            continue
+        out.update(item.provides)
+    return out
+
+
+def adjust_scores(
+    scored: list[tuple[str, float]],
+    history: RouteHistory,
+    items: dict[str, SelectableItem],
+    *,
+    result_similarity: dict[str, float] | None = None,
+    dependency_satisfied_boost: float = DEFAULT_DEPENDENCY_SATISFIED_BOOST,
+    dependency_unsatisfied_penalty: float = DEFAULT_DEPENDENCY_UNSATISFIED_PENALTY,
+) -> tuple[list[tuple[str, float]], dict[str, float]]:
+    """Apply *history* to *scored* and return ``(adjusted, deltas)``.
+
+    The adjustment rules are deterministic and applied in this order so
+    the deltas dict reports the net per-candidate change in one pass:
+
+    1. **Repeat penalty** — multiply by :attr:`history.repeat_penalty` when
+       the candidate id is in :attr:`history.called_tool_ids`.
+    2. **Result-summary boost** — add ``weight * sim`` when
+       *result_similarity* carries an entry for the candidate.
+    3. **Dependency boost** — add *dependency_satisfied_boost* when the
+       candidate's :attr:`SelectableItem.requires` are non-empty and are
+       fully satisfied by ``provides`` of already-called tools.
+    4. **Dependency penalty** — subtract *dependency_unsatisfied_penalty*
+       when the candidate's :attr:`SelectableItem.depends_on` references
+       a tool not present in :attr:`history.called_tool_ids`.
+
+    Args:
+        scored: Pre-adjustment ``(item_id, score)`` pairs.  Order
+            preserved on the way in; output is re-sorted by ``(-score, id)``.
+        history: The execution-history signal.
+        items: Full pre-filter catalog (used to read ``depends_on`` /
+            ``provides`` / ``requires`` metadata).
+        result_similarity: Optional pre-computed similarity between
+            ``history.last_result_summary`` and each candidate.  Skipped
+            when ``None`` or when the candidate has no entry.
+        dependency_satisfied_boost: Boost added when ``requires`` is
+            satisfied by ``provides`` of already-called tools.
+        dependency_unsatisfied_penalty: Penalty subtracted when
+            ``depends_on`` references an uncalled tool.
+
+    Returns:
+        ``(adjusted_scored, deltas)`` — ``adjusted_scored`` is sorted by
+        ``(-score, id)``; ``deltas`` maps ``item_id`` → net adjustment
+        (only entries with a non-zero net change are included so
+        downstream telemetry stays compact).
+    """
+    called = set(history.called_tool_ids)
+    provides = _collect_provides(history.called_tool_ids, items)
+    deltas: dict[str, float] = {}
+    adjusted: list[tuple[str, float]] = []
+    for item_id, score in scored:
+        new_score = score
+        # 1. repeat penalty
+        if item_id in called:
+            new_score = new_score * history.repeat_penalty
+        # 2. result-summary boost
+        if result_similarity is not None:
+            sim = result_similarity.get(item_id)
+            if sim is not None:
+                new_score = new_score + history.result_boost_weight * sim
+        # 3 + 4. dependency metadata
+        item = items.get(item_id)
+        if item is not None:
+            if item.requires and all(cap in provides for cap in item.requires):
+                new_score = new_score + dependency_satisfied_boost
+            if item.depends_on and any(dep not in called for dep in item.depends_on):
+                new_score = new_score - dependency_unsatisfied_penalty
+        delta = new_score - score
+        if delta != 0.0:
+            deltas[item_id] = delta
+        adjusted.append((item_id, new_score))
+    adjusted.sort(key=lambda x: (-x[1], x[0]))
+    return adjusted, deltas

--- a/src/contextweaver/routing/navigator.py
+++ b/src/contextweaver/routing/navigator.py
@@ -1,0 +1,325 @@
+"""Beam-search navigator extracted from :mod:`router` (issue #56).
+
+Implements the :class:`~contextweaver.protocols.Navigator` protocol so the
+routing pipeline can swap, skip, or tune the navigation stage independently
+from retrieval and packing.
+
+The behaviour is byte-identical to the pre-refactor :meth:`Router.route`
+beam search — :class:`BeamSearchNavigator` is a verbatim move of
+``_eligible_internals``, ``_beam_search``, ``_rank_collected``, and
+``_expand_subtree``.  Determinism is preserved by tie-breaking on node id
+(alphabetical) at every step.
+
+Privacy: the navigator never reads item descriptions or schemas directly;
+all scoring goes through the injected :class:`~contextweaver.protocols.Retriever`
+(corpus fitted upstream by the pipeline).  Nodes outside the fitted corpus
+fall back to id-token Jaccard so internal graph nodes (which carry only a
+``label`` + ``routing_hint``) can still be scored.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from contextweaver._utils import jaccard, tokenize
+from contextweaver.protocols import NavigationResult
+from contextweaver.routing.trace import TraceStep
+
+if TYPE_CHECKING:
+    from contextweaver.protocols import Retriever
+    from contextweaver.routing.graph import ChoiceGraph
+    from contextweaver.types import SelectableItem
+
+
+class BeamSearchNavigator:
+    """Default :class:`~contextweaver.protocols.Navigator` implementation.
+
+    Walks a :class:`~contextweaver.routing.graph.ChoiceGraph` with bounded
+    beam search.  ``beam_width`` and ``max_depth`` cap fan-out; an adaptive
+    ``confidence_gap`` keeps one extra beam slot when the rank-1 vs rank-2
+    spread is below the threshold (issue #14 carry-over).
+
+    Args:
+        beam_width: Beams kept at each level (default 2).
+        max_depth: Maximum tree depth (default 8).
+        top_k: Soft target for the backtracking pass — when fewer than
+            ``top_k`` items have been collected, navigator backtracks into
+            unexplored branches.  The pipeline does the final trim.
+        confidence_gap: Score gap below which the navigator keeps one extra
+            child per node (adaptive beam, issue #14).
+    """
+
+    def __init__(
+        self,
+        *,
+        beam_width: int = 2,
+        max_depth: int = 8,
+        top_k: int = 10,
+        confidence_gap: float = 0.15,
+    ) -> None:
+        self._beam_width = beam_width
+        self._max_depth = max_depth
+        self._top_k = top_k
+        self._confidence_gap = confidence_gap
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def navigate(
+        self,
+        query: str,
+        graph: ChoiceGraph,
+        active_items: dict[str, SelectableItem],
+        scorer: Retriever,
+        doc_id_to_idx: dict[str, int],
+        *,
+        all_item_ids: set[str] | None = None,
+        debug: bool = False,
+    ) -> NavigationResult:
+        """Run beam search and return collected ``(item_id, score, path)`` tuples.
+
+        Args:
+            query: Augmented scoring query.
+            graph: Choice graph to walk.
+            active_items: Post-filter catalog (only IDs in this dict are
+                collectable).
+            scorer: Fitted :class:`Retriever` used to score nodes.
+            doc_id_to_idx: doc-id → corpus-index map for *scorer*.
+            all_item_ids: Full pre-filter set of catalog item IDs.  Used
+                to distinguish leaves (catalog items, even when filtered)
+                from internal graph nodes — preserves the issue #112 /
+                #22 pre-filter behaviour exactly.  Defaults to
+                ``set(active_items)`` when not supplied.
+            debug: When ``True``, populate ``NavigationResult.steps``.
+        """
+        item_ids = all_item_ids if all_item_ids is not None else set(active_items)
+        eligible_internals = self._eligible_internals(graph, active_items)
+        steps, collected = self._beam_search(
+            query,
+            graph,
+            active_items,
+            item_ids,
+            eligible_internals,
+            scorer,
+            doc_id_to_idx,
+            debug,
+        )
+        return NavigationResult(collected=collected, steps=steps)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _eligible_internals(
+        self,
+        graph: ChoiceGraph,
+        active_items: dict[str, SelectableItem],
+    ) -> set[str]:
+        """Return internal nodes that have at least one descendant in *active_items*.
+
+        Computed via reverse BFS from each active item.  Used to skip
+        subtrees whose every leaf was filtered out (exclude_* / allowed_*)
+        before scoring — preserves issue #112 / #22 behaviour.
+        """
+        eligible: set[str] = set()
+        queue: list[str] = list(active_items)
+        while queue:
+            node = queue.pop()
+            for parent in graph.predecessors(node):
+                if parent in eligible:
+                    continue
+                eligible.add(parent)
+                queue.append(parent)
+        return eligible
+
+    def _is_eligible_child(
+        self,
+        child: str,
+        active_items: dict[str, SelectableItem],
+        item_ids: set[str],
+        eligible_internals: set[str],
+    ) -> bool:
+        """Return ``True`` when *child* may participate in beam search.
+
+        Leaves (catalog items, regardless of post-filter state) must be in
+        *active_items*; internals must reach an active descendant.
+        Children failing this gate are skipped before scoring so they
+        cannot consume beam slots.
+        """
+        if child in item_ids:
+            return child in active_items
+        return child in eligible_internals
+
+    def _score_node(
+        self,
+        query: str,
+        node_id: str,
+        scorer: Retriever,
+        doc_id_to_idx: dict[str, int],
+    ) -> float:
+        """Score a single node — fitted-corpus path then id-token Jaccard fallback."""
+        idx = doc_id_to_idx.get(node_id)
+        if idx is not None:
+            return scorer.score_one(query, idx)
+        q_tokens = tokenize(query)
+        n_tokens = tokenize(node_id)
+        return jaccard(q_tokens, n_tokens)
+
+    def _beam_search(
+        self,
+        query: str,
+        graph: ChoiceGraph,
+        active_items: dict[str, SelectableItem],
+        item_ids: set[str],
+        eligible_internals: set[str],
+        scorer: Retriever,
+        doc_id_to_idx: dict[str, int],
+        debug: bool,
+    ) -> tuple[list[TraceStep], dict[str, tuple[float, list[str]]]]:
+        """Run beam search and return ``(trace_steps, collected)``."""
+        root = graph.root_id
+        beam: list[tuple[float, list[str]]] = [(0.0, [root])]
+        collected: dict[str, tuple[float, list[str]]] = {}
+        unexplored: list[tuple[float, str, list[str]]] = []
+        steps: list[TraceStep] = []
+
+        for depth in range(self._max_depth):
+            if not beam:
+                break
+            next_beam: list[tuple[float, list[str]]] = []
+            for score, path in beam:
+                node_id = path[-1]
+                children = graph.successors(node_id)
+                if not children:
+                    if node_id in active_items and node_id not in collected:
+                        collected[node_id] = (score, path[1:])
+                    continue
+
+                scored: list[tuple[float, str]] = []
+                for child in children:
+                    if not self._is_eligible_child(
+                        child, active_items, item_ids, eligible_internals
+                    ):
+                        continue
+                    s = self._score_node(query, child, scorer, doc_id_to_idx)
+                    scored.append((s, child))
+                scored.sort(key=lambda x: (-x[0], x[1]))
+
+                keep = self._beam_width
+                if len(scored) >= 2 and scored[0][0] - scored[1][0] < self._confidence_gap:
+                    keep = self._beam_width + 1
+
+                kept_ids: list[str] = []
+                for i, (s, child) in enumerate(scored):
+                    new_path = path + [child]
+                    if i < keep:
+                        kept_ids.append(child)
+                        if child in item_ids:
+                            if child in active_items and child not in collected:
+                                collected[child] = (score + s, new_path[1:])
+                        else:
+                            next_beam.append((score + s, new_path))
+                    else:
+                        unexplored.append((score + s, child, new_path))
+
+                if debug:
+                    steps.append(
+                        TraceStep(
+                            depth=depth,
+                            node=node_id,
+                            scored_children=[(cid, cs) for cs, cid in scored],
+                            kept=kept_ids,
+                        )
+                    )
+
+            next_beam.sort(key=lambda x: (-x[0], x[1][-1]))
+            beam = next_beam[: self._beam_width]
+
+        # Collect any remaining beam items.
+        for score, path in beam:
+            node_id = path[-1]
+            if node_id in active_items and node_id not in collected:
+                collected[node_id] = (score, path[1:])
+
+        # Backtrack into unexplored branches if under-filled.
+        unexplored.sort(key=lambda x: (-x[0], x[1]))
+        while len(collected) < self._top_k and unexplored:
+            u_score, u_node, u_path = unexplored.pop(0)
+            if u_node in collected:
+                continue
+            if u_node in active_items:
+                collected[u_node] = (u_score, u_path[1:])
+            else:
+                current_depth = len(u_path) - 1
+                remaining = max(0, self._max_depth - current_depth)
+                sub = self._expand_subtree(
+                    query,
+                    graph,
+                    u_node,
+                    u_score,
+                    u_path,
+                    active_items,
+                    item_ids,
+                    eligible_internals,
+                    scorer,
+                    doc_id_to_idx,
+                    max_depth=remaining,
+                )
+                for sid, (ss, sp) in sub.items():
+                    if sid in active_items and sid not in collected:
+                        collected[sid] = (ss, sp)
+
+        return steps, collected
+
+    def _expand_subtree(
+        self,
+        query: str,
+        graph: ChoiceGraph,
+        node_id: str,
+        base_score: float,
+        base_path: list[str],
+        active_items: dict[str, SelectableItem],
+        item_ids: set[str],
+        eligible_internals: set[str],
+        scorer: Retriever,
+        doc_id_to_idx: dict[str, int],
+        *,
+        max_depth: int | None = None,
+    ) -> dict[str, tuple[float, list[str]]]:
+        """Expand children of *node_id* recursively, collecting items."""
+        depth_limit = max_depth if max_depth is not None else self._max_depth
+        result: dict[str, tuple[float, list[str]]] = {}
+        stack: list[tuple[float, str, list[str], int]] = [(base_score, node_id, base_path, 0)]
+        while stack:
+            score, nid, path, depth = stack.pop()
+            children = graph.successors(nid)
+            if not children or depth >= depth_limit:
+                if nid in active_items:
+                    result[nid] = (score, path[1:])
+                continue
+            for child in sorted(children):
+                if not self._is_eligible_child(child, active_items, item_ids, eligible_internals):
+                    continue
+                s = self._score_node(query, child, scorer, doc_id_to_idx)
+                new_path = path + [child]
+                if child in item_ids:
+                    result[child] = (score + s, new_path[1:])
+                else:
+                    stack.append((score + s, child, new_path, depth + 1))
+        return result
+
+
+def rank_collected(
+    collected: dict[str, tuple[float, list[str]]],
+    active_items: dict[str, SelectableItem],
+) -> list[tuple[str, tuple[float, list[str]]]]:
+    """Sort *collected* by ``(-score, id)`` and drop items outside *active_items*.
+
+    Truncation to ``top_k`` is the caller's responsibility so ambiguity /
+    runner-up reads can use the full ranking even when ``top_k=1`` (issue #14).
+    """
+    return sorted(
+        (entry for entry in collected.items() if entry[0] in active_items),
+        key=lambda x: (-x[1][0], x[0]),
+    )

--- a/src/contextweaver/routing/packer.py
+++ b/src/contextweaver/routing/packer.py
@@ -1,0 +1,82 @@
+"""Card-packing stage of the routing pipeline (issue #56).
+
+Implements :class:`~contextweaver.protocols.CardPacker`.  The default
+implementation wraps :func:`contextweaver.routing.cards.make_choice_cards`
+to preserve every byte of pre-refactor output: same ordering, same per-card
+truncation, same prompt-cache-stability guarantee (issue #218).
+
+A *budget_tokens* hint controls the cumulative number of cards returned
+(soft cap — the underlying card renderer enforces per-card hard caps).
+``budget_tokens=None`` disables the cap and matches pre-refactor behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from contextweaver.routing.cards import make_choice_cards
+
+if TYPE_CHECKING:
+    from contextweaver.envelope import ChoiceCard
+    from contextweaver.types import SelectableItem
+
+
+def _estimate_card_tokens(card: ChoiceCard) -> int:
+    """Cheap character-/4 token estimate matching the rest of the engine.
+
+    The :class:`~contextweaver.routing.cards` renderer already pins each
+    card to a target-token budget per §2.4; the packer only needs a coarse
+    upper bound for the cumulative-budget cap.
+    """
+    parts = [card.id, card.namespace or "", card.name, card.kind, card.description]
+    parts.extend(card.tags)
+    return sum(len(p) for p in parts) // 4
+
+
+class DefaultCardPacker:
+    """Default :class:`~contextweaver.protocols.CardPacker`.
+
+    Args:
+        max_cards: Hard upper bound on the number of cards returned.
+            Defaults to 20, matching
+            :func:`~contextweaver.routing.cards.make_choice_cards`.
+        target_tokens_per_card: Per-card target budget (forwarded).
+        hard_cap_tokens_per_card: Per-card hard cap (forwarded).
+    """
+
+    def __init__(
+        self,
+        *,
+        max_cards: int = 20,
+        target_tokens_per_card: int | None = None,
+        hard_cap_tokens_per_card: int | None = None,
+    ) -> None:
+        self._max_cards = max_cards
+        self._target_tokens_per_card = target_tokens_per_card
+        self._hard_cap_tokens_per_card = hard_cap_tokens_per_card
+
+    def pack(
+        self,
+        items: list[SelectableItem],
+        scores: dict[str, float],
+        *,
+        budget_tokens: int | None = None,
+    ) -> list[ChoiceCard]:
+        """Render *items* as :class:`ChoiceCard` and apply *budget_tokens* soft cap."""
+        kwargs: dict[str, int] = {"max_cards": self._max_cards}
+        if self._target_tokens_per_card is not None:
+            kwargs["target_tokens_per_card"] = self._target_tokens_per_card
+        if self._hard_cap_tokens_per_card is not None:
+            kwargs["hard_cap_tokens_per_card"] = self._hard_cap_tokens_per_card
+        cards = make_choice_cards(items, scores=scores, **kwargs)
+        if budget_tokens is None or not cards:
+            return cards
+        used = 0
+        out: list[ChoiceCard] = []
+        for card in cards:
+            est = _estimate_card_tokens(card)
+            if used + est > budget_tokens and out:
+                break
+            out.append(card)
+            used += est
+        return out

--- a/src/contextweaver/routing/pipeline.py
+++ b/src/contextweaver/routing/pipeline.py
@@ -1,0 +1,165 @@
+"""Explicit routing pipeline composer (issue #56).
+
+Decomposes the routing engine into four named stages — *retrieve*,
+*rerank*, *navigate*, *pack* — that can be swapped, skipped, or tuned
+independently.  Mirrors the 8-stage context-engine pipeline pattern.
+
+The default pipeline produced by :meth:`RoutingPipeline.from_config`
+yields **byte-identical** output to the pre-refactor monolithic
+:meth:`Router.route` implementation.  This invariant is enforced by the
+existing ``tests/test_router.py`` regression gate and the
+``make scorecard-check`` drift gate.
+
+Stages:
+
+1. ``retrieve`` — :class:`~contextweaver.protocols.Retriever` fits the
+   item + node corpus (idempotent via internal flag).
+2. ``rerank`` — :class:`~contextweaver.protocols.Reranker` re-orders the
+   shortlist.  Defaults to :class:`NoOpReranker` which leaves order
+   unchanged.
+3. ``navigate`` — :class:`~contextweaver.protocols.Navigator` walks the
+   :class:`~contextweaver.routing.graph.ChoiceGraph` and returns scored
+   ``(item_id, score, path)`` tuples.
+4. ``pack`` — :class:`~contextweaver.protocols.CardPacker` renders the
+   ranked items as :class:`ChoiceCard` instances within a soft token
+   budget.
+
+Privacy: the pipeline never serialises raw item bodies; only ids, scores,
+and the public ``ChoiceCard`` projection cross the stage boundaries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from contextweaver.routing.packer import DefaultCardPacker
+from contextweaver.routing.registry import EngineRegistry, default_registry
+
+if TYPE_CHECKING:
+    from contextweaver.envelope import ChoiceCard
+    from contextweaver.profiles import RoutingConfig
+    from contextweaver.protocols import (
+        CardPacker,
+        NavigationResult,
+        Navigator,
+        Reranker,
+        Retriever,
+    )
+    from contextweaver.routing.graph import ChoiceGraph
+    from contextweaver.types import SelectableItem
+
+
+@dataclass
+class RoutingPipeline:
+    """Composed routing pipeline: ``retrieve → rerank → navigate → pack``.
+
+    The pipeline itself is stateless; per-call mutable state (corpus
+    indexing flag, doc-id → corpus-index map) lives on the
+    :class:`~contextweaver.routing.router.Router` that owns the pipeline.
+
+    Attributes:
+        retriever: First-stage retriever (TF-IDF default).
+        reranker: Optional second-stage reranker (no-op default).
+        navigator: Graph navigator (beam search default).
+        packer: Card packer (default wraps ``make_choice_cards``).
+    """
+
+    retriever: Retriever
+    reranker: Reranker | None = None
+    navigator: Navigator | None = None
+    packer: CardPacker = field(default_factory=DefaultCardPacker)
+
+    @classmethod
+    def from_config(
+        cls,
+        config: RoutingConfig | None = None,
+        *,
+        registry: EngineRegistry | None = None,
+    ) -> RoutingPipeline:
+        """Build a default pipeline from *config* (or the default registry).
+
+        Args:
+            config: Optional :class:`~contextweaver.profiles.RoutingConfig`
+                whose ``beam_width`` / ``max_depth`` / ``top_k`` /
+                ``confidence_gap`` populate the bundled
+                :class:`~contextweaver.routing.navigator.BeamSearchNavigator`.
+            registry: Engine registry to resolve the retriever (and
+                reranker, if registered).  Defaults to
+                :data:`~contextweaver.routing.registry.default_registry`.
+
+        Returns:
+            A :class:`RoutingPipeline` with all four stages wired.
+        """
+        from contextweaver.profiles import RoutingConfig as _RoutingConfig
+        from contextweaver.routing.navigator import BeamSearchNavigator
+
+        reg = registry or default_registry
+        cfg = config or _RoutingConfig()
+        retriever: Retriever = reg.resolve("retriever")
+        # Reranker is intentionally ``None`` by default: the pre-refactor
+        # :meth:`Router.route` had no rerank stage, and adding a no-op one
+        # is a behaviour change for callers who introspect the pipeline.
+        # Callers wanting a reranker pass one explicitly to the dataclass
+        # constructor or to :meth:`from_config` via a custom registry.
+        navigator: Navigator = BeamSearchNavigator(
+            beam_width=cfg.beam_width,
+            max_depth=cfg.max_depth,
+            top_k=cfg.top_k,
+            confidence_gap=cfg.confidence_gap,
+        )
+        return cls(
+            retriever=retriever,
+            reranker=None,
+            navigator=navigator,
+            packer=DefaultCardPacker(),
+        )
+
+    # ------------------------------------------------------------------
+    # Stage-level entry points (composable; bypass the orchestrator
+    # when callers need partial control)
+    # ------------------------------------------------------------------
+
+    def navigate(
+        self,
+        query: str,
+        graph: ChoiceGraph,
+        active_items: dict[str, SelectableItem],
+        doc_id_to_idx: dict[str, int],
+        *,
+        all_item_ids: set[str] | None = None,
+        debug: bool = False,
+    ) -> NavigationResult:
+        """Run the navigate stage in isolation (intended for tests + benchmarks)."""
+        from contextweaver.routing.navigator import BeamSearchNavigator
+
+        nav = self.navigator or BeamSearchNavigator()
+        return nav.navigate(
+            query,
+            graph,
+            active_items,
+            self.retriever,
+            doc_id_to_idx,
+            all_item_ids=all_item_ids,
+            debug=debug,
+        )
+
+    def rerank(
+        self,
+        query: str,
+        candidates: list[tuple[str, float]],
+    ) -> list[tuple[str, float]]:
+        """Run the rerank stage in isolation.  ``None`` reranker is a no-op."""
+        if self.reranker is None:
+            return list(candidates)
+        return self.reranker.rerank(query, candidates)
+
+    def pack(
+        self,
+        items: list[SelectableItem],
+        scores: dict[str, float],
+        *,
+        budget_tokens: int | None = None,
+    ) -> list[ChoiceCard]:
+        """Run the pack stage in isolation."""
+        return self.packer.pack(items, scores, budget_tokens=budget_tokens)

--- a/src/contextweaver/routing/pipeline.py
+++ b/src/contextweaver/routing/pipeline.py
@@ -15,8 +15,8 @@ Stages:
 1. ``retrieve`` — :class:`~contextweaver.protocols.Retriever` fits the
    item + node corpus (idempotent via internal flag).
 2. ``rerank`` — :class:`~contextweaver.protocols.Reranker` re-orders the
-   shortlist.  Defaults to :class:`NoOpReranker` which leaves order
-   unchanged.
+   shortlist.  Defaults to ``None`` (no rerank stage); callers wanting a
+   reranker pass one explicitly to the dataclass constructor.
 3. ``navigate`` — :class:`~contextweaver.protocols.Navigator` walks the
    :class:`~contextweaver.routing.graph.ChoiceGraph` and returns scored
    ``(item_id, score, path)`` tuples.

--- a/src/contextweaver/routing/router.py
+++ b/src/contextweaver/routing/router.py
@@ -341,11 +341,15 @@ class Router:
             need finer control.
         pipeline: Keyword-only.  Optional pre-built
             :class:`~contextweaver.routing.pipeline.RoutingPipeline`.
-            When supplied, the navigator / packer / reranker stages on
-            the pipeline replace the router's bundled defaults; the
+            When supplied, the navigator and reranker stages on the
+            pipeline replace the router's bundled defaults; the
             retriever on the pipeline is overridden by the one resolved
             from the other constructor args (so corpus indexing stays a
-            single source of truth).  Issue #56.
+            single source of truth).  The packer stage is available for
+            callers to invoke via ``router.pipeline.pack(...)`` but is
+            not called by :meth:`route` itself — cards are produced
+            externally by :meth:`RouteResult.to_routing_decision`.
+            Issue #56.
 
     Raises:
         ConfigError: If *confidence_gap* is outside ``[0.0, 1.0]`` or
@@ -574,6 +578,16 @@ class Router:
         collected = nav_result.collected
         steps = nav_result.steps
         all_sorted = rank_collected(collected, active_items)
+
+        # Rerank stage (issue #56): apply the pipeline reranker after
+        # navigation scoring.  When reranker is None this is a no-op copy.
+        if self._pipeline.reranker is not None and all_sorted:
+            id_to_path = {iid: path for iid, (_, path) in all_sorted}
+            reranked = self._pipeline.rerank(
+                scoring_query,
+                [(iid, score) for iid, (score, _) in all_sorted],
+            )
+            all_sorted = [(iid, (score, id_to_path[iid])) for iid, score in reranked]
 
         history_adjustments: dict[str, float] = {}
         if history is not None and all_sorted:

--- a/src/contextweaver/routing/router.py
+++ b/src/contextweaver/routing/router.py
@@ -23,11 +23,11 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Literal, overload
 
-from contextweaver._utils import BM25Scorer, FuzzyScorer, TfIdfScorer, jaccard, tokenize
+from contextweaver._utils import BM25Scorer, FuzzyScorer, TfIdfScorer
 from contextweaver.envelope import RoutingDecision
 from contextweaver.exceptions import ConfigError, RouteError
 from contextweaver.profiles import RoutingConfig
-from contextweaver.protocols import Retriever
+from contextweaver.protocols import EmbeddingBackend, Retriever
 from contextweaver.routing.cards import make_choice_cards
 from contextweaver.routing.explanation import explain_route, explain_route_dict
 from contextweaver.routing.filters import (
@@ -36,8 +36,11 @@ from contextweaver.routing.filters import (
     suggest_clarifying_question,
 )
 from contextweaver.routing.graph import ChoiceGraph
+from contextweaver.routing.history import RouteHistory, adjust_scores
+from contextweaver.routing.navigator import BeamSearchNavigator, rank_collected
+from contextweaver.routing.pipeline import RoutingPipeline
 from contextweaver.routing.registry import EngineRegistry, default_registry
-from contextweaver.routing.trace import RouteTrace, TraceStep
+from contextweaver.routing.trace import RouteTrace
 from contextweaver.types import SelectableItem
 
 logger = logging.getLogger("contextweaver.routing")
@@ -100,6 +103,10 @@ class RouteResult:
             were supplied.
         context_boost_applied: ``True`` when *context_hints* contains at
             least one non-blank hint that altered the scoring query.
+        history_adjustments: When a :class:`RouteHistory` is passed to
+            :meth:`Router.route`, this maps each candidate item id to the
+            net score delta the history-aware re-ranking applied (issue #27).
+            Empty dict when no history was supplied or no adjustments fired.
         trace: Structured audit record of the routing call (issue #51).
             Always populated; ``trace.steps`` is non-empty only when
             ``debug=True``.
@@ -115,6 +122,7 @@ class RouteResult:
     gated_count: int = 0
     context_hints: list[str] = field(default_factory=list)
     context_boost_applied: bool = False
+    history_adjustments: dict[str, float] = field(default_factory=dict)
     trace: RouteTrace = field(default_factory=RouteTrace)
 
     @property
@@ -322,10 +330,27 @@ class Router:
             are both ``None`` and *scorer_backend* is the default
             (``"tfidf"``).  Defaults to
             :data:`~contextweaver.routing.registry.default_registry`.
+        embedding_backend: Keyword-only.  Optional
+            :class:`~contextweaver.protocols.EmbeddingBackend` (issue #8).
+            When supplied, the router uses a hybrid embedding + TF-IDF
+            :class:`Retriever` for initial candidate scoring.  Requires
+            the ``contextweaver[embeddings]`` extra at the call site;
+            the core install never imports an embedding library.
+            Mutually exclusive with *retriever* — pass an embedding-aware
+            :class:`Retriever` directly via *retriever* if both routes
+            need finer control.
+        pipeline: Keyword-only.  Optional pre-built
+            :class:`~contextweaver.routing.pipeline.RoutingPipeline`.
+            When supplied, the navigator / packer / reranker stages on
+            the pipeline replace the router's bundled defaults; the
+            retriever on the pipeline is overridden by the one resolved
+            from the other constructor args (so corpus indexing stays a
+            single source of truth).  Issue #56.
 
     Raises:
         ConfigError: If *confidence_gap* is outside ``[0.0, 1.0]`` or
-            if *scorer_backend* is not a recognised backend name.
+            if *scorer_backend* is not a recognised backend name, or if
+            both *retriever* and *embedding_backend* are supplied.
     """
 
     def __init__(
@@ -342,6 +367,8 @@ class Router:
         routing_config: RoutingConfig | None = None,
         retriever: Retriever | None = None,
         engine_registry: EngineRegistry | None = None,
+        embedding_backend: EmbeddingBackend | None = None,
+        pipeline: RoutingPipeline | None = None,
     ) -> None:
         if routing_config is not None:
             beam_width = routing_config.beam_width
@@ -355,6 +382,12 @@ class Router:
                 f"Unknown scorer_backend {scorer_backend!r}; "
                 f"valid options: {sorted(_SCORER_BACKENDS)}"
             )
+        if embedding_backend is not None and retriever is not None:
+            raise ConfigError(
+                "Pass either retriever= or embedding_backend=, not both. "
+                "Construct an embedding-aware Retriever and pass it via retriever= "
+                "if you need both signals combined under a custom policy."
+            )
         self._graph = graph
         self._beam_width = beam_width
         self._max_depth = max_depth
@@ -366,6 +399,14 @@ class Router:
         if retriever is not None:
             self._retriever: Retriever = retriever
             self._retriever_engine_name = self._engine_registry.default_for("retriever") or "tfidf"
+        elif embedding_backend is not None:
+            # Late import keeps the core install free of any sentence-
+            # transformers / hnswlib / torch dependency.  Importing the
+            # adapter only happens when a backend is actually supplied.
+            from contextweaver.extras.embeddings import HybridEmbeddingRetriever
+
+            self._retriever = HybridEmbeddingRetriever(embedding_backend)
+            self._retriever_engine_name = "embedding+tfidf"
         elif scorer is not None:
             self._retriever = _ScorerRetriever(scorer)
             self._retriever_engine_name = "tfidf"
@@ -377,8 +418,41 @@ class Router:
             self._retriever_engine_name = self._engine_registry.default_for("retriever") or "tfidf"
         self._indexed = False
         self._doc_id_to_idx: dict[str, int] = {}
+        self._pipeline = self._build_pipeline(pipeline)
         if items is not None:
             self.set_items(items)
+
+    def _build_pipeline(self, override: RoutingPipeline | None) -> RoutingPipeline:
+        """Construct the routing pipeline (issue #56).
+
+        When *override* is supplied, its navigator / packer / reranker
+        replace the bundled defaults; the retriever is always set to the
+        one this :class:`Router` already resolved so corpus indexing has
+        a single source of truth.
+        """
+        navigator = BeamSearchNavigator(
+            beam_width=self._beam_width,
+            max_depth=self._max_depth,
+            top_k=self._top_k,
+            confidence_gap=self._confidence_gap,
+        )
+        if override is None:
+            return RoutingPipeline(
+                retriever=self._retriever,
+                reranker=None,
+                navigator=navigator,
+            )
+        return RoutingPipeline(
+            retriever=self._retriever,
+            reranker=override.reranker,
+            navigator=override.navigator or navigator,
+            packer=override.packer,
+        )
+
+    @property
+    def pipeline(self) -> RoutingPipeline:
+        """The :class:`RoutingPipeline` this router delegates to (issue #56)."""
+        return self._pipeline
 
     def set_items(self, items: list[SelectableItem]) -> None:
         """Register the catalog items for retriever indexing and result lookup.
@@ -413,22 +487,6 @@ class Router:
         self._doc_id_to_idx = {did: i for i, did in enumerate(doc_ids)}
         self._indexed = True
 
-    def _score_node(self, query: str, node_id: str) -> float:
-        """Score a single graph node against *query* via the configured retriever."""
-        self._ensure_index()
-        idx = self._doc_id_to_idx.get(node_id)
-        if idx is not None:
-            return self._retriever.score_one(query, idx)
-
-        # ``tokenize`` now handles ``:`` (outer split), ``_`` ``-`` ``.`` ``/``
-        # (inner-compound split) directly — see issue #213 — so the manual
-        # ``replace(...)`` workarounds that used to live here are no longer
-        # needed: feeding the raw node_id produces both the compound form
-        # (high-confidence exact-id hits) and the per-segment sub-tokens.
-        q_tokens = tokenize(query)
-        n_tokens = tokenize(node_id)
-        return jaccard(q_tokens, n_tokens)
-
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -443,6 +501,7 @@ class Router:
         allowed_namespaces: set[str] | None = None,
         allowed_tags: set[str] | None = None,
         context_hints: list[str] | None = None,
+        history: RouteHistory | None = None,
     ) -> RouteResult:
         """Route *query* through the graph and return ranked results.
 
@@ -464,6 +523,13 @@ class Router:
             context_hints: Optional list of conversation context hints.
                 Hints are appended to the query for scoring purposes
                 (issue #116).  Hints do not change the catalog or graph.
+            history: Optional :class:`RouteHistory` (issue #27).  When
+                supplied, already-called tools are deprioritised, tools
+                semantically related to ``last_result_summary`` are
+                boosted, and ``SelectableItem.depends_on`` / ``provides``
+                / ``requires`` metadata is applied.  Per-candidate score
+                deltas surface on :attr:`RouteResult.history_adjustments`.
+                ``None`` is byte-equivalent to pre-#27 behaviour.
 
         Returns:
             A :class:`RouteResult` with ranked items and a populated
@@ -493,12 +559,34 @@ class Router:
                 "All items were filtered out by exclude_ids / exclude_tags / "
                 "allowed_namespaces / allowed_tags."
             )
-        eligible_internals = self._eligible_internals(active_items)
         applied_hints = [h.strip() for h in (context_hints or []) if h and h.strip()]
         scoring_query = augment_query(query, context_hints)
         boost_applied = scoring_query != query and bool(applied_hints)
-        steps, collected = self._beam_search(scoring_query, active_items, eligible_internals, debug)
-        all_sorted = self._rank_collected(collected, active_items)
+
+        nav_result = self._pipeline.navigate(
+            scoring_query,
+            self._graph,
+            active_items,
+            self._doc_id_to_idx,
+            all_item_ids=set(self._items),
+            debug=debug,
+        )
+        collected = nav_result.collected
+        steps = nav_result.steps
+        all_sorted = rank_collected(collected, active_items)
+
+        history_adjustments: dict[str, float] = {}
+        if history is not None and all_sorted:
+            id_to_path = {iid: path for iid, (_, path) in all_sorted}
+            scored_pairs = [(iid, score) for iid, (score, _) in all_sorted]
+            result_similarity = self._result_similarity_map(history, scored_pairs)
+            adjusted, history_adjustments = adjust_scores(
+                scored_pairs,
+                history,
+                self._items,
+                result_similarity=result_similarity,
+            )
+            all_sorted = [(iid, (score, id_to_path[iid])) for iid, score in adjusted]
         top = all_sorted[: self._top_k]
 
         # Ambiguity reads from the untrimmed sorted view so that callers
@@ -523,6 +611,8 @@ class Router:
         trace.is_ambiguous = is_ambiguous
         trace.extra["context_hints"] = list(applied_hints)
         trace.extra["context_boost_applied"] = boost_applied
+        if history_adjustments:
+            trace.extra["history_adjustments"] = dict(history_adjustments)
         top_items = [active_items[iid] for iid, _ in top if iid in active_items]
         # Clarifying question is rendered from the top of the untrimmed
         # sort so it stays useful when top_k=1.
@@ -541,13 +631,14 @@ class Router:
             gated_count=gated_count,
             context_hints=list(applied_hints),
             context_boost_applied=boost_applied,
+            history_adjustments=dict(history_adjustments),
             trace=trace,
         )
 
         if logger.isEnabledFor(logging.INFO):
             logger.info(
                 "route: query_len=%d, top_k=%d, candidates=%d, scores=%s, "
-                "ambiguous=%s, excluded=%d, gated=%d",
+                "ambiguous=%s, excluded=%d, gated=%d, history_adjustments=%d",
                 len(query),
                 self._top_k,
                 len(result.candidate_ids),
@@ -555,202 +646,29 @@ class Router:
                 is_ambiguous,
                 excluded_count,
                 gated_count,
+                len(history_adjustments),
             )
         return result
 
-    # ------------------------------------------------------------------
-    # Beam search internals
-    # ------------------------------------------------------------------
-
-    def _eligible_internals(self, active_items: dict[str, SelectableItem]) -> set[str]:
-        """Return internal nodes that have at least one descendant in *active_items*.
-
-        Computed via reverse BFS from each active item.  Used by
-        :meth:`_beam_search` and :meth:`_expand_subtree` to skip
-        children whose entire subtree was filtered out before scoring,
-        so exclusions and toolset gating happen pre-search rather than
-        only at collection time (issue #112 / #22).
-        """
-        eligible: set[str] = set()
-        queue: list[str] = list(active_items)
-        while queue:
-            node = queue.pop()
-            for parent in self._graph.predecessors(node):
-                if parent in eligible:
-                    continue
-                eligible.add(parent)
-                queue.append(parent)
-        return eligible
-
-    def _is_eligible_child(
+    def _result_similarity_map(
         self,
-        child: str,
-        active_items: dict[str, SelectableItem],
-        eligible_internals: set[str],
-    ) -> bool:
-        """Return ``True`` if *child* may participate in beam search.
+        history: RouteHistory,
+        scored: list[tuple[str, float]],
+    ) -> dict[str, float] | None:
+        """Per-candidate similarity to ``history.last_result_summary``.
 
-        Leaves must be in *active_items*; internals must reach an
-        active descendant.  Children that fail this gate are skipped
-        before scoring so they cannot consume beam slots.
+        Reuses the router's fitted retriever so the boost is computed in
+        the same scoring space as the primary query.  Returns ``None`` when
+        the history has no summary so :func:`adjust_scores` can skip the
+        boost stage entirely.
         """
-        if child in self._items:
-            return child in active_items
-        return child in eligible_internals
-
-    def _beam_search(
-        self,
-        query: str,
-        active_items: dict[str, SelectableItem],
-        eligible_internals: set[str],
-        debug: bool,
-    ) -> tuple[list[TraceStep], dict[str, tuple[float, list[str]]]]:
-        """Run the beam search and return ``(trace_steps, collected)``.
-
-        *active_items* is the post-filter catalog; only IDs in this dict
-        are eligible for collection.  *eligible_internals* is the set of
-        internal nodes with at least one active descendant — children
-        outside this set (and outside *active_items*) are skipped before
-        scoring (issue #112 / #22).
-        """
-        root = self._graph.root_id
-        beam: list[tuple[float, list[str]]] = [(0.0, [root])]
-        collected: dict[str, tuple[float, list[str]]] = {}
-        unexplored: list[tuple[float, str, list[str]]] = []
-        steps: list[TraceStep] = []
-
-        for depth in range(self._max_depth):
-            if not beam:
-                break
-            next_beam: list[tuple[float, list[str]]] = []
-            for score, path in beam:
-                node_id = path[-1]
-                children = self._graph.successors(node_id)
-                if not children:
-                    if node_id in active_items and node_id not in collected:
-                        collected[node_id] = (score, path[1:])
-                    continue
-
-                scored: list[tuple[float, str]] = []
-                for child in children:
-                    if not self._is_eligible_child(child, active_items, eligible_internals):
-                        continue
-                    s = self._score_node(query, child)
-                    scored.append((s, child))
-                scored.sort(key=lambda x: (-x[0], x[1]))
-
-                keep = self._beam_width
-                if len(scored) >= 2 and scored[0][0] - scored[1][0] < self._confidence_gap:
-                    keep = self._beam_width + 1
-
-                kept_ids: list[str] = []
-                for i, (s, child) in enumerate(scored):
-                    new_path = path + [child]
-                    if i < keep:
-                        kept_ids.append(child)
-                        if child in self._items:
-                            if child in active_items and child not in collected:
-                                collected[child] = (score + s, new_path[1:])
-                        else:
-                            next_beam.append((score + s, new_path))
-                    else:
-                        unexplored.append((score + s, child, new_path))
-
-                if debug:
-                    steps.append(
-                        TraceStep(
-                            depth=depth,
-                            node=node_id,
-                            scored_children=[(cid, cs) for cs, cid in scored],
-                            kept=kept_ids,
-                        )
-                    )
-
-            next_beam.sort(key=lambda x: (-x[0], x[1][-1]))
-            beam = next_beam[: self._beam_width]
-
-        # Collect any remaining beam items.
-        for score, path in beam:
-            node_id = path[-1]
-            if node_id in active_items and node_id not in collected:
-                collected[node_id] = (score, path[1:])
-
-        # Backtrack into unexplored branches if under-filled.
-        unexplored.sort(key=lambda x: (-x[0], x[1]))
-        while len(collected) < self._top_k and unexplored:
-            u_score, u_node, u_path = unexplored.pop(0)
-            if u_node in collected:
+        summary = history.last_result_summary
+        if not summary:
+            return None
+        sims: dict[str, float] = {}
+        for item_id, _ in scored:
+            idx = self._doc_id_to_idx.get(item_id)
+            if idx is None:
                 continue
-            if u_node in active_items:
-                collected[u_node] = (u_score, u_path[1:])
-            else:
-                current_depth = len(u_path) - 1
-                remaining = max(0, self._max_depth - current_depth)
-                sub = self._expand_subtree(
-                    query,
-                    u_node,
-                    u_score,
-                    u_path,
-                    active_items,
-                    eligible_internals,
-                    max_depth=remaining,
-                )
-                for sid, (ss, sp) in sub.items():
-                    if sid in active_items and sid not in collected:
-                        collected[sid] = (ss, sp)
-
-        return steps, collected
-
-    def _rank_collected(
-        self,
-        collected: dict[str, tuple[float, list[str]]],
-        active_items: dict[str, SelectableItem],
-    ) -> list[tuple[str, tuple[float, list[str]]]]:
-        """Return *collected* sorted by ``(-score, id)``, untrimmed.
-
-        Truncation to ``self._top_k`` is the caller's responsibility so
-        ambiguity / runner-up reads can use the full ranking even when
-        ``top_k=1`` (issue #14).
-        """
-        return sorted(
-            (entry for entry in collected.items() if entry[0] in active_items),
-            key=lambda x: (-x[1][0], x[0]),
-        )
-
-    def _expand_subtree(
-        self,
-        query: str,
-        node_id: str,
-        base_score: float,
-        base_path: list[str],
-        active_items: dict[str, SelectableItem],
-        eligible_internals: set[str],
-        *,
-        max_depth: int | None = None,
-    ) -> dict[str, tuple[float, list[str]]]:
-        """Expand children of *node_id* recursively, collecting items.
-
-        Children outside *active_items* (leaves) or *eligible_internals*
-        (internals) are skipped before scoring so excluded subtrees do
-        not consume backtracking work (issue #112 / #22).
-        """
-        depth_limit = max_depth if max_depth is not None else self._max_depth
-        result: dict[str, tuple[float, list[str]]] = {}
-        stack: list[tuple[float, str, list[str], int]] = [(base_score, node_id, base_path, 0)]
-        while stack:
-            score, nid, path, depth = stack.pop()
-            children = self._graph.successors(nid)
-            if not children or depth >= depth_limit:
-                if nid in active_items:
-                    result[nid] = (score, path[1:])
-                continue
-            for child in sorted(children):
-                if not self._is_eligible_child(child, active_items, eligible_internals):
-                    continue
-                s = self._score_node(query, child)
-                new_path = path + [child]
-                if child in self._items:
-                    result[child] = (score + s, new_path[1:])
-                else:
-                    stack.append((score + s, child, new_path, depth + 1))
-        return result
+            sims[item_id] = self._retriever.score_one(summary, idx)
+        return sims

--- a/src/contextweaver/types.py
+++ b/src/contextweaver/types.py
@@ -62,6 +62,11 @@ class SelectableItem:
 
     This is the single vocabulary the Routing Engine operates on.  Use the
     :data:`ToolCard` alias when you want to emphasise the tool-card framing.
+
+    The optional ``depends_on`` / ``provides`` / ``requires`` fields (issue
+    #27 Phase 2) carry tool-dependency metadata used by history-aware
+    routing.  All three default to ``None`` so existing catalogs round-trip
+    unchanged.
     """
 
     id: str
@@ -77,10 +82,18 @@ class SelectableItem:
     side_effects: bool = False
     cost_hint: float = 0.0
     metadata: dict[str, Any] = field(default_factory=dict)
+    depends_on: list[str] | None = None
+    provides: list[str] | None = None
+    requires: list[str] | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialise to a JSON-compatible dict."""
-        return {
+        """Serialise to a JSON-compatible dict.
+
+        ``depends_on`` / ``provides`` / ``requires`` are omitted from the
+        payload when ``None`` so older consumers see the same shape as
+        before issue #27 Phase 2.
+        """
+        payload: dict[str, Any] = {
             "id": self.id,
             "kind": self.kind,
             "name": self.name,
@@ -95,10 +108,21 @@ class SelectableItem:
             "cost_hint": self.cost_hint,
             "metadata": dict(self.metadata),
         }
+        if self.depends_on is not None:
+            payload["depends_on"] = list(self.depends_on)
+        if self.provides is not None:
+            payload["provides"] = list(self.provides)
+        if self.requires is not None:
+            payload["requires"] = list(self.requires)
+        return payload
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SelectableItem:
-        """Deserialise from a JSON-compatible dict."""
+        """Deserialise from a JSON-compatible dict.
+
+        Missing ``depends_on`` / ``provides`` / ``requires`` keys round-trip
+        to ``None`` (issue #27 Phase 2).
+        """
         return cls(
             id=data["id"],
             kind=data["kind"],
@@ -115,6 +139,9 @@ class SelectableItem:
             side_effects=bool(data.get("side_effects", False)),
             cost_hint=float(data.get("cost_hint", 0.0)),
             metadata=dict(data.get("metadata", {})),
+            depends_on=list(data["depends_on"]) if data.get("depends_on") is not None else None,
+            provides=list(data["provides"]) if data.get("provides") is not None else None,
+            requires=list(data["requires"]) if data.get("requires") is not None else None,
         )
 
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -82,6 +82,58 @@ def test_filter_by_tags() -> None:
     assert [r.id for r in results] == ["t1"]
 
 
+# ------------------------------------------------------------------
+# validate_dependencies (issue #27 phase 2)
+# ------------------------------------------------------------------
+
+
+def test_validate_dependencies_returns_empty_for_consistent_catalog() -> None:
+    catalog = Catalog()
+    catalog.register(_item("auth"))
+    catalog.register(
+        SelectableItem(
+            id="send_email",
+            kind="tool",
+            name="send_email",
+            description="email",
+            depends_on=["auth"],
+        )
+    )
+    assert catalog.validate_dependencies() == []
+
+
+def test_validate_dependencies_warns_on_unknown_reference() -> None:
+    catalog = Catalog()
+    catalog.register(
+        SelectableItem(
+            id="send_email",
+            kind="tool",
+            name="send_email",
+            description="email",
+            depends_on=["does_not_exist"],
+        )
+    )
+    warnings = catalog.validate_dependencies()
+    assert len(warnings) == 1
+    assert "send_email" in warnings[0]
+    assert "does_not_exist" in warnings[0]
+
+
+def test_validate_dependencies_warns_per_missing_reference() -> None:
+    catalog = Catalog()
+    catalog.register(
+        SelectableItem(
+            id="send_email",
+            kind="tool",
+            name="send_email",
+            description="email",
+            depends_on=["missing_a", "missing_b"],
+        )
+    )
+    warnings = catalog.validate_dependencies()
+    assert len(warnings) == 2
+
+
 def test_roundtrip() -> None:
     catalog = Catalog()
     catalog.register(_item("t1", tags=["a"]))

--- a/tests/test_extras_embeddings.py
+++ b/tests/test_extras_embeddings.py
@@ -1,0 +1,220 @@
+"""Tests for contextweaver.extras.embeddings (issue #8).
+
+Default-install tests use a deterministic mock backend; the real sentence-
+transformers integration test is gated behind :func:`pytest.importorskip`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+
+import pytest
+
+from contextweaver.extras.embeddings import HybridEmbeddingRetriever
+from contextweaver.protocols import EmbeddingBackend
+from contextweaver.routing.router import Router
+from contextweaver.routing.tree import TreeBuilder
+from contextweaver.types import SelectableItem
+
+# ---------------------------------------------------------------------------
+# Deterministic mock backend
+# ---------------------------------------------------------------------------
+
+
+class HashEmbeddingBackend:
+    """Deterministic stand-in :class:`EmbeddingBackend` for unit tests.
+
+    Embeds each text as a 16-dim L2-normalised vector derived from a SHA-256
+    hash of the text.  Reproducible across runs / processes — no model
+    download or randomness.
+    """
+
+    DIM = 16
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        out: list[list[float]] = []
+        for text in texts:
+            digest = hashlib.sha256(text.encode("utf-8")).digest()
+            # Take the first DIM bytes, scale to [-1, 1].
+            vec = [(b - 128) / 128.0 for b in digest[: self.DIM]]
+            norm = math.sqrt(sum(x * x for x in vec)) or 1.0
+            out.append([x / norm for x in vec])
+        return out
+
+    def similarity(
+        self,
+        query_vec: list[float],
+        corpus_vecs: list[list[float]],
+    ) -> list[float]:
+        return [sum(a * b for a, b in zip(query_vec, v, strict=False)) for v in corpus_vecs]
+
+
+def _item(
+    iid: str,
+    *,
+    name: str | None = None,
+    description: str = "desc",
+    tags: list[str] | None = None,
+    namespace: str = "",
+) -> SelectableItem:
+    return SelectableItem(
+        id=iid,
+        kind="tool",
+        name=name or iid,
+        description=description,
+        tags=list(tags or []),
+        namespace=namespace,
+    )
+
+
+# ---------------------------------------------------------------------------
+# EmbeddingBackend protocol surface
+# ---------------------------------------------------------------------------
+
+
+def test_hash_backend_implements_embedding_backend_protocol() -> None:
+    """The mock backend satisfies the public protocol shape used by Router."""
+    backend = HashEmbeddingBackend()
+    assert isinstance(backend, EmbeddingBackend)
+
+
+# ---------------------------------------------------------------------------
+# HybridEmbeddingRetriever — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_hybrid_retriever_fit_then_score_one_is_in_unit_range_for_normalised_backend() -> None:
+    backend = HashEmbeddingBackend()
+    retriever = HybridEmbeddingRetriever(backend)
+    retriever.fit(["read database", "send email", "search docs"])
+    # Hybrid score = 0.7 * cos + 0.3 * tfidf; with unit-norm vectors the cos
+    # component is in [-1, 1] and tfidf is non-negative, so the hybrid is
+    # bounded.
+    s = retriever.score_one("read database", 0)
+    assert -1.0 <= s <= 1.0 + 0.3  # +0.3 cap from the tfidf weight
+
+
+def test_hybrid_retriever_search_returns_top_k_sorted_desc_with_id_tie_break() -> None:
+    backend = HashEmbeddingBackend()
+    retriever = HybridEmbeddingRetriever(backend)
+    retriever.fit(["alpha", "beta", "gamma", "delta", "epsilon"])
+    out = retriever.search("alpha", top_k=3)
+    assert len(out) == 3
+    scores = [score for _, score in out]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_hybrid_retriever_empty_corpus_returns_empty_search() -> None:
+    backend = HashEmbeddingBackend()
+    retriever = HybridEmbeddingRetriever(backend)
+    retriever.fit([])
+    assert retriever.search("query", top_k=5) == []
+
+
+def test_hybrid_retriever_score_one_returns_zero_for_out_of_range_index() -> None:
+    backend = HashEmbeddingBackend()
+    retriever = HybridEmbeddingRetriever(backend)
+    retriever.fit(["a", "b"])
+    assert retriever.score_one("q", -1) == 0.0
+    assert retriever.score_one("q", 5) == 0.0
+
+
+def test_hybrid_retriever_rejects_out_of_range_embedding_weight() -> None:
+    backend = HashEmbeddingBackend()
+    with pytest.raises(ValueError, match="embedding_weight"):
+        HybridEmbeddingRetriever(backend, embedding_weight=1.5)
+    with pytest.raises(ValueError, match="embedding_weight"):
+        HybridEmbeddingRetriever(backend, embedding_weight=-0.1)
+
+
+def test_hybrid_retriever_score_one_is_deterministic_for_same_query() -> None:
+    backend = HashEmbeddingBackend()
+    retriever = HybridEmbeddingRetriever(backend)
+    retriever.fit(["read database", "send email"])
+    a = retriever.score_one("read database", 0)
+    b = retriever.score_one("read database", 0)
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# Router integration with embedding_backend
+# ---------------------------------------------------------------------------
+
+
+def test_router_accepts_embedding_backend_and_routes_successfully() -> None:
+    items = [
+        _item("db_read", description="Read from the database", tags=["data"]),
+        _item("send_email", description="Send an email", tags=["comm"]),
+        _item("search_docs", description="Search documentation", tags=["search"]),
+    ]
+    graph = TreeBuilder().build(items)
+    router = Router(
+        graph,
+        items=items,
+        embedding_backend=HashEmbeddingBackend(),
+        top_k=3,
+    )
+    result = router.route("read database")
+    assert result.candidate_ids  # at least one match
+    assert result.trace.retriever_engine == "embedding+tfidf"
+
+
+def test_router_rejects_both_retriever_and_embedding_backend() -> None:
+    from contextweaver.exceptions import ConfigError
+    from contextweaver.routing.registry import TfIdfRetriever
+
+    items = [_item("a"), _item("b")]
+    graph = TreeBuilder().build(items)
+    with pytest.raises(ConfigError, match="retriever= or embedding_backend="):
+        Router(
+            graph,
+            items=items,
+            retriever=TfIdfRetriever(),
+            embedding_backend=HashEmbeddingBackend(),
+        )
+
+
+def test_router_without_embedding_backend_falls_back_to_tfidf() -> None:
+    items = [_item("a"), _item("b")]
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items)
+    result = router.route("anything")
+    assert result.trace.retriever_engine == "tfidf"
+
+
+# ---------------------------------------------------------------------------
+# Real sentence-transformers integration (skipped when extra not installed)
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_transformer_backend_real_model_round_trip() -> None:
+    """End-to-end sanity check with the real sentence-transformers library."""
+    pytest.importorskip("sentence_transformers")
+    from contextweaver.extras.embeddings import SentenceTransformerBackend
+
+    backend = SentenceTransformerBackend("all-MiniLM-L6-v2")
+    vecs = backend.embed(["read database", "send email"])
+    assert len(vecs) == 2
+    assert all(len(v) == len(vecs[0]) for v in vecs)
+    # Self-similarity dominates cross-similarity
+    sims_self = backend.similarity(vecs[0], [vecs[0]])
+    sims_cross = backend.similarity(vecs[0], [vecs[1]])
+    assert sims_self[0] > sims_cross[0]
+
+
+def test_sentence_transformer_backend_top_k_membership_for_known_query() -> None:
+    """The hybrid retriever returns the lexically + semantically closest item first."""
+    pytest.importorskip("sentence_transformers")
+    from contextweaver.extras.embeddings import SentenceTransformerBackend
+
+    items = [
+        _item("schedule_meeting", description="Schedule a meeting on the calendar"),
+        _item("send_email", description="Send an email message"),
+        _item("create_invoice", description="Create a new invoice for billing"),
+    ]
+    graph = TreeBuilder().build(items)
+    backend = SentenceTransformerBackend("all-MiniLM-L6-v2")
+    router = Router(graph, items=items, embedding_backend=backend, top_k=3)
+    result = router.route("book a calendar event")
+    assert "schedule_meeting" in result.candidate_ids

--- a/tests/test_extras_embeddings.py
+++ b/tests/test_extras_embeddings.py
@@ -11,6 +11,7 @@ import math
 
 import pytest
 
+from contextweaver.exceptions import ConfigError
 from contextweaver.extras.embeddings import HybridEmbeddingRetriever
 from contextweaver.protocols import EmbeddingBackend
 from contextweaver.routing.router import Router
@@ -122,9 +123,9 @@ def test_hybrid_retriever_score_one_returns_zero_for_out_of_range_index() -> Non
 
 def test_hybrid_retriever_rejects_out_of_range_embedding_weight() -> None:
     backend = HashEmbeddingBackend()
-    with pytest.raises(ValueError, match="embedding_weight"):
+    with pytest.raises(ConfigError, match="embedding_weight"):
         HybridEmbeddingRetriever(backend, embedding_weight=1.5)
-    with pytest.raises(ValueError, match="embedding_weight"):
+    with pytest.raises(ConfigError, match="embedding_weight"):
         HybridEmbeddingRetriever(backend, embedding_weight=-0.1)
 
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,202 @@
+"""Tests for contextweaver.routing.history (issue #27)."""
+
+from __future__ import annotations
+
+import pytest
+
+from contextweaver.routing.history import (
+    DEFAULT_DEPENDENCY_SATISFIED_BOOST,
+    DEFAULT_DEPENDENCY_UNSATISFIED_PENALTY,
+    DEFAULT_REPEAT_PENALTY,
+    DEFAULT_RESULT_BOOST_WEIGHT,
+    RouteHistory,
+    adjust_scores,
+)
+from contextweaver.types import SelectableItem
+
+
+def _item(iid: str, **kw: object) -> SelectableItem:
+    return SelectableItem(
+        id=iid,
+        kind="tool",
+        name=str(kw.get("name", iid)),
+        description=str(kw.get("description", "desc")),
+        depends_on=kw.get("depends_on"),  # type: ignore[arg-type]
+        provides=kw.get("provides"),  # type: ignore[arg-type]
+        requires=kw.get("requires"),  # type: ignore[arg-type]
+    )
+
+
+# ---------------------------------------------------------------------------
+# RouteHistory dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_route_history_to_dict_round_trips() -> None:
+    h = RouteHistory(
+        called_tool_ids=["a", "b"],
+        last_result_summary="found 3 results",
+        step_number=3,
+        repeat_penalty=0.4,
+        result_boost_weight=0.2,
+    )
+    assert RouteHistory.from_dict(h.to_dict()) == h
+
+
+def test_route_history_from_dict_supplies_defaults_for_missing_keys() -> None:
+    """Old payloads (missing the tuning weights) must still deserialise."""
+    h = RouteHistory.from_dict(
+        {"called_tool_ids": ["a"], "last_result_summary": None, "step_number": 1}
+    )
+    assert h.repeat_penalty == DEFAULT_REPEAT_PENALTY
+    assert h.result_boost_weight == DEFAULT_RESULT_BOOST_WEIGHT
+
+
+def test_route_history_default_state_is_empty_step_one() -> None:
+    h = RouteHistory()
+    assert h.called_tool_ids == []
+    assert h.last_result_summary is None
+    assert h.step_number == 1
+
+
+# ---------------------------------------------------------------------------
+# adjust_scores — rule 1: repeat penalty
+# ---------------------------------------------------------------------------
+
+
+def test_adjust_scores_applies_repeat_penalty_to_called_tools() -> None:
+    items = {"a": _item("a"), "b": _item("b")}
+    history = RouteHistory(called_tool_ids=["a"], repeat_penalty=0.5)
+    scored = [("a", 1.0), ("b", 1.0)]
+    adjusted, deltas = adjust_scores(scored, history, items)
+    by_id = dict(adjusted)
+    assert by_id["a"] == 0.5  # 1.0 * 0.5
+    assert by_id["b"] == 1.0
+    assert deltas == {"a": -0.5}
+
+
+def test_adjust_scores_rerank_demotes_repeated_tool_below_fresh_one() -> None:
+    items = {"a": _item("a"), "b": _item("b")}
+    history = RouteHistory(called_tool_ids=["a"], repeat_penalty=0.5)
+    # ``a`` starts ahead — without history it would lead the ranking.
+    scored = [("a", 0.9), ("b", 0.7)]
+    adjusted, _ = adjust_scores(scored, history, items)
+    # After the penalty: a=0.45, b=0.7 → b wins.
+    assert adjusted[0] == ("b", 0.7)
+    assert adjusted[1][0] == "a"
+
+
+# ---------------------------------------------------------------------------
+# adjust_scores — rule 2: result-summary boost
+# ---------------------------------------------------------------------------
+
+
+def test_adjust_scores_applies_result_summary_boost() -> None:
+    items = {"a": _item("a"), "b": _item("b")}
+    history = RouteHistory(last_result_summary="result", result_boost_weight=0.5)
+    scored = [("a", 0.5), ("b", 0.5)]
+    result_sim = {"a": 1.0, "b": 0.0}
+    adjusted, deltas = adjust_scores(scored, history, items, result_similarity=result_sim)
+    by_id = dict(adjusted)
+    assert by_id["a"] == 0.5 + 0.5 * 1.0
+    assert by_id["b"] == 0.5
+    assert deltas == {"a": 0.5}
+
+
+def test_adjust_scores_skips_result_boost_when_similarity_map_is_none() -> None:
+    items = {"a": _item("a")}
+    history = RouteHistory(last_result_summary=None)
+    scored = [("a", 0.5)]
+    adjusted, deltas = adjust_scores(scored, history, items, result_similarity=None)
+    assert adjusted == [("a", 0.5)]
+    assert deltas == {}
+
+
+# ---------------------------------------------------------------------------
+# adjust_scores — rule 3: dependency satisfied boost
+# ---------------------------------------------------------------------------
+
+
+def test_adjust_scores_boosts_when_requires_is_satisfied_by_provides_of_called() -> None:
+    items = {
+        "search_contacts": _item("search_contacts", provides=["contact_id"]),
+        "send_email": _item("send_email", requires=["contact_id"]),
+    }
+    history = RouteHistory(called_tool_ids=["search_contacts"])
+    scored = [("send_email", 0.5)]
+    adjusted, deltas = adjust_scores(scored, history, items)
+    assert adjusted[0][0] == "send_email"
+    assert adjusted[0][1] == pytest.approx(0.5 + DEFAULT_DEPENDENCY_SATISFIED_BOOST)
+    assert deltas["send_email"] == pytest.approx(DEFAULT_DEPENDENCY_SATISFIED_BOOST)
+
+
+def test_adjust_scores_does_not_boost_when_requires_unsatisfied() -> None:
+    items = {
+        "send_email": _item("send_email", requires=["contact_id"]),
+    }
+    history = RouteHistory(called_tool_ids=[])  # no tools provide anything
+    scored = [("send_email", 0.5)]
+    adjusted, deltas = adjust_scores(scored, history, items)
+    assert adjusted == [("send_email", 0.5)]
+    assert deltas == {}
+
+
+# ---------------------------------------------------------------------------
+# adjust_scores — rule 4: dependency unsatisfied penalty
+# ---------------------------------------------------------------------------
+
+
+def test_adjust_scores_penalises_when_depends_on_references_uncalled_tool() -> None:
+    items = {
+        "send_email": _item("send_email", depends_on=["auth_login"]),
+    }
+    history = RouteHistory(called_tool_ids=["unrelated_tool"])
+    scored = [("send_email", 0.5)]
+    adjusted, deltas = adjust_scores(scored, history, items)
+    assert adjusted[0][0] == "send_email"
+    assert adjusted[0][1] == pytest.approx(0.5 - DEFAULT_DEPENDENCY_UNSATISFIED_PENALTY)
+    assert deltas["send_email"] == pytest.approx(-DEFAULT_DEPENDENCY_UNSATISFIED_PENALTY)
+
+
+def test_adjust_scores_does_not_penalise_when_depends_on_is_satisfied() -> None:
+    items = {
+        "send_email": _item("send_email", depends_on=["auth_login"]),
+    }
+    history = RouteHistory(called_tool_ids=["auth_login"])
+    scored = [("send_email", 0.5)]
+    adjusted, deltas = adjust_scores(scored, history, items)
+    assert adjusted == [("send_email", 0.5)]
+    assert deltas == {}
+
+
+# ---------------------------------------------------------------------------
+# Determinism + sort stability
+# ---------------------------------------------------------------------------
+
+
+def test_adjust_scores_resorts_by_negative_score_then_id() -> None:
+    items = {"a": _item("a"), "b": _item("b"), "c": _item("c")}
+    history = RouteHistory(called_tool_ids=["a"], repeat_penalty=0.5)
+    scored = [("a", 1.0), ("b", 0.5), ("c", 0.5)]
+    adjusted, _ = adjust_scores(scored, history, items)
+    # After penalty: a=0.5, b=0.5, c=0.5 — three-way tie on score, id-asc breaks it.
+    assert [iid for iid, _ in adjusted] == ["a", "b", "c"]
+
+
+def test_adjust_scores_is_deterministic_across_calls() -> None:
+    items = {"a": _item("a"), "b": _item("b")}
+    history = RouteHistory(called_tool_ids=["a"])
+    scored = [("a", 1.0), ("b", 0.5)]
+    out_1, deltas_1 = adjust_scores(scored, history, items)
+    out_2, deltas_2 = adjust_scores(scored, history, items)
+    assert out_1 == out_2
+    assert deltas_1 == deltas_2
+
+
+def test_adjust_scores_tolerates_unknown_called_tool_ids() -> None:
+    """called_tool_ids referencing items absent from the catalog must not error."""
+    items = {"b": _item("b")}
+    history = RouteHistory(called_tool_ids=["a_ghost"])  # not in items
+    scored = [("b", 0.5)]
+    adjusted, _ = adjust_scores(scored, history, items)
+    assert adjusted == [("b", 0.5)]

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -438,6 +438,104 @@ def test_build_route_prompt_sync_alias() -> None:
 
 
 # ---------------------------------------------------------------------------
+# build_route_prompt history-aware (issue #27)
+# ---------------------------------------------------------------------------
+
+
+def test_build_route_prompt_with_no_tool_results_produces_no_history_adjustments() -> None:
+    """First routing call in a session: log has no tool results → no history."""
+    items = _make_selectable_items()
+    graph = TreeBuilder(max_children=10).build(items)
+    router = Router(graph, items=items)
+
+    log = InMemoryEventLog()
+    log.append(ContextItem(id="u1", kind=ItemKind.user_turn, text="read database"))
+    mgr = ContextManager(event_log=log)
+    _, _, result = mgr.build_route_prompt(
+        goal="Find data tools", query="read database", router=router
+    )
+    assert result.history_adjustments == {}
+
+
+def test_build_route_prompt_auto_constructs_history_from_event_log() -> None:
+    """When the event log has a prior tool_result, the router sees a RouteHistory."""
+    items = _make_selectable_items()
+    graph = TreeBuilder(max_children=10).build(items)
+    router = Router(graph, items=items, top_k=5)
+
+    log = InMemoryEventLog()
+    log.append(ContextItem(id="u1", kind=ItemKind.user_turn, text="read database"))
+    log.append(
+        ContextItem(
+            id="tc1",
+            parent_id=None,
+            kind=ItemKind.tool_call,
+            text="db_read invoked",
+        )
+    )
+    # The tool_result.parent_id is the tool call's id but we expose called
+    # tool ids via that — see the _build_route_history_from_log helper.
+    log.append(
+        ContextItem(
+            id="tr1",
+            parent_id="db_read",
+            kind=ItemKind.tool_result,
+            text="rows: id, name, email",
+        )
+    )
+
+    mgr = ContextManager(event_log=log)
+    _, _, result = mgr.build_route_prompt(
+        goal="Find next tool", query="read database again", router=router
+    )
+    # db_read was already called → it should get a negative adjustment
+    assert result.history_adjustments.get("db_read", 0.0) < 0.0
+
+
+def test_build_route_prompt_history_from_log_can_be_disabled() -> None:
+    """Setting history_from_log=False preserves stateless pre-#27 behaviour."""
+    items = _make_selectable_items()
+    graph = TreeBuilder(max_children=10).build(items)
+    router = Router(graph, items=items, top_k=5)
+
+    log = InMemoryEventLog()
+    log.append(ContextItem(id="tr1", parent_id="db_read", kind=ItemKind.tool_result, text="rows"))
+    mgr = ContextManager(event_log=log)
+    _, _, result = mgr.build_route_prompt(
+        goal="g",
+        query="read database",
+        router=router,
+        history_from_log=False,
+    )
+    assert result.history_adjustments == {}
+
+
+def test_build_route_prompt_explicit_history_overrides_event_log_construction() -> None:
+    """An explicit ``history=`` wins over the auto-built one."""
+    from contextweaver.routing.history import RouteHistory
+
+    items = _make_selectable_items()
+    graph = TreeBuilder(max_children=10).build(items)
+    # beam_width has to be wide enough that send_email is one of the candidates
+    # for the query we send, otherwise it never reaches the history-adjustment
+    # phase.
+    router = Router(graph, items=items, beam_width=5, top_k=5)
+
+    log = InMemoryEventLog()
+    log.append(ContextItem(id="tr1", parent_id="db_read", kind=ItemKind.tool_result, text="rows"))
+    mgr = ContextManager(event_log=log)
+    explicit = RouteHistory(called_tool_ids=["send_email"], repeat_penalty=0.1)
+    _, _, result = mgr.build_route_prompt(
+        goal="g", query="send email notification", router=router, history=explicit
+    )
+    # The explicit history names send_email, so we expect send_email to get the
+    # adjustment.  db_read is not in the explicit called list so it must NOT
+    # receive a repeat penalty even though the log mentions db_read.
+    assert "send_email" in result.history_adjustments
+    assert "db_read" not in result.history_adjustments
+
+
+# ---------------------------------------------------------------------------
 # build_call_prompt
 # ---------------------------------------------------------------------------
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -471,14 +471,16 @@ def test_build_route_prompt_auto_constructs_history_from_event_log() -> None:
             parent_id=None,
             kind=ItemKind.tool_call,
             text="db_read invoked",
+            metadata={"function_name": "db_read"},
         )
     )
-    # The tool_result.parent_id is the tool call's id but we expose called
-    # tool ids via that — see the _build_route_history_from_log helper.
+    # In production, tool_result.parent_id points to the tool_call item id
+    # ("tc1"), not the tool catalog id ("db_read"). The resolver derives the
+    # catalog id via the tool_call's metadata["function_name"].
     log.append(
         ContextItem(
             id="tr1",
-            parent_id="db_read",
+            parent_id="tc1",
             kind=ItemKind.tool_result,
             text="rows: id, name, email",
         )
@@ -499,7 +501,15 @@ def test_build_route_prompt_history_from_log_can_be_disabled() -> None:
     router = Router(graph, items=items, top_k=5)
 
     log = InMemoryEventLog()
-    log.append(ContextItem(id="tr1", parent_id="db_read", kind=ItemKind.tool_result, text="rows"))
+    log.append(
+        ContextItem(
+            id="tc1",
+            kind=ItemKind.tool_call,
+            text="db_read",
+            metadata={"function_name": "db_read"},
+        )
+    )
+    log.append(ContextItem(id="tr1", parent_id="tc1", kind=ItemKind.tool_result, text="rows"))
     mgr = ContextManager(event_log=log)
     _, _, result = mgr.build_route_prompt(
         goal="g",

--- a/tests/test_navigator.py
+++ b/tests/test_navigator.py
@@ -1,0 +1,154 @@
+"""Tests for contextweaver.routing.navigator (issue #56)."""
+
+from __future__ import annotations
+
+from contextweaver.routing.navigator import BeamSearchNavigator, rank_collected
+from contextweaver.routing.registry import TfIdfRetriever
+from contextweaver.routing.tree import TreeBuilder
+from contextweaver.types import SelectableItem
+
+
+def _item(iid: str, **kw: object) -> SelectableItem:
+    return SelectableItem(
+        id=iid,
+        kind="tool",
+        name=str(kw.get("name", iid)),
+        description=str(kw.get("description", "desc")),
+        tags=list(kw.get("tags", [])),  # type: ignore[arg-type]
+        namespace=str(kw.get("namespace", "")),
+    )
+
+
+def _setup() -> tuple[
+    list[SelectableItem],
+    object,
+    TfIdfRetriever,
+    dict[str, int],
+]:
+    items = [
+        _item("db_read", name="read_db", description="Read database", tags=["data"]),
+        _item("db_write", name="write_db", description="Write database", tags=["data"]),
+        _item("send_email", name="send_email", description="Send email", tags=["comm"]),
+        _item("search_docs", name="search_docs", description="Search docs", tags=["search"]),
+    ]
+    graph = TreeBuilder().build(items)
+    retriever = TfIdfRetriever()
+    docs: list[str] = []
+    doc_ids: list[str] = []
+    for it in sorted(items, key=lambda x: x.id):
+        docs.append(f"{it.name} {it.description} {' '.join(it.tags)}")
+        doc_ids.append(it.id)
+    for nid in graph.nodes():
+        if nid not in {it.id for it in items}:
+            node = graph.get_node(nid)
+            docs.append(f"{node.label} {node.routing_hint}")
+            doc_ids.append(nid)
+    retriever.fit(docs)
+    doc_id_to_idx = {did: i for i, did in enumerate(doc_ids)}
+    return items, graph, retriever, doc_id_to_idx
+
+
+def test_navigate_returns_navigation_result_with_collected_items() -> None:
+    items, graph, retriever, doc_id_to_idx = _setup()
+    nav = BeamSearchNavigator(beam_width=3, max_depth=5, top_k=10)
+    result = nav.navigate(
+        "read database",
+        graph,  # type: ignore[arg-type]
+        {it.id: it for it in items},
+        retriever,
+        doc_id_to_idx,
+        all_item_ids={it.id for it in items},
+    )
+    assert "db_read" in result.collected
+    score, path = result.collected["db_read"]
+    assert isinstance(score, float)
+    assert isinstance(path, list)
+
+
+def test_navigate_is_deterministic_across_calls() -> None:
+    items, graph, retriever, doc_id_to_idx = _setup()
+    nav = BeamSearchNavigator(beam_width=3, max_depth=5, top_k=10)
+    a = nav.navigate(
+        "read database",
+        graph,  # type: ignore[arg-type]
+        {it.id: it for it in items},
+        retriever,
+        doc_id_to_idx,
+        all_item_ids={it.id for it in items},
+    )
+    b = nav.navigate(
+        "read database",
+        graph,  # type: ignore[arg-type]
+        {it.id: it for it in items},
+        retriever,
+        doc_id_to_idx,
+        all_item_ids={it.id for it in items},
+    )
+    assert a.collected == b.collected
+
+
+def test_navigate_debug_populates_steps_otherwise_empty() -> None:
+    items, graph, retriever, doc_id_to_idx = _setup()
+    nav = BeamSearchNavigator(beam_width=3, max_depth=5, top_k=10)
+    quiet = nav.navigate(
+        "read",
+        graph,  # type: ignore[arg-type]
+        {it.id: it for it in items},
+        retriever,
+        doc_id_to_idx,
+        all_item_ids={it.id for it in items},
+    )
+    loud = nav.navigate(
+        "read",
+        graph,  # type: ignore[arg-type]
+        {it.id: it for it in items},
+        retriever,
+        doc_id_to_idx,
+        all_item_ids={it.id for it in items},
+        debug=True,
+    )
+    assert quiet.steps == []
+    assert loud.steps
+    # Identical search result either way; debug only affects the trace
+    assert quiet.collected == loud.collected
+
+
+def test_navigate_skips_inactive_items() -> None:
+    """Items removed from active_items must not appear in the collected map."""
+    items, graph, retriever, doc_id_to_idx = _setup()
+    active = {it.id: it for it in items if it.id != "db_read"}
+    nav = BeamSearchNavigator(beam_width=3, max_depth=5, top_k=10)
+    result = nav.navigate(
+        "read database",
+        graph,  # type: ignore[arg-type]
+        active,
+        retriever,
+        doc_id_to_idx,
+        all_item_ids={it.id for it in items},
+    )
+    assert "db_read" not in result.collected
+
+
+def test_rank_collected_sorts_by_negative_score_then_id() -> None:
+    active = {
+        "a": _item("a"),
+        "b": _item("b"),
+        "c": _item("c"),
+    }
+    collected = {
+        "a": (0.3, ["root", "a"]),
+        "b": (0.9, ["root", "b"]),
+        "c": (0.9, ["root", "c"]),  # tie with b → b before c
+    }
+    ranked = rank_collected(collected, active)
+    assert [iid for iid, _ in ranked] == ["b", "c", "a"]
+
+
+def test_rank_collected_drops_inactive_entries() -> None:
+    active = {"a": _item("a")}
+    collected = {
+        "a": (0.5, ["root", "a"]),
+        "ghost": (0.9, ["root", "ghost"]),
+    }
+    ranked = rank_collected(collected, active)
+    assert [iid for iid, _ in ranked] == ["a"]

--- a/tests/test_packer.py
+++ b/tests/test_packer.py
@@ -1,0 +1,82 @@
+"""Tests for contextweaver.routing.packer (issue #56)."""
+
+from __future__ import annotations
+
+from contextweaver.routing.packer import DefaultCardPacker, _estimate_card_tokens
+from contextweaver.types import SelectableItem
+
+
+def _item(iid: str, desc: str = "desc", **kw: object) -> SelectableItem:
+    return SelectableItem(
+        id=iid,
+        kind="tool",
+        name=str(kw.get("name", iid)),
+        description=desc,
+        tags=list(kw.get("tags", [])),  # type: ignore[arg-type]
+        namespace=str(kw.get("namespace", "")),
+    )
+
+
+def test_pack_returns_choice_cards_in_score_descending_id_ascending_order() -> None:
+    """Prompt-cache-stability invariant (issue #218): -score then +id."""
+    items = [
+        _item("z", desc="A test tool"),
+        _item("a", desc="A test tool"),
+        _item("m", desc="A test tool"),
+    ]
+    packer = DefaultCardPacker()
+    scores = {"a": 0.5, "m": 0.5, "z": 0.9}
+    cards = packer.pack(items, scores)
+    assert [c.id for c in cards] == ["z", "a", "m"]
+
+
+def test_pack_passes_max_cards_through() -> None:
+    items = [_item(f"t{i}") for i in range(30)]
+    packer = DefaultCardPacker(max_cards=5)
+    scores = {it.id: 1.0 for it in items}
+    cards = packer.pack(items, scores)
+    assert len(cards) == 5
+
+
+def test_pack_budget_tokens_caps_cumulative_token_estimate() -> None:
+    items = [_item(f"t{i}", desc="x" * 200) for i in range(10)]
+    packer = DefaultCardPacker()
+    scores = {it.id: 1.0 for it in items}
+    cards = packer.pack(items, scores, budget_tokens=1)
+    # The first card always lands (the packer must never return an empty
+    # list when items exist).  But the budget caps subsequent cards.
+    assert cards
+    assert len(cards) < len(items)
+
+
+def test_pack_budget_none_disables_cap() -> None:
+    items = [_item(f"t{i}", desc="x" * 1000) for i in range(5)]
+    packer = DefaultCardPacker()
+    scores = {it.id: 1.0 for it in items}
+    cards = packer.pack(items, scores, budget_tokens=None)
+    assert len(cards) == len(items)
+
+
+def test_pack_empty_items_returns_empty_list() -> None:
+    packer = DefaultCardPacker()
+    assert packer.pack([], {}, budget_tokens=100) == []
+
+
+def test_pack_scores_attached_to_cards() -> None:
+    items = [_item("a"), _item("b")]
+    packer = DefaultCardPacker()
+    cards = packer.pack(items, {"a": 0.8, "b": 0.4})
+    by_id = {c.id: c for c in cards}
+    assert by_id["a"].score == 0.8
+    assert by_id["b"].score == 0.4
+
+
+def test_estimate_card_tokens_uses_char_div_four_heuristic() -> None:
+    items = [_item("a", desc="abcd" * 10)]
+    packer = DefaultCardPacker()
+    cards = packer.pack(items, {"a": 1.0})
+    est = _estimate_card_tokens(cards[0])
+    # Sum of len(id) + len(name) + len(kind) + len(summary) + len(tags) divided by 4.
+    assert est >= 0
+    # Not absurdly large for a short item
+    assert est < 200

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,222 @@
+"""Tests for contextweaver.routing.pipeline (issue #56)."""
+
+from __future__ import annotations
+
+import pytest
+
+from contextweaver.profiles import RoutingConfig
+from contextweaver.protocols import (
+    CardPacker,
+    Navigator,
+    Reranker,
+    Retriever,
+)
+from contextweaver.routing.navigator import BeamSearchNavigator
+from contextweaver.routing.packer import DefaultCardPacker
+from contextweaver.routing.pipeline import RoutingPipeline
+from contextweaver.routing.registry import EngineRegistry, TfIdfRetriever
+from contextweaver.routing.tree import TreeBuilder
+from contextweaver.types import SelectableItem
+
+
+def _item(iid: str, **kw: object) -> SelectableItem:
+    return SelectableItem(
+        id=iid,
+        kind="tool",
+        name=str(kw.get("name", iid)),
+        description=str(kw.get("description", "desc")),
+        tags=list(kw.get("tags", [])),  # type: ignore[arg-type]
+        namespace=str(kw.get("namespace", "")),
+    )
+
+
+def _catalog() -> list[SelectableItem]:
+    return [
+        _item("db_read", name="read_db", description="Read database", tags=["data"]),
+        _item("db_write", name="write_db", description="Write database", tags=["data"]),
+        _item("send_email", name="send_email", description="Send email", tags=["comm"]),
+        _item("search_docs", name="search_docs", description="Search docs", tags=["search"]),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# from_config
+# ---------------------------------------------------------------------------
+
+
+def test_from_config_default_pipeline_has_all_stages_wired() -> None:
+    """Default pipeline wires retriever + navigator + packer; reranker is None."""
+    pipeline = RoutingPipeline.from_config(RoutingConfig())
+    assert isinstance(pipeline.retriever, Retriever)
+    assert pipeline.reranker is None  # NEW pipeline does not enable rerank by default
+    assert isinstance(pipeline.navigator, Navigator)
+    assert isinstance(pipeline.packer, CardPacker)
+
+
+def test_from_config_propagates_routing_config_to_navigator() -> None:
+    """beam_width / max_depth / top_k / confidence_gap flow into the navigator."""
+    cfg = RoutingConfig(beam_width=5, max_depth=12, top_k=7, confidence_gap=0.25)
+    pipeline = RoutingPipeline.from_config(cfg)
+    assert isinstance(pipeline.navigator, BeamSearchNavigator)
+    nav = pipeline.navigator
+    # Internal fields are private but stable; assert via repr / vars to pin
+    assert nav._beam_width == 5
+    assert nav._max_depth == 12
+    assert nav._top_k == 7
+    assert nav._confidence_gap == 0.25
+
+
+def test_from_config_uses_default_registry_when_none() -> None:
+    pipeline = RoutingPipeline.from_config()
+    assert isinstance(pipeline.retriever, Retriever)
+
+
+def test_from_config_respects_custom_registry() -> None:
+    """A registry with a non-default retriever is honoured."""
+
+    class _ConstantRetriever:
+        def fit(self, corpus: list[str]) -> None:
+            self._n = len(corpus)
+
+        def search(self, query: str, top_k: int) -> list[tuple[int, float]]:
+            return [(i, 0.5) for i in range(min(top_k, self._n))]
+
+        def score_one(self, query: str, index: int) -> float:
+            return 0.5
+
+    reg = EngineRegistry()
+    reg.register("retriever", "constant", _ConstantRetriever, default=True)
+    pipeline = RoutingPipeline.from_config(registry=reg)
+    assert type(pipeline.retriever).__name__ == "_ConstantRetriever"
+
+
+# ---------------------------------------------------------------------------
+# Direct construction
+# ---------------------------------------------------------------------------
+
+
+def test_direct_construction_accepts_only_retriever() -> None:
+    """Pipeline can be constructed with only a retriever; other slots are None / default."""
+    pipeline = RoutingPipeline(retriever=TfIdfRetriever())
+    assert pipeline.reranker is None
+    assert pipeline.navigator is None
+    assert isinstance(pipeline.packer, DefaultCardPacker)
+
+
+def test_direct_construction_accepts_explicit_reranker() -> None:
+    """An explicit reranker survives construction unchanged."""
+
+    class _IdReranker:
+        def rerank(
+            self,
+            query: str,
+            candidates: list[tuple[str, float]],
+        ) -> list[tuple[str, float]]:
+            return list(candidates)
+
+    pipeline = RoutingPipeline(retriever=TfIdfRetriever(), reranker=_IdReranker())
+    assert isinstance(pipeline.reranker, Reranker)
+    assert type(pipeline.reranker).__name__ == "_IdReranker"
+
+
+# ---------------------------------------------------------------------------
+# Stage-level entry points
+# ---------------------------------------------------------------------------
+
+
+def test_navigate_in_isolation_returns_navigation_result() -> None:
+    items = _catalog()
+    graph = TreeBuilder().build(items)
+    retriever = TfIdfRetriever()
+    docs = [f"{it.name} {it.description} {' '.join(it.tags)}" for it in items]
+    retriever.fit(docs)
+    doc_id_to_idx = {it.id: i for i, it in enumerate(items)}
+    pipeline = RoutingPipeline(
+        retriever=retriever,
+        navigator=BeamSearchNavigator(beam_width=3, max_depth=5, top_k=10),
+    )
+    result = pipeline.navigate(
+        "read database",
+        graph,
+        {it.id: it for it in items},
+        doc_id_to_idx,
+        all_item_ids={it.id for it in items},
+    )
+    assert "db_read" in result.collected
+    assert result.steps == []  # debug=False
+
+
+def test_navigate_with_debug_populates_steps() -> None:
+    items = _catalog()
+    graph = TreeBuilder().build(items)
+    retriever = TfIdfRetriever()
+    docs = [f"{it.name} {it.description} {' '.join(it.tags)}" for it in items]
+    retriever.fit(docs)
+    doc_id_to_idx = {it.id: i for i, it in enumerate(items)}
+    pipeline = RoutingPipeline.from_config(RoutingConfig(beam_width=3, max_depth=5))
+    pipeline = RoutingPipeline(retriever=retriever, navigator=pipeline.navigator)
+    result = pipeline.navigate(
+        "read database",
+        graph,
+        {it.id: it for it in items},
+        doc_id_to_idx,
+        all_item_ids={it.id for it in items},
+        debug=True,
+    )
+    assert result.steps  # at least one step recorded
+
+
+def test_rerank_with_no_reranker_is_passthrough() -> None:
+    pipeline = RoutingPipeline(retriever=TfIdfRetriever())
+    pairs = [("a", 0.9), ("b", 0.5), ("c", 0.1)]
+    assert pipeline.rerank("any query", pairs) == pairs
+
+
+def test_rerank_calls_reranker_when_present() -> None:
+    """Reranker.rerank() is invoked; result threads through verbatim."""
+
+    class _ReverseReranker:
+        def rerank(
+            self,
+            query: str,
+            candidates: list[tuple[str, float]],
+        ) -> list[tuple[str, float]]:
+            return list(reversed(candidates))
+
+    pipeline = RoutingPipeline(retriever=TfIdfRetriever(), reranker=_ReverseReranker())
+    pairs = [("a", 0.9), ("b", 0.5)]
+    assert pipeline.rerank("q", pairs) == [("b", 0.5), ("a", 0.9)]
+
+
+def test_pack_renders_choice_cards() -> None:
+    items = _catalog()
+    pipeline = RoutingPipeline(retriever=TfIdfRetriever())
+    scores = {it.id: 1.0 - 0.1 * i for i, it in enumerate(items)}
+    cards = pipeline.pack(items, scores)
+    assert len(cards) == len(items)
+    # Score-descending order with id tie-break — established invariant (#218)
+    assert cards[0].id == items[0].id  # highest score by construction
+    assert cards[0].score is not None
+    assert cards[0].score >= (cards[-1].score or -1.0)
+
+
+def test_pack_respects_budget_tokens_soft_cap() -> None:
+    items = _catalog()
+    pipeline = RoutingPipeline(retriever=TfIdfRetriever())
+    scores = {it.id: 1.0 for it in items}
+    # Forcing a tiny budget — at least one card must always come back so the
+    # pipeline never returns an empty list when items exist.
+    cards = pipeline.pack(items, scores, budget_tokens=1)
+    assert cards
+    assert len(cards) < len(items)
+
+
+# ---------------------------------------------------------------------------
+# Defensive: invalid construction
+# ---------------------------------------------------------------------------
+
+
+def test_pipeline_retriever_field_is_required() -> None:
+    """Retriever has no default and must be supplied."""
+    with pytest.raises(TypeError):
+        RoutingPipeline()  # type: ignore[call-arg]

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -772,3 +772,175 @@ def test_route_result_explanation_surfaces_context_hints() -> None:
     md = router.route("send notification", context_hints=["email"]).explanation()
     assert "Context hints applied" in md
     assert "email" in md
+
+
+# ------------------------------------------------------------------
+# Pipeline-level public surface (issue #56)
+# ------------------------------------------------------------------
+
+
+def test_router_exposes_pipeline_property() -> None:
+    """The Router holds the RoutingPipeline it delegates to (issue #56)."""
+    from contextweaver.routing.pipeline import RoutingPipeline
+
+    items = _build_catalog_items()
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items)
+    assert isinstance(router.pipeline, RoutingPipeline)
+    # Same retriever instance — single source of truth for the fitted corpus.
+    assert router.pipeline.retriever is router._retriever  # type: ignore[attr-defined]
+
+
+def test_router_results_unchanged_after_pipeline_refactor_for_a_handful_of_queries() -> None:
+    """Spot-check regression gate: known queries return their known top item."""
+    items = _build_catalog_items()
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items, top_k=1)
+    assert router.route("read database").candidate_ids[0] == "db_read"
+    assert router.route("send email to user").candidate_ids[0] == "send_email"
+    assert router.route("search documentation").candidate_ids[0] == "search_docs"
+
+
+# ------------------------------------------------------------------
+# History-aware routing (issue #27)
+# ------------------------------------------------------------------
+
+
+def test_route_without_history_kwarg_is_identical_to_pre_27() -> None:
+    """Backward-compat: omitting history= must reproduce the prior shape."""
+    items = _build_catalog_items()
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items, top_k=3)
+    result = router.route("read database")
+    assert result.history_adjustments == {}
+    assert "history_adjustments" not in result.trace.extra
+
+
+def test_route_with_history_deprioritises_called_tool() -> None:
+    from contextweaver.routing.history import RouteHistory
+
+    items = _build_catalog_items()
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items, top_k=5)
+
+    # Without history: db_read leads.
+    fresh = router.route("read database")
+    assert fresh.candidate_ids[0] == "db_read"
+
+    # With history saying db_read already ran: the penalty pushes it down.
+    history = RouteHistory(
+        called_tool_ids=["db_read"],
+        last_result_summary=None,
+        repeat_penalty=0.1,
+    )
+    rerouted = router.route("read database", history=history)
+    # db_read must no longer be the top pick after a strong penalty.
+    assert rerouted.candidate_ids[0] != "db_read"
+    # The score delta is reported on the result.
+    assert rerouted.history_adjustments.get("db_read", 0.0) < 0.0
+
+
+def test_route_history_adjustments_surface_on_trace_extra() -> None:
+    from contextweaver.routing.history import RouteHistory
+
+    items = _build_catalog_items()
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items, top_k=5)
+    history = RouteHistory(called_tool_ids=["db_read"], repeat_penalty=0.5)
+    result = router.route("read database", history=history)
+    assert "history_adjustments" in result.trace.extra
+    assert result.trace.extra["history_adjustments"] == result.history_adjustments
+
+
+def test_route_history_with_unsatisfied_depends_on_penalises_dependent_tool() -> None:
+    """Phase 2: depends_on referencing an uncalled tool subtracts the penalty."""
+    from contextweaver.routing.history import RouteHistory
+    from contextweaver.types import SelectableItem
+
+    items = [
+        SelectableItem(
+            id="auth_login",
+            kind="tool",
+            name="auth_login",
+            description="Authenticate the user",
+            tags=["auth"],
+        ),
+        SelectableItem(
+            id="send_email",
+            kind="tool",
+            name="send_email",
+            description="Send email",
+            tags=["comm"],
+            depends_on=["auth_login"],
+        ),
+    ]
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items, top_k=2)
+    # Empty history — auth_login has not run yet, so send_email should be
+    # penalised.  We assert the delta is negative; absolute ranking depends
+    # on other terms.
+    history = RouteHistory(called_tool_ids=[])
+    result = router.route("send the email", history=history)
+    assert result.history_adjustments.get("send_email", 0.0) < 0.0
+
+
+def test_route_history_with_provides_requires_boosts_satisfied_tool() -> None:
+    """Phase 2: requires fully satisfied by called tools' provides adds the boost."""
+    from contextweaver.routing.history import RouteHistory
+    from contextweaver.types import SelectableItem
+
+    items = [
+        SelectableItem(
+            id="search_contacts",
+            kind="tool",
+            name="search_contacts",
+            description="Search the contacts directory",
+            tags=["contacts"],
+            provides=["contact_id"],
+        ),
+        SelectableItem(
+            id="send_email",
+            kind="tool",
+            name="send_email",
+            description="Send email to a contact",
+            tags=["comm"],
+            requires=["contact_id"],
+        ),
+    ]
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items, top_k=2)
+    history = RouteHistory(called_tool_ids=["search_contacts"])
+    result = router.route("send email", history=history)
+    assert result.history_adjustments.get("send_email", 0.0) > 0.0
+
+
+def test_route_history_result_summary_boost_threads_through_retriever() -> None:
+    """``last_result_summary`` is scored via the router's fitted retriever."""
+    from contextweaver.routing.history import RouteHistory
+
+    items = _build_catalog_items()
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items, top_k=5)
+    history = RouteHistory(
+        called_tool_ids=[],
+        last_result_summary="user requested an email to be sent",
+        result_boost_weight=1.0,
+    )
+    result = router.route("notify", history=history)
+    # send_email should have a positive delta because the result summary
+    # mentions "email".
+    assert result.history_adjustments.get("send_email", 0.0) > 0.0
+
+
+def test_route_history_is_byte_identical_to_no_history_when_history_empty() -> None:
+    """An all-default RouteHistory must not move any score."""
+    from contextweaver.routing.history import RouteHistory
+
+    items = _build_catalog_items()
+    graph = TreeBuilder().build(items)
+    router = Router(graph, items=items, top_k=5)
+    a = router.route("read database")
+    b = router.route("read database", history=RouteHistory())
+    assert a.candidate_ids == b.candidate_ids
+    assert a.scores == b.scores
+    assert b.history_adjustments == {}

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -51,6 +51,60 @@ def test_selectable_item_roundtrip() -> None:
     assert restored.cost_hint == item.cost_hint
 
 
+def test_selectable_item_dependency_fields_default_to_none(  # issue #27 phase 2
+) -> None:
+    """``depends_on`` / ``provides`` / ``requires`` default to ``None``."""
+    item = SelectableItem(id="t1", kind="tool", name="t1", description="d")
+    assert item.depends_on is None
+    assert item.provides is None
+    assert item.requires is None
+
+
+def test_selectable_item_to_dict_omits_unset_dependency_fields() -> None:
+    """Default ``None`` fields are omitted from the serialised payload."""
+    item = SelectableItem(id="t1", kind="tool", name="t1", description="d")
+    payload = item.to_dict()
+    assert "depends_on" not in payload
+    assert "provides" not in payload
+    assert "requires" not in payload
+
+
+def test_selectable_item_dependency_fields_roundtrip() -> None:
+    """All three #27-phase-2 fields survive a to_dict / from_dict pass."""
+    item = SelectableItem(
+        id="send_email",
+        kind="tool",
+        name="send_email",
+        description="Send email",
+        depends_on=["auth_login"],
+        provides=["message_id"],
+        requires=["contact_id", "draft"],
+    )
+    payload = item.to_dict()
+    assert payload["depends_on"] == ["auth_login"]
+    assert payload["provides"] == ["message_id"]
+    assert payload["requires"] == ["contact_id", "draft"]
+    restored = SelectableItem.from_dict(payload)
+    assert restored.depends_on == ["auth_login"]
+    assert restored.provides == ["message_id"]
+    assert restored.requires == ["contact_id", "draft"]
+
+
+def test_selectable_item_from_dict_tolerates_missing_dependency_keys() -> None:
+    """Old catalogs that pre-date #27 phase 2 deserialise to ``None``."""
+    restored = SelectableItem.from_dict(
+        {
+            "id": "t1",
+            "kind": "tool",
+            "name": "t1",
+            "description": "d",
+        }
+    )
+    assert restored.depends_on is None
+    assert restored.provides is None
+    assert restored.requires is None
+
+
 def test_artifact_ref_roundtrip() -> None:
     ref = ArtifactRef(handle="h1", media_type="text/plain", size_bytes=100, label="test")
     assert ArtifactRef.from_dict(ref.to_dict()).handle == "h1"


### PR DESCRIPTION
## Summary

Three interrelated routing enhancements that unlock composable pipeline stages, embedding-based retrieval, and history-aware re-routing — addressing the most-requested extensibility gaps in the routing engine.

Fixes #8, #27, #56

## Why

The monolithic `Router.route()` method was a single 200-line function mixing retrieval, navigation, and card rendering — impossible to swap stages independently. Users with large catalogs needed embedding-based retrieval but couldn't plug it in. Multi-turn agents had no way to penalize already-called tools or boost candidates that follow naturally from prior results.

## Changes

### #56 — Routing pipeline decomposition

- `routing/pipeline.py`: explicit `RoutingPipeline` dataclass with four named stages (retrieve → rerank → navigate → pack), each independently swappable via constructor or `EngineRegistry`
- `routing/navigator.py`: `BeamSearchNavigator` extracted verbatim from `router.py` — byte-identical default output verified by 50+ existing regression tests and `make scorecard-check`
- `routing/packer.py`: `DefaultCardPacker` wraps `make_choice_cards` with a soft `budget_tokens` cap
- `protocols.py`: new `Navigator`, `NavigationResult`, `CardPacker` protocol interfaces
- `Router.__init__(pipeline=...)` accepts a custom pipeline; `route()` delegates navigation and reranking through it

### #8 — Optional embedding-based retrieval

- `extras/embeddings.py`: `SentenceTransformerBackend` (gated behind `[embeddings]` extra) + `HybridEmbeddingRetriever` (70/30 embedding + TF-IDF weighted sum preserving lexical floor)
- `Router(embedding_backend=...)` constructs the hybrid retriever lazily so the core install never pulls torch
- LRU-1 query-embedding cache avoids O(K) re-embedding in the history-boost loop (`_result_similarity_map`)

### #27 — History-aware re-routing

- `routing/history.py`: `RouteHistory` dataclass + `adjust_scores()` — applies repeat penalty to already-called tools, result-similarity boost via the router's fitted retriever, and dependency satisfaction/unsatisfied penalties
- `types.py`: `SelectableItem` gains optional `depends_on` / `provides` / `requires` fields for tool-dependency metadata
- `context/manager.py`: `_build_route_history_from_log()` auto-constructs `RouteHistory` from the event log. Tool IDs resolved via `metadata["function_name"]` on the tool_call item (not `parent_id` which is an internal event-log reference)
- `Catalog.validate_dependencies()` returns human-readable warnings for dangling `depends_on` references

### Review-driven refinements (post-review commit `eefa770`)

- History ID mapping: resolves catalog tool IDs through metadata lookup chain (function_name on result → function_name on parent tool_call → fallback to parent_id)
- Rerank wiring: `pipeline.rerank()` now invoked in `route()` after navigation (no-op when reranker is None)
- Docstring accuracy: fixed pipeline.py (reranker defaults to None), protocols.py (CardPacker scope), embeddings.py (import vs instantiation behavior)
- Exception hygiene: bare `ValueError` → `ConfigError` in embeddings

## Checklist

- [x] Tests added or updated for every new/changed public function
- [x] `make ci` passes locally (fmt + lint + type + test + example + demo)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docstrings added for all new public APIs (Google-style)
- [x] Every modified module stays ≤ 300 lines (or a decomposition issue is linked above)
- [x] Related issue linked in the summary above
- [x] Agent-facing docs updated if pipeline, API, or conventions changed

## Notes for reviewers

- `manager.py` grows by ~60 lines (now ~876 total) — decomposition tracked in #73/#69. The new `_build_route_history_from_log` + `_resolve_tool_id_from_result` are self-contained helpers that will move cleanly when that lands.
- The `[embeddings]` extra is entirely opt-in. Core install remains zero heavy deps. `test_extras_embeddings.py` uses a mock `HashEmbeddingBackend`; real sentence-transformers test is gated behind `pytest.importorskip`.
- `RouteResult.history_adjustments` follows the existing pattern of no `to_dict()`/`from_dict()` on `RouteResult` — serialization path is `to_routing_decision()` → `RoutingDecision.to_dict()`. Follow-up in #289.
- `rank_collected` export decision tracked in #288.

## Non-goals

- MCP proxy/gateway changes — those are separate work
- Async routing — routing engine remains sync-only by design
- Breaking changes to `RouteResult` public fields — all new fields are additive with empty defaults

## Verification

```
ruff format --check src/ tests/ examples/ scripts/   → clean
ruff check src/ tests/ examples/ scripts/            → clean
mypy src/                                            → 0 issues / 79 files
pytest -q                                            → 1112 passed, 14 skipped
                                                       (+70 new tests)
scripts/gen_schemas.py --check                       → schemas up to date
make example                                         → all scripts clean
make demo                                            → Demo complete
make llms-check                                      → up to date
```