### PR TITLE
feat(adapters,extras): CrewAI adapter + Mem0 external-memory backend (#193, #195)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,8 @@ It prepares context and routes tools but never calls models or executes tools.
 | `_schema_gen.py` | Dataclass → JSON Schema (Draft 2020-12) generator + `make schemas-check` engine (issue #225) |
 | `routing/tool_id.py` | Canonical `tool_id` grammar (`parse_tool_id` / `format_tool_id` / `compute_hash8`) per `docs/gateway_spec.md` §1 |
 | `routing/path.py` | `tool_browse` path-navigation grammar (`parse_path` / `resolve_path`) per `docs/gateway_spec.md` §3 |
-| `adapters/` | MCP, FastMCP, A2A, weaver-spec protocol adapters + MCP proxy / gateway runtime + provider-message ingestion helpers for OpenAI / Anthropic / Gemini chat histories (issues #13, #28, #29, #34, #194, #219, #222) |
+| `adapters/` | MCP, FastMCP, A2A, weaver-spec, CrewAI protocol adapters + MCP proxy / gateway runtime + provider-message ingestion helpers for OpenAI / Anthropic / Gemini chat histories (issues #13, #28, #29, #34, #193, #194, #219, #222) |
+| `adapters/crewai.py` | CrewAI `BaseTool` (or equivalent plain-dict shape) ↔ `SelectableItem` (`crewai_tool_to_selectable`, `crewai_tools_to_catalog`, `infer_crewai_namespace`, `load_crewai_catalog`, issue #193) |
 | `adapters/proxy_runtime.py` | `ProxyRuntime` shared core + `ExposureMode` enum + `UpstreamCall` Protocol (issue #29) |
 | `adapters/mcp_gateway.py` | Two-tool gateway dispatch (`tool_browse` + `tool_execute` + `tool_view`, issues #28 / #34) |
 | `adapters/mcp_proxy.py` | Transparent proxy dispatch (stripped `tools/list` + `tool_hydrate` + `tool_execute`, issue #13) |
@@ -56,6 +57,9 @@ It prepares context and routes tools but never calls models or executes tools.
 | `adapters/openai_messages.py` | OpenAI Chat Completions `messages` ↔ `ContextItem` round-trip (`from_/to_openai_messages`, issue #219) |
 | `adapters/anthropic_messages.py` | Anthropic Messages API `messages` ↔ `ContextItem` round-trip (`from_/to_anthropic_messages`, issue #222) |
 | `adapters/gemini_contents.py` | Google Gemini `contents[]` ↔ `ContextItem` round-trip (`from_/to_gemini_contents`, issue #222) |
+| `extras/otel.py` | OpenTelemetry GenAI integration (`OTelEventHook` — `invoke_agent` / `execute_tool` spans + GenAI SemConv attributes, gated behind the `[otel]` extra, issue #224). |
+| `extras/memory/` | External-memory backend adapters that implement `EpisodicStore` / `FactStore` against an existing long-lived memory deployment without widening the Protocols (issue #195). |
+| `extras/memory/mem0.py` | `Mem0EpisodicStore` + `Mem0FactStore` — wrap a `mem0.Memory` instance scoped by `user_id`; writes go through `Memory.add(infer=False)` and items are stamped with `cw_episode_id` / `cw_fact_id` metadata for canonical-ID resolution. Gated behind the `[mem0]` extra (issue #195). |
 | `__main__.py` | CLI: 8 subcommands (`demo`, `build`, `route`, `print-tree`, `init`, `ingest`, `replay`, `stats`). Typer + Rich (both core deps as of v0.5, issue #221). |
 
 ## Pipelines (summary)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CrewAI adapter — `adapters/crewai.py`** (#193, Phase 1).  New
+  thin stateless converter that turns CrewAI tool definitions (live
+  `crewai.tools.BaseTool` instances or the equivalent plain-dict
+  shape returned by `BaseTool.model_dump()`) into
+  `SelectableItem`s.  Ships `crewai_tool_to_selectable`,
+  `crewai_tools_to_catalog`, `infer_crewai_namespace`, and
+  `load_crewai_catalog`.  The dict-conversion path works without
+  the `[crewai]` extra installed; `load_crewai_catalog` consumes
+  live `BaseTool` instances when the extra is available.  New
+  `[crewai]` optional-dependency group + `crewai>=0.80` added to
+  `[dev]` so CI exercises the real upstream wire shape.  New
+  `docs/integration_crewai.md` integration guide and
+  `examples/crewai_adapter_demo.py` (wired into `make example`).
+  Follow-ups for Pydantic AI / smolagents / Agno tracked on the
+  same issue.
+- **Mem0 external-memory backend — `extras/memory/mem0.py`** (#195,
+  Phase 1).  `Mem0EpisodicStore` + `Mem0FactStore` implement the
+  existing `store.protocols.EpisodicStore` / `FactStore` Protocols
+  verbatim (no Protocol widening — see
+  `docs/agent-context/invariants.md`).  Writes go through
+  `mem0.Memory.add(infer=False)` so the raw text is stored as-is;
+  every record is stamped with `cw_episode_id` / `cw_fact_id` in
+  its metadata so canonical-ID resolution survives mem0's UUID
+  generation.  New `[mem0]` optional-dependency group + `mem0ai>=0.1`
+  added to `[dev]`.  New `docs/integration_memory.md` decision
+  matrix covering Mem0 / Zep / LangMem (the latter two follow-ups
+  against the same Protocol shape).  Documented in
+  `docs/cookbook.md` §6 and `docs/interop.md` interop matrix.
+
+### Changed
+
+- **Provider-SDK leak invariant tests run in a subprocess.**
+  `test_module_does_not_import_provider_sdk_at_load_time` in
+  `tests/test_adapters_openai_messages.py`,
+  `tests/test_adapters_anthropic_messages.py`, and
+  `tests/test_adapters_gemini_contents.py` previously asserted
+  the absence of `openai` / `anthropic` / `google.generativeai`
+  from `sys.modules` in the running session — which made the
+  assertion sensitive to whatever any other test (in our case
+  `tests/test_adapters_crewai.py`'s live `BaseTool` test, since
+  `crewai` transitively pulls `openai`) had already imported.
+  The tests now spawn a fresh interpreter, import only the
+  contextweaver adapter under test, and assert against that
+  process's `sys.modules`.  The invariant they check is now
+  independent of test ordering and other installed extras.
+
 ## [0.6.0] - 2026-05-17
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ example:
 	python examples/mcp_gateway_demo.py
 	python examples/mcp_proxy_demo.py
 	python examples/a2a_adapter_demo.py
+	python examples/crewai_adapter_demo.py
 	python examples/langchain_memory_demo.py
 	python examples/cookbook/byot_recipe.py
 	python examples/cookbook/firewall_drilldown_recipe.py

--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ Looking for "where does contextweaver fit alongside my runtime?" — start with 
 | Google ADK / Vertex AI | [Guide](docs/integration_google_adk.md) | Gemini tool-use with context budgets |
 | LangChain + LangGraph | [Guide](docs/integration_langchain.md) | Chain + graph agents with firewall |
 | Pipecat | [Guide](docs/integration_pipecat.md) | Real-time voice agents with async context build |
+| CrewAI | [Guide](docs/integration_crewai.md) | Role-based agent crews with bounded tool shortlists |
+| External memory (Mem0) | [Guide](docs/integration_memory.md) | Plug an existing Mem0 deployment as the `EpisodicStore` / `FactStore` |
 
 ---
 
@@ -365,6 +367,8 @@ contextweaver works with any LLM provider and any agent framework:
 | Google ADK / Vertex AI | [Guide](docs/integration_google_adk.md) | Gemini tool-use with context budgets |
 | LangChain + LangGraph | [Guide](docs/integration_langchain.md) | Chain + graph agents with firewall |
 | Pipecat | [Guide](docs/integration_pipecat.md) | Real-time voice agents with async context build |
+| CrewAI | [Guide](docs/integration_crewai.md) | Role-based agent crews with bounded tool shortlists |
+| External memory (Mem0) | [Guide](docs/integration_memory.md) | Plug an existing Mem0 deployment as the `EpisodicStore` / `FactStore` |
 
 > You are not locked into a specific framework or LLM provider. contextweaver is a layer
 > *beneath* frameworks — context management as a composable primitive.
@@ -533,8 +537,12 @@ to any LLM or framework. See dedicated guides for
 [LlamaIndex](docs/integration_llamaindex.md),
 [LangChain + LangGraph](docs/integration_langchain.md),
 [OpenAI Agents SDK](docs/integration_openai_adk.md),
-[Google ADK / Vertex AI](docs/integration_google_adk.md), and
-[Pipecat](docs/integration_pipecat.md).  If your runtime isn't listed, the
+[Google ADK / Vertex AI](docs/integration_google_adk.md),
+[Pipecat](docs/integration_pipecat.md), and
+[CrewAI](docs/integration_crewai.md).  Already running a long-lived
+memory layer? Adapt
+[Mem0](docs/integration_memory.md) onto the `EpisodicStore` / `FactStore`
+protocols.  If your runtime isn't listed, the
 [bring-your-own-tools cookbook recipe](docs/cookbook.md#3-bring-your-own-tools)
 is the canonical starting point.
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -10,6 +10,8 @@ The recipes:
 2. [A2A multi-agent session](#2-a2a-multi-agent-session)
 3. [Bring-your-own-tools](#3-bring-your-own-tools)
 4. [Firewall + drilldown for large tool outputs](#4-firewall-drilldown-for-large-tool-outputs)
+5. [CrewAI routing — bounded tool shortlists for crews](#5-crewai-routing-bounded-tool-shortlists-for-crews)
+6. [External memory backend — Mem0 / Zep / LangMem](#6-external-memory-backend)
 
 If you are evaluating where contextweaver fits in your runtime, start with
 the [How contextweaver Fits](interop.md) page first; come back here for
@@ -264,6 +266,59 @@ This is tracked as a known sharp edge — see the recipe's module docstring.
 
 ---
 
+## 5. CrewAI routing — bounded tool shortlists for crews
+
+**Goal.** Take a crew's full tool registry, convert it into a
+contextweaver `Catalog`, route each task to a top-`k` shortlist, and
+hand only that shortlist to the agent's `BaseTool` list — so the LLM's
+system prompt never carries every tool's schema.
+
+**Use this when:** your crew has 10+ tools and you see prompts ballooning
+past 4 K tokens before any reasoning happens.
+
+The repo already ships a runnable demo:
+
+```bash
+python examples/crewai_adapter_demo.py
+```
+
+Full walkthrough (including the firewall-wrap pattern for `_run`):
+[CrewAI Integration](integration_crewai.md).
+
+---
+
+## 6. External memory backend
+
+**Goal.** Plug an existing [Mem0](https://docs.mem0.ai/) deployment as
+the backing `EpisodicStore` / `FactStore` so contextweaver compiles
+per-turn prompts over memory you've already invested in — instead of
+the bundled in-memory or SQLite stores.
+
+**Use this when:** your agent already maintains long-lived memory in
+Mem0 (or [Zep](https://www.getzep.com/) / [LangMem](https://langchain-ai.github.io/langmem/)
+when those adapters land) and you don't want a second persistence
+layer to keep in sync.
+
+```python
+from mem0 import Memory
+
+from contextweaver.extras.memory.mem0 import Mem0EpisodicStore, Mem0FactStore
+from contextweaver.context.manager import ContextManager
+from contextweaver.store import StoreBundle
+
+memory = Memory()  # your existing mem0 client
+bundle = StoreBundle(
+    episodic=Mem0EpisodicStore(memory, user_id="agent:support-bot"),
+    facts=Mem0FactStore(memory, user_id="agent:support-bot"),
+)
+ctx_mgr = ContextManager(store_bundle=bundle)
+```
+
+Full walkthrough, decision matrix, and the Zep / LangMem follow-up
+status: [External Memory Backends](integration_memory.md).
+
+---
+
 ## See also
 
 - [How contextweaver Fits](interop.md) — boundary, hook points, non-goals
@@ -274,5 +329,7 @@ This is tracked as a known sharp edge — see the recipe's module docstring.
   [LangChain + LangGraph](integration_langchain.md) ·
   [OpenAI ADK](integration_openai_adk.md) ·
   [Google ADK](integration_google_adk.md) ·
-  [Pipecat](integration_pipecat.md)
+  [Pipecat](integration_pipecat.md) ·
+  [CrewAI](integration_crewai.md) ·
+  [External Memory](integration_memory.md)
 - Existing examples directory: [`examples/`](https://github.com/dgenio/contextweaver/tree/main/examples)

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -308,10 +308,10 @@ from contextweaver.store import StoreBundle
 
 memory = Memory()  # your existing mem0 client
 bundle = StoreBundle(
-    episodic=Mem0EpisodicStore(memory, user_id="agent:support-bot"),
-    facts=Mem0FactStore(memory, user_id="agent:support-bot"),
+    episodic_store=Mem0EpisodicStore(memory, user_id="agent:support-bot"),
+    fact_store=Mem0FactStore(memory, user_id="agent:support-bot"),
 )
-ctx_mgr = ContextManager(store_bundle=bundle)
+ctx_mgr = ContextManager(stores=bundle)
 ```
 
 Full walkthrough, decision matrix, and the Zep / LangMem follow-up

--- a/docs/integration_crewai.md
+++ b/docs/integration_crewai.md
@@ -1,0 +1,207 @@
+# CrewAI Integration
+
+> Pair contextweaver's bounded-choice routing and context firewall with
+> [CrewAI](https://docs.crewai.com/) so role-based agent crews see a
+> focused shortlist of tools instead of every `BaseTool` in their
+> registry, and large tool results never blow up the prompt budget.
+
+## Why
+
+A CrewAI `Crew` running multi-step tasks across a shared tool registry
+hits three problems contextweaver was built for:
+
+- **Tool overload.** Every `BaseTool` description (plus its JSON schema
+  preamble — CrewAI ships those to the LLM) is in the system prompt on
+  every step. A 30-tool crew burns 4-6 K tokens before any reasoning.
+- **Unbounded shared state.** Crews pass tool outputs between agents;
+  one multi-KB scrape or transcript poisons every subsequent agent's
+  prompt.
+- **No phase awareness.** The same instructions drive "pick the next
+  tool", "fill in its arguments", and "produce the final answer" —
+  they all need different surfaces.
+
+contextweaver fixes all three without forking CrewAI. The adapter is a
+thin stateless converter (`adapters/`); no CrewAI internals are wrapped.
+
+## Prerequisites
+
+```bash
+pip install 'contextweaver[crewai]'
+export OPENAI_API_KEY=sk-...  # CrewAI defaults to OpenAI; bring your own LLM client
+```
+
+The plain-dict conversion path (`crewai_tool_to_selectable`,
+`crewai_tools_to_catalog`) works **without** the `[crewai]` extra —
+useful for CI fixtures and unit tests that want to exercise routing
+without instantiating the CrewAI runtime.
+
+## Architecture
+
+```text
+User goal
+   │
+   ▼
+contextweaver Router               ← all crew tools registered in Catalog
+   │ (top-k shortlist for this step)
+   ▼
+CrewAI Agent                       ← receives only the shortlist as tools
+   │ (BaseTool.run)
+   ▼
+contextweaver Firewall             ← intercepts large results
+   │ (summary + artifact handle)
+   ▼
+contextweaver ContextManager       ← phase-specific prompt for the next step
+   │ (budgeted ContextPack)
+   ▼
+LLM
+```
+
+You hook contextweaver in at two points: **before each agent's `kickoff`**
+to narrow the available tools to a shortlist, and **after each tool
+invocation** to firewall the raw result before it joins the shared crew
+context.
+
+## Minimal wiring
+
+```python
+from crewai import Agent, Crew, Task
+from crewai.tools import BaseTool
+
+from contextweaver.adapters.crewai import load_crewai_catalog
+from contextweaver.routing.router import Router
+from contextweaver.routing.tree import TreeBuilder
+
+
+class SearchTool(BaseTool):
+    name: str = "github_search_repos"
+    description: str = "Search GitHub repositories by keyword."
+
+    def _run(self, query: str) -> str:
+        ...  # your implementation
+
+
+class CreateIssueTool(BaseTool):
+    name: str = "github_create_issue"
+    description: str = "Open a new issue on a GitHub repository."
+
+    def _run(self, repo: str, title: str, body: str = "") -> str:
+        ...
+
+
+# 1. Build a contextweaver Catalog from the full set of crew tools.
+all_tools = [SearchTool(), CreateIssueTool(), ...]
+catalog = load_crewai_catalog(all_tools)
+
+# 2. Compile the routing graph once.
+graph = TreeBuilder(max_children=8).build(catalog.all())
+router = Router(graph, items=catalog.all(), top_k=3)
+
+# 3. At task assembly time, shortlist tools per-task instead of dumping
+#    the full registry into every agent.
+result = router.route("find recent typescript repos and open a tracking issue")
+shortlist = {it.id.removeprefix("crewai:") for it in result.candidate_items}
+agent_tools = [t for t in all_tools if t.name in shortlist]
+
+researcher = Agent(
+    role="repo researcher",
+    goal="find candidate repositories matching the user request",
+    backstory="An information-retrieval specialist.",
+    tools=agent_tools,
+)
+task = Task(
+    description="Find five candidate typescript repos and open a tracking issue.",
+    expected_output="A list of repo URLs plus the URL of the opened issue.",
+    agent=researcher,
+)
+crew = Crew(agents=[researcher], tasks=[task])
+crew.kickoff()
+```
+
+## Firewalling tool results
+
+For long-running crews, wrap each tool's `_run` so its return value
+flows through `ContextManager.ingest_tool_result` before the next
+agent sees it. The simplest pattern is a per-tool decorator:
+
+```python
+from contextweaver.context.manager import ContextManager
+from contextweaver.types import ContextItem, ItemKind
+
+ctx_mgr = ContextManager()
+
+def firewalled(tool: BaseTool) -> BaseTool:
+    """Wrap *tool* so every return value is firewalled before propagation."""
+    original_run = tool._run
+
+    def _run(*args: object, **kwargs: object) -> object:
+        raw = original_run(*args, **kwargs)
+        item = ctx_mgr.ingest_tool_result(
+            tool_name=tool.name,
+            content=str(raw),
+        )
+        # Return the firewalled summary; the raw bytes stay addressable
+        # in ctx_mgr.artifact_store and are accessible via drilldown.
+        return item.text
+
+    tool._run = _run  # type: ignore[method-assign]
+    return tool
+```
+
+The same `ContextManager` instance can then build per-phase prompts
+(`Phase.call` for argument selection, `Phase.answer` for the crew's
+final synthesis) via `ctx_mgr.build_sync(phase=...)`.
+
+## Namespace inference
+
+The adapter infers a namespace from the tool name's prefix (separator =
+`.`, `/`, or `_`). A tool named `github_search_repos` lands as:
+
+- `id`: `crewai:github_search_repos`
+- `name`: `search_repos` (namespace prefix stripped)
+- `namespace`: `github`
+
+Force a uniform namespace with the `namespace=` argument on
+`crewai_tools_to_catalog`:
+
+```python
+catalog = load_crewai_catalog(all_tools, namespace="my_crew")
+```
+
+## CrewAI description-preamble note
+
+CrewAI's `BaseTool.model_dump()` returns a `description` field with the
+tool name and a JSON-schema preamble prepended (e.g.
+`Tool Name: search\nTool Arguments: {...}\nTool Description: ...`).
+contextweaver is intentionally faithful to that enriched form so the
+router scores against the same text the LLM eventually sees from CrewAI.
+If you need the original description without the preamble, parse it out
+of `item.metadata` or convert from a plain dict via
+`crewai_tool_to_selectable({...})`.
+
+## Troubleshooting
+
+**Q: `CatalogError: CrewAI tool definition is missing a non-empty 'name'
+field`** — Your tool exposes `name` as a class-level Pydantic field but
+the model isn't instantiated. Pass `MyTool()` (a live instance), not
+`MyTool` (the class), to `load_crewai_catalog`.
+
+**Q: `infer_crewai_namespace` returned `crewai` for my tool** — Your tool
+name has no detectable separator (`_` / `.` / `/`). Pass an explicit
+`namespace=` to `crewai_tool_to_selectable` if you want a different
+default.
+
+**Q: Routing scores look low for all candidates** — The router uses TF-IDF
+by default. CrewAI tool descriptions tend to be short imperative
+sentences ("Search the corpus."); for richer scoring, add representative
+examples to `SelectableItem.examples` in a post-processing step, or
+enable the BM25 backend (`Router(... scorer_backend="bm25")`).
+
+## See also
+
+- [`examples/crewai_adapter_demo.py`](https://github.com/dgenio/contextweaver/blob/main/examples/crewai_adapter_demo.py) —
+  Runnable demo: 4 tools → catalog → routing.
+- [How contextweaver Fits](interop.md) — Positioning page covering the
+  policy vs. execution boundary for every supported runtime.
+- [`docs/cookbook.md`](cookbook.md#3-bring-your-own-tools) — The
+  bring-your-own-tools recipe is the canonical fallback if your CrewAI
+  setup deviates from the standard `BaseTool` shape.

--- a/docs/integration_crewai.md
+++ b/docs/integration_crewai.md
@@ -135,9 +135,10 @@ def firewalled(tool: BaseTool) -> BaseTool:
 
     def _run(*args: object, **kwargs: object) -> object:
         raw = original_run(*args, **kwargs)
-        item = ctx_mgr.ingest_tool_result(
+        item, _envelope = ctx_mgr.ingest_tool_result(
+            tool_call_id=f"{tool.name}:{id(raw)}",
+            raw_output=str(raw),
             tool_name=tool.name,
-            content=str(raw),
         )
         # Return the firewalled summary; the raw bytes stay addressable
         # in ctx_mgr.artifact_store and are accessible via drilldown.
@@ -174,8 +175,9 @@ tool name and a JSON-schema preamble prepended (e.g.
 `Tool Name: search\nTool Arguments: {...}\nTool Description: ...`).
 contextweaver is intentionally faithful to that enriched form so the
 router scores against the same text the LLM eventually sees from CrewAI.
-If you need the original description without the preamble, parse it out
-of `item.metadata` or convert from a plain dict via
+If you need the original description without the preamble, access
+`item.metadata["original_description"]` (populated automatically when
+the preamble is detected) or convert from a plain dict via
 `crewai_tool_to_selectable({...})`.
 
 ## Troubleshooting

--- a/docs/integration_memory.md
+++ b/docs/integration_memory.md
@@ -1,0 +1,164 @@
+# External Memory Backends
+
+> Wire an existing [Mem0](https://docs.mem0.ai/) / [Zep](https://www.getzep.com/)
+> / [LangMem](https://langchain-ai.github.io/langmem/) deployment as the
+> backing store for contextweaver's optional long-lived stores
+> (`EpisodicStore`, `FactStore`) so contextweaver compiles per-turn
+> prompts on top of memory you've already invested in — instead of
+> forcing a separate in-memory or SQLite store.
+
+## Why
+
+contextweaver and external memory services solve **complementary**
+problems:
+
+- **External memory layers** (Mem0, Zep, LangMem) hold cross-session
+  state: passive memory extraction, temporal knowledge graphs,
+  semantic / episodic / procedural memory.
+- **contextweaver** compiles those memories — plus the current turn's
+  tool calls and tool results — into a phase-specific, budget-aware
+  prompt every time the LLM is invoked.
+
+The two compose: external memory persists across sessions;
+contextweaver decides what to surface this turn and how to compact
+oversized tool outputs (the context firewall).
+
+## Decision matrix
+
+| Backend | Best for | Status | Install |
+|---|---|---|---|
+| **Mem0** | Passive memory extraction from conversations, multi-tenant deployments | Available | `pip install 'contextweaver[mem0]'` |
+| **Zep / Graphiti** | Temporal knowledge graphs, time-aware fact retrieval | Planned (issue [#195](https://github.com/dgenio/contextweaver/issues/195)) | `pip install 'contextweaver[zep]'` |
+| **LangMem** | LangGraph-native episodic / semantic / procedural memory split | Planned (issue [#195](https://github.com/dgenio/contextweaver/issues/195)) | `pip install 'contextweaver[langmem]'` |
+
+All three implement the **same** existing protocols
+(`EpisodicStore` / `FactStore` from `contextweaver.store.protocols`)
+without widening them, so the wiring is identical across backends
+once their respective adapters land.
+
+## Boundary diagram
+
+```text
+┌──────────────────────────────────────────────────────────────┐
+│ Your agent runtime (any framework)                            │
+│                                                              │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │ contextweaver — policy layer                           │  │
+│  │                                                        │  │
+│  │   ContextManager.build()                               │  │
+│  │     ├─ EpisodicStore.search(query)  ─┐                 │  │
+│  │     └─ FactStore.get_by_key(key)    ─┤                 │  │
+│  │                                       │                │  │
+│  └───────────────────────────────────────┼────────────────┘  │
+│                                          ▼                   │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │ External memory service (Mem0 / Zep / LangMem)         │  │
+│  │  • Long-lived store across sessions                    │  │
+│  │  • Vector / graph recall                               │  │
+│  │  • Memory extraction / consolidation                   │  │
+│  └────────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────┘
+```
+
+contextweaver never reaches outward — the adapter wraps the **client
+object you already hold** (a configured `mem0.Memory`, etc.) and routes
+protocol calls through it.
+
+## Mem0
+
+`contextweaver.extras.memory.mem0` ships two classes:
+
+- `Mem0EpisodicStore` — `EpisodicStore` Protocol
+- `Mem0FactStore` — `FactStore` Protocol
+
+Both wrap a `mem0.Memory` instance scoped by a stable `user_id`. Writes
+go through `Memory.add(... infer=False)` so mem0 does **not** run an
+LLM extraction pass — the raw `Episode.summary` / `Fact.value` is stored
+as-supplied. Every record is stamped with a contextweaver metadata
+key (`cw_episode_id` / `cw_fact_id`) so `get` / `delete` can resolve
+the canonical ID back to mem0's UUID.
+
+### Minimal wiring
+
+```python
+from mem0 import Memory
+
+from contextweaver.extras.memory.mem0 import Mem0EpisodicStore, Mem0FactStore
+from contextweaver.context.manager import ContextManager
+from contextweaver.store import StoreBundle
+from contextweaver.store.episodic import Episode
+from contextweaver.store.facts import Fact
+
+# 1. Configure mem0 — bring your own LLM / vector store / reranker.
+memory = Memory()
+
+# 2. Adapt mem0 onto contextweaver's protocols.  user_id is the mem0
+#    session id used for scope partitioning; use a stable value per
+#    agent / per tenant.
+episodic = Mem0EpisodicStore(memory, user_id="agent:support-bot")
+facts = Mem0FactStore(memory, user_id="agent:support-bot")
+
+# 3. Plug into the StoreBundle the ContextManager uses.
+bundle = StoreBundle(episodic=episodic, facts=facts)
+ctx_mgr = ContextManager(store_bundle=bundle)
+
+# 4. From here on, use the standard contextweaver API.
+episodic.add(Episode("ep-1", "User asked about refund policy for SKU-42"))
+facts.put(Fact("f-tier", key="user.tier", value="enterprise"))
+```
+
+### Search semantics
+
+`Mem0EpisodicStore.search` delegates to `Memory.search` and inherits
+mem0's vector + reranker stack — this is the main reason to choose
+mem0 over the bundled `InMemoryEpisodicStore`. The configured
+`user_id` scope is applied at search time so two adapter instances
+constructed with different `user_id`s don't see each other's records.
+
+### Mem0FactStore design notes
+
+mem0 has no first-class concept of a `key` separate from the content
+itself, so `Mem0FactStore.get_by_key` and `list_keys` reconstruct the
+answer client-side by scanning `Memory.get_all`. When the configured
+`user_id` scope exceeds `scan_limit` (default `1000`), these methods
+raise `NotImplementedError` rather than silently truncating. Narrow
+scope by partitioning across multiple `user_id`s or pick a dedicated
+`FactStore` backend (in-memory or SQLite).
+
+### Out-of-scope (current cycle)
+
+`Mem0EpisodicStore.search` does **not** currently expose mem0's
+threshold / rerank parameters — both will surface once the protocol
+gains a `search_options` parameter (tracked separately; this PR
+intentionally does not widen the Protocol).
+
+## Zep / Graphiti
+
+Same protocol shape as Mem0; deferred to a follow-up cycle. See issue
+[#195](https://github.com/dgenio/contextweaver/issues/195) for the
+acceptance criteria. The adapter will live at
+`contextweaver.extras.memory.zep` once it lands.
+
+When implemented, the wiring becomes:
+
+```python
+# Planned — module not shipped yet.
+# from contextweaver.extras.memory.zep import ZepEpisodicStore, ZepFactStore
+```
+
+## LangMem
+
+Same shape; deferred. Will live at
+`contextweaver.extras.memory.langmem` once landed. Issue
+[#195](https://github.com/dgenio/contextweaver/issues/195) covers the
+acceptance criteria.
+
+## See also
+
+- [`tests/test_extras_memory_mem0.py`](https://github.com/dgenio/contextweaver/blob/main/tests/test_extras_memory_mem0.py) —
+  Reference for the wire shape and the per-method semantics.
+- [`docs/integration_otel.md`](integration_otel.md) — Same
+  `extras/` pattern, different responsibility (observability vs.
+  memory).
+- [How contextweaver Fits](interop.md) — Where the policy layer sits
+  relative to runtimes and persistence layers.

--- a/docs/integration_memory.md
+++ b/docs/integration_memory.md
@@ -99,8 +99,8 @@ episodic = Mem0EpisodicStore(memory, user_id="agent:support-bot")
 facts = Mem0FactStore(memory, user_id="agent:support-bot")
 
 # 3. Plug into the StoreBundle the ContextManager uses.
-bundle = StoreBundle(episodic=episodic, facts=facts)
-ctx_mgr = ContextManager(store_bundle=bundle)
+bundle = StoreBundle(episodic_store=episodic, fact_store=facts)
+ctx_mgr = ContextManager(stores=bundle)
 
 # 4. From here on, use the standard contextweaver API.
 episodic.add(Episode("ep-1", "User asked about refund policy for SKU-42"))

--- a/docs/interop.md
+++ b/docs/interop.md
@@ -63,6 +63,11 @@ contextweaver never reaches outward.
 | OpenAI Agents SDK | Function wrapper / pre-call hook | Router + Firewall | [OpenAI ADK Integration](integration_openai_adk.md) | Available |
 | Google ADK / Vertex AI | Tool list filter / pre-call hook | Router + Firewall | [Google ADK Integration](integration_google_adk.md) | Available |
 | Pipecat | Frame processor | ContextManager (async) | [Pipecat Integration](integration_pipecat.md) | Available |
+| CrewAI | Adapter (`BaseTool` → `SelectableItem`) | `adapters.crewai` + Router + Firewall | [CrewAI Integration](integration_crewai.md), `examples/crewai_adapter_demo.py` | Available |
+| Pydantic AI / smolagents / Agno | Adapter (tool object → `SelectableItem`) | `adapters.*` (planned) | — | Planned ([#193](https://github.com/dgenio/contextweaver/issues/193)) |
+| Mem0 (external memory) | `EpisodicStore` / `FactStore` backend | `extras.memory.mem0` | [External Memory](integration_memory.md) | Available |
+| Zep / Graphiti (external memory) | `EpisodicStore` / `FactStore` backend | `extras.memory.zep` (planned) | [External Memory](integration_memory.md) | Planned ([#195](https://github.com/dgenio/contextweaver/issues/195)) |
+| LangMem (external memory) | `EpisodicStore` / `FactStore` backend | `extras.memory.langmem` (planned) | [External Memory](integration_memory.md) | Planned ([#195](https://github.com/dgenio/contextweaver/issues/195)) |
 | MCP Proxy / Gateway | Standalone server | Full pipeline | — | Planned ([#13](https://github.com/dgenio/contextweaver/issues/13), [#28](https://github.com/dgenio/contextweaver/issues/28), v1.0) |
 
 If your runtime is not listed, the

--- a/examples/crewai_adapter_demo.py
+++ b/examples/crewai_adapter_demo.py
@@ -1,0 +1,107 @@
+"""CrewAI adapter demo (issue #193).
+
+Demonstrates converting CrewAI tool definitions into contextweaver-native
+types and routing a query against the resulting catalog.  Uses plain dicts
+matching the ``crewai.tools.BaseTool`` field shape — no ``crewai`` install
+required for this demo.
+
+For live conversion of real :class:`crewai.tools.BaseTool` instances,
+install the optional extra: ``pip install 'contextweaver[crewai]'`` and
+call :func:`contextweaver.adapters.crewai.load_crewai_catalog`.
+"""
+
+from __future__ import annotations
+
+from contextweaver.adapters.crewai import (
+    crewai_tool_to_selectable,
+    crewai_tools_to_catalog,
+    infer_crewai_namespace,
+)
+from contextweaver.routing.router import Router
+from contextweaver.routing.tree import TreeBuilder
+
+# Simulated tools as they would appear from a multi-agent CrewAI deployment
+# (https://docs.crewai.com/concepts/tools).  Names use the underscore-
+# prefixed namespace convention used by most CrewAI catalogs.
+CREWAI_TOOLS: list[dict[str, object]] = [
+    {
+        "name": "github_search_repos",
+        "description": "Search GitHub repositories by keyword.",
+        "args_schema": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}, "limit": {"type": "integer"}},
+            "required": ["query"],
+        },
+        "tags": ["vcs", "search"],
+    },
+    {
+        "name": "github_create_issue",
+        "description": "Open a new issue in a GitHub repository.",
+        "args_schema": {
+            "type": "object",
+            "properties": {
+                "repo": {"type": "string"},
+                "title": {"type": "string"},
+                "body": {"type": "string"},
+            },
+            "required": ["repo", "title"],
+        },
+        "tags": ["vcs"],
+        "result_as_answer": False,
+    },
+    {
+        "name": "slack_send_message",
+        "description": "Send a Slack message to a channel.",
+        "args_schema": {
+            "type": "object",
+            "properties": {"channel": {"type": "string"}, "text": {"type": "string"}},
+            "required": ["channel", "text"],
+        },
+        "tags": ["messaging"],
+    },
+    {
+        "name": "calendar.create_event",
+        "description": "Schedule a calendar event for a participant set.",
+        "tags": ["scheduling", "write"],
+    },
+]
+
+
+def main() -> None:
+    print("=== CrewAI Adapter Demo ===\n")
+
+    # 1. Namespace inference picks the prefix before the first ``_`` / ``.``.
+    print("[1] Namespace inference:")
+    for name in ("github_search_repos", "slack_send_message", "calendar.create_event"):
+        print(f"    {name!r:30s} → namespace={infer_crewai_namespace(name)!r}")
+
+    # 2. Single conversion.
+    print("\n[2] Single tool conversion:")
+    item = crewai_tool_to_selectable(CREWAI_TOOLS[0])  # type: ignore[arg-type]
+    print(f"    ID:        {item.id}")
+    print(f"    Name:      {item.name}")
+    print(f"    Namespace: {item.namespace}")
+    print(f"    Tags:      {item.tags}")
+
+    # 3. Batch conversion → Catalog.
+    print("\n[3] Building Catalog from 4 CrewAI tools:")
+    catalog = crewai_tools_to_catalog(CREWAI_TOOLS)  # type: ignore[arg-type]
+    for it in catalog.all():
+        print(f"    {it.id:40s} ns={it.namespace:10s} tags={sorted(it.tags)}")
+
+    # 4. Routing — contextweaver narrows the catalog to a shortlist that
+    # the calling LLM can reason about under a tight token budget.
+    print("\n[4] Routing the query 'find typescript repos and open an issue':")
+    graph = TreeBuilder(max_children=8).build(catalog.all())
+    router = Router(graph, items=catalog.all(), top_k=3)
+    result = router.route("find typescript repos and open an issue")
+    for rank, (item, score) in enumerate(
+        zip(result.candidate_items, result.scores, strict=False), 1
+    ):
+        print(f"    #{rank} {item.id:40s} score={score:.3f}")
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,8 @@ nav:
       - OpenAI Agents SDK: integration_openai_adk.md
       - Google ADK / Vertex AI: integration_google_adk.md
       - Pipecat: integration_pipecat.md
+      - CrewAI: integration_crewai.md
+      - External Memory: integration_memory.md
   - Architecture: architecture.md
   - Benchmarks: benchmarks.md
   - Contracts: contracts.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,9 @@ Discussions = "https://github.com/dgenio/contextweaver/discussions"
 [project.optional-dependencies]
 # Dev / test toolchain. Includes weaver_contracts + jsonschema so the
 # weaver-spec adapter (#143) and CI conformance check (#145) run on every PR
-# without requiring the [weaver-spec] runtime extra.
+# without requiring the [weaver-spec] runtime extra.  ``crewai`` and ``mem0ai``
+# are pulled in so the CrewAI adapter (#193) and Mem0 external-memory backend
+# (#195) are exercised against real upstream wire shapes on every CI run.
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
@@ -81,6 +83,8 @@ dev = [
     # 4.18 ships ``referencing`` — the conformance script's local $ref
     # resolver depends on it (PR #201 review).
     "jsonschema>=4.18",
+    "crewai>=0.80",
+    "mem0ai>=0.1",
 ]
 # weaver-spec contract adapter (https://github.com/dgenio/weaver-spec).
 # Runtime extra for end users who want to interoperate with the canonical
@@ -91,6 +95,14 @@ weaver-spec = [
 # FastMCP adapter integration.
 fastmcp = [
     "fastmcp>=2.0",
+]
+# CrewAI adapter integration (issue #193).  Pulls the CrewAI runtime so user
+# applications can import the live-discovery helper
+# (``contextweaver.adapters.crewai.load_crewai_catalog``).  The plain-dict
+# conversion path (``crewai_tool_to_selectable`` / ``crewai_tools_to_catalog``)
+# works without this extra installed.
+crewai = [
+    "crewai>=0.80",
 ]
 # LangChain integration examples.
 langchain = [
@@ -127,6 +139,15 @@ ann = [
 # purpose — the contract is "if you want the SQLite stores, install this
 # extra" even though it currently adds no third-party deps.
 sqlite = []
+# External-memory backend interop (issue #195).  Each backend implements the
+# existing ``EpisodicStore`` / ``FactStore`` protocols from
+# ``contextweaver.store.protocols`` without widening them.  Adapters live
+# under ``contextweaver.extras.memory.*``.  Only Mem0 is shipped today; Zep
+# and LangMem rows are listed in ``docs/integration_memory.md`` as
+# follow-ups against the same protocol surface.
+mem0 = [
+    "mem0ai>=0.1",
+]
 # OpenTelemetry tracing + metrics export with native GenAI semantic
 # conventions (#224).  Pinned at >=1.27 because the
 # ``opentelemetry.semconv.attributes.gen_ai_attributes`` module landed in
@@ -179,6 +200,14 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "fastmcp"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "crewai.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "mem0.*"
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/src/contextweaver/adapters/__init__.py
+++ b/src/contextweaver/adapters/__init__.py
@@ -4,8 +4,8 @@ Provides thin, pure stateless adapters across three responsibility groups:
 
 1. **Protocol adapters** — convert external protocol data into
    contextweaver-native types and back: MCP (:mod:`.mcp`),
-   FastMCP (:mod:`.fastmcp`), A2A (:mod:`.a2a`), and weaver-spec
-   (:mod:`.weaver_contracts`).
+   FastMCP (:mod:`.fastmcp`), A2A (:mod:`.a2a`), weaver-spec
+   (:mod:`.weaver_contracts`), and CrewAI (:mod:`.crewai`).
 2. **Runtime modes** — front upstream MCP servers as a transparent
    proxy or two-tool gateway: :mod:`.proxy_runtime`, :mod:`.mcp_proxy`,
    :mod:`.mcp_gateway`, :mod:`.mcp_proxy_server`,
@@ -30,6 +30,12 @@ from contextweaver.adapters.a2a import (
 from contextweaver.adapters.anthropic_messages import (
     from_anthropic_messages,
     to_anthropic_messages,
+)
+from contextweaver.adapters.crewai import (
+    crewai_tool_to_selectable,
+    crewai_tools_to_catalog,
+    infer_crewai_namespace,
+    load_crewai_catalog,
 )
 from contextweaver.adapters.fastmcp import (
     fastmcp_tool_to_selectable,
@@ -94,6 +100,8 @@ __all__ = [
     "UpstreamCall",
     "a2a_agent_to_selectable",
     "a2a_result_to_envelope",
+    "crewai_tool_to_selectable",
+    "crewai_tools_to_catalog",
     "dispatch_meta_tool",
     "dispatch_proxy_request",
     "fastmcp_tool_to_selectable",
@@ -106,9 +114,11 @@ __all__ = [
     "from_weaver_frame",
     "from_weaver_routing_decision",
     "from_weaver_selectable_item",
+    "infer_crewai_namespace",
     "infer_fastmcp_namespace",
     "infer_namespace",
     "load_a2a_session_jsonl",
+    "load_crewai_catalog",
     "load_fastmcp_catalog",
     "load_mcp_session_jsonl",
     "make_gateway_meta_tools",

--- a/src/contextweaver/adapters/crewai.py
+++ b/src/contextweaver/adapters/crewai.py
@@ -20,6 +20,7 @@ CrewAI tools docs: https://docs.crewai.com/concepts/tools
 
 from __future__ import annotations
 
+import copy
 import logging
 from typing import Any
 
@@ -81,7 +82,7 @@ def _args_schema_dict(raw: object) -> dict[str, Any]:
     if raw is None:
         return {}
     if isinstance(raw, dict):
-        return dict(raw)
+        return copy.deepcopy(raw)
     schema_fn = getattr(raw, "model_json_schema", None)
     if callable(schema_fn):
         try:

--- a/src/contextweaver/adapters/crewai.py
+++ b/src/contextweaver/adapters/crewai.py
@@ -1,0 +1,273 @@
+"""CrewAI adapter for contextweaver (issue #193).
+
+Bridges [CrewAI](https://docs.crewai.com/) tools and
+:class:`~contextweaver.routing.catalog.Catalog` objects.  Converts CrewAI
+``BaseTool`` instances (or the equivalent plain-dict shape) into
+:class:`~contextweaver.types.SelectableItem` objects so that crews built with
+``crewai.Agent`` and ``crewai.Crew`` can route through contextweaver's
+bounded-choice router instead of dumping every tool definition into the
+prompt.
+
+The plain-dict conversion functions (:func:`crewai_tool_to_selectable`,
+:func:`crewai_tools_to_catalog`) work without the ``crewai`` package
+installed — they accept dicts with the same shape that
+``BaseTool.model_dump()`` emits.  Live conversion of real
+``crewai.tools.BaseTool`` instances (:func:`load_crewai_catalog`) requires
+the ``contextweaver[crewai]`` optional extra.
+
+CrewAI tools docs: https://docs.crewai.com/concepts/tools
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from contextweaver.exceptions import CatalogError
+from contextweaver.routing.catalog import Catalog
+from contextweaver.types import SelectableItem
+
+logger = logging.getLogger("contextweaver.adapters")
+
+_FALLBACK_NS = "crewai"
+
+
+def infer_crewai_namespace(tool_name: str) -> str:
+    """Infer a namespace from a CrewAI tool name.
+
+    CrewAI tools are usually named in human-readable PascalCase or
+    snake_case (e.g. ``SerperDevTool``, ``code_interpreter``).  This helper
+    extracts a namespace using the same dot- / slash- / underscore-
+    separated prefix rules that the FastMCP adapter uses, falling back to
+    ``"crewai"`` when no prefix can be detected.
+
+    Args:
+        tool_name: The raw tool name string.
+
+    Returns:
+        The inferred namespace string.
+    """
+    if not tool_name:
+        return _FALLBACK_NS
+    if "." in tool_name:
+        prefix = tool_name.split(".", 1)[0]
+        if prefix:
+            return prefix
+    if "/" in tool_name:
+        prefix = tool_name.split("/", 1)[0]
+        if prefix:
+            return prefix
+    parts = tool_name.split("_")
+    if len(parts) >= 2 and parts[0] and not parts[0].startswith("_"):
+        return parts[0]
+    return _FALLBACK_NS
+
+
+def _strip_namespace_prefix(tool_name: str, namespace: str) -> str:
+    """Return the short tool name with the namespace prefix removed."""
+    for prefix in (f"{namespace}_", f"{namespace}.", f"{namespace}/"):
+        if tool_name.startswith(prefix) and len(tool_name) > len(prefix):
+            return tool_name[len(prefix) :]
+    return tool_name
+
+
+def _args_schema_dict(raw: object) -> dict[str, Any]:
+    """Coerce a CrewAI ``args_schema`` value into a JSON-shaped dict.
+
+    CrewAI accepts either a Pydantic model class or an already-built dict.
+    For Pydantic models we call :meth:`model_json_schema`; for dicts we
+    return a shallow copy; everything else returns ``{}``.
+    """
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return dict(raw)
+    schema_fn = getattr(raw, "model_json_schema", None)
+    if callable(schema_fn):
+        try:
+            schema = schema_fn()
+        except Exception:  # pragma: no cover - defensive; depends on user model
+            return {}
+        if isinstance(schema, dict):
+            return dict(schema)
+    return {}
+
+
+def crewai_tool_to_selectable(
+    tool_def: dict[str, Any],
+    *,
+    namespace: str | None = None,
+) -> SelectableItem:
+    """Convert a CrewAI tool definition dict to a :class:`SelectableItem`.
+
+    The dict shape mirrors the field set on ``crewai.tools.BaseTool``
+    (which is a Pydantic ``BaseModel``):
+
+    - ``name`` (required): the tool's display name.
+    - ``description`` (required): natural-language description used by the
+      LLM at routing time.
+    - ``args_schema`` (optional): either a JSON-schema dict or a Pydantic
+      model class — both are accepted; the class is converted via
+      ``model_json_schema()``.
+    - ``tags`` (optional): list of tag strings.
+    - ``result_as_answer`` (optional): CrewAI flag indicating the tool's
+      raw return should bypass agent reflection; surfaced as a metadata
+      field for downstream consumers and is **not** the same as
+      ``side_effects``.
+    - ``cache_function`` (optional): CrewAI cache predicate; preserved in
+      ``metadata`` only — not exercised by contextweaver's routing.
+
+    Args:
+        tool_def: Raw tool definition dict (typically the result of
+            ``crewai.tools.BaseTool().model_dump()`` on a live instance).
+        namespace: Explicit namespace override.  When ``None``, the
+            namespace is inferred from the tool name via
+            :func:`infer_crewai_namespace`.
+
+    Returns:
+        A :class:`SelectableItem` with ``kind="tool"`` and ``id`` of the
+        form ``"crewai:{name}"``.
+
+    Raises:
+        CatalogError: If required fields (``name``, ``description``) are
+            missing or non-string.
+    """
+    raw_name = tool_def.get("name")
+    if not isinstance(raw_name, str) or not raw_name:
+        raise CatalogError("CrewAI tool definition is missing a non-empty 'name' field.")
+    raw_description = tool_def.get("description")
+    if not isinstance(raw_description, str) or not raw_description:
+        raise CatalogError(f"CrewAI tool {raw_name!r} is missing a non-empty 'description' field.")
+
+    full_name = raw_name
+    ns = namespace if namespace is not None else infer_crewai_namespace(full_name)
+    short_name = _strip_namespace_prefix(full_name, ns)
+
+    raw_tags = tool_def.get("tags")
+    tags: set[str] = {_FALLBACK_NS}
+    if isinstance(raw_tags, (list, set, tuple)):
+        for tag in raw_tags:
+            if isinstance(tag, str) and tag:
+                tags.add(tag)
+
+    args_schema = _args_schema_dict(tool_def.get("args_schema"))
+
+    metadata: dict[str, Any] = {}
+    if "result_as_answer" in tool_def:
+        metadata["result_as_answer"] = bool(tool_def["result_as_answer"])
+    if "max_usage_count" in tool_def and tool_def["max_usage_count"] is not None:
+        metadata["max_usage_count"] = tool_def["max_usage_count"]
+
+    logger.debug(
+        "crewai_tool_to_selectable: name=%s, ns=%s, tags=%s",
+        full_name,
+        ns,
+        sorted(tags),
+    )
+    return SelectableItem(
+        id=f"crewai:{full_name}",
+        kind="tool",
+        name=short_name,
+        description=raw_description,
+        tags=sorted(tags),
+        namespace=ns,
+        args_schema=args_schema,
+        metadata=metadata,
+    )
+
+
+def crewai_tools_to_catalog(
+    tools: list[dict[str, Any]],
+    *,
+    namespace: str | None = None,
+) -> Catalog:
+    """Convert a list of CrewAI tool definitions to a populated :class:`Catalog`.
+
+    Args:
+        tools: List of raw tool definition dicts.
+        namespace: Optional namespace override applied to every item.  When
+            ``None``, each tool's namespace is inferred individually.
+
+    Returns:
+        A :class:`~contextweaver.routing.catalog.Catalog` with all
+        converted items registered.
+
+    Raises:
+        CatalogError: If a tool definition is invalid or duplicate IDs are
+            encountered.
+    """
+    catalog = Catalog()
+    for tool_def in tools:
+        item = crewai_tool_to_selectable(tool_def, namespace=namespace)
+        catalog.register(item)
+    logger.debug("crewai_tools_to_catalog: registered %d items", len(tools))
+    return catalog
+
+
+def load_crewai_catalog(
+    tools: list[object],
+    *,
+    namespace: str | None = None,
+) -> Catalog:
+    """Convert a list of live ``crewai.tools.BaseTool`` instances to a :class:`Catalog`.
+
+    Each tool is dumped via Pydantic's ``model_dump()`` and routed through
+    :func:`crewai_tools_to_catalog`.  Non-CrewAI objects are accepted as
+    long as they expose ``name`` and ``description`` attributes — the
+    function reads them via ``getattr`` and constructs the equivalent
+    dict.
+
+    This is a synchronous helper because CrewAI tools are sync objects;
+    the FastMCP adapter's async counterpart exists because FastMCP tools
+    are discovered over the wire.
+
+    Requires the ``contextweaver[crewai]`` optional extra **only** if
+    you intend to import ``crewai`` itself in the same process; the
+    helper itself does not import the library.
+
+    Args:
+        tools: List of live CrewAI tool instances (or any object exposing
+            ``name`` / ``description`` attributes plus an optional
+            ``args_schema`` / ``tags`` / ``model_dump``).
+        namespace: Optional namespace override applied to every item.
+
+    Returns:
+        A populated :class:`Catalog`.
+
+    Raises:
+        CatalogError: If a tool object is missing required attributes.
+    """
+    tool_dicts: list[dict[str, Any]] = []
+    for tool in tools:
+        if hasattr(tool, "model_dump"):
+            try:
+                dumped = tool.model_dump()
+            except Exception as exc:
+                raise CatalogError(f"Failed to dump CrewAI tool {tool!r}: {exc}") from exc
+            if not isinstance(dumped, dict):
+                raise CatalogError(f"CrewAI tool {tool!r}.model_dump() did not return a dict.")
+            # Replace args_schema with the raw class so _args_schema_dict
+            # can convert it via model_json_schema().  model_dump() drops
+            # class objects by default and emits ``None`` instead.
+            raw_args = getattr(tool, "args_schema", None)
+            if raw_args is not None:
+                dumped["args_schema"] = raw_args
+            tool_dicts.append(dumped)
+        else:
+            name = getattr(tool, "name", None)
+            description = getattr(tool, "description", None)
+            if not isinstance(name, str) or not name:
+                raise CatalogError(f"CrewAI tool {tool!r} is missing a non-empty 'name' attribute.")
+            if not isinstance(description, str) or not description:
+                raise CatalogError(
+                    f"CrewAI tool {name!r} is missing a non-empty 'description' attribute."
+                )
+            tool_dicts.append(
+                {
+                    "name": name,
+                    "description": description,
+                    "args_schema": getattr(tool, "args_schema", None),
+                    "tags": list(getattr(tool, "tags", []) or []),
+                }
+            )
+    return crewai_tools_to_catalog(tool_dicts, namespace=namespace)

--- a/src/contextweaver/adapters/crewai.py
+++ b/src/contextweaver/adapters/crewai.py
@@ -114,8 +114,6 @@ def crewai_tool_to_selectable(
       raw return should bypass agent reflection; surfaced as a metadata
       field for downstream consumers and is **not** the same as
       ``side_effects``.
-    - ``cache_function`` (optional): CrewAI cache predicate; preserved in
-      ``metadata`` only — not exercised by contextweaver's routing.
 
     Args:
         tool_def: Raw tool definition dict (typically the result of
@@ -157,6 +155,12 @@ def crewai_tool_to_selectable(
         metadata["result_as_answer"] = bool(tool_def["result_as_answer"])
     if "max_usage_count" in tool_def and tool_def["max_usage_count"] is not None:
         metadata["max_usage_count"] = tool_def["max_usage_count"]
+
+    # Store the preamble-free description when CrewAI's enriched format is
+    # detected (pattern: "Tool Name: ...\nTool Description: <original>").
+    _preamble_marker = "\nTool Description: "
+    if _preamble_marker in raw_description:
+        metadata["original_description"] = raw_description.split(_preamble_marker, 1)[1]
 
     logger.debug(
         "crewai_tool_to_selectable: name=%s, ns=%s, tags=%s",

--- a/src/contextweaver/extras/__init__.py
+++ b/src/contextweaver/extras/__init__.py
@@ -9,6 +9,10 @@ Currently shipped:
 
 - :mod:`contextweaver.extras.otel` — OpenTelemetry tracing + metrics
   (``contextweaver[otel]``).
+- :mod:`contextweaver.extras.memory.mem0` — Mem0 ``EpisodicStore`` /
+  ``FactStore`` implementations (``contextweaver[mem0]``).  See
+  :mod:`contextweaver.extras.memory` for the external-memory backend
+  sub-package layout (issue #195).
 """
 
 from __future__ import annotations

--- a/src/contextweaver/extras/memory/__init__.py
+++ b/src/contextweaver/extras/memory/__init__.py
@@ -1,0 +1,28 @@
+"""External-memory backend adapters for contextweaver (issue #195).
+
+This sub-package hosts ``EpisodicStore`` / ``FactStore`` implementations
+that delegate to external long-lived memory services (Mem0, Zep,
+LangMem).  Each module imports its third-party dependency at module
+load time and surfaces a friendly :class:`ImportError` (with the exact
+pip command to install it) when the extra is missing.  Importing
+:mod:`contextweaver.extras.memory` itself does *not* trigger those
+imports — the per-backend modules are reached via attribute access
+(e.g. ``from contextweaver.extras.memory.mem0 import Mem0EpisodicStore``).
+
+Currently shipped:
+
+- :mod:`contextweaver.extras.memory.mem0` — Mem0
+  (``contextweaver[mem0]``).
+
+Planned (same protocol shape; see ``docs/integration_memory.md``):
+
+- Zep / Graphiti (``contextweaver[zep]``)
+- LangMem (``contextweaver[langmem]``)
+
+The adapters honour the existing ``store/protocols.py`` Protocols
+without widening them — methods that an upstream backend cannot
+implement raise :class:`NotImplementedError` with a clear message
+pointing at the closest natively-supported call.
+"""
+
+from __future__ import annotations

--- a/src/contextweaver/extras/memory/mem0.py
+++ b/src/contextweaver/extras/memory/mem0.py
@@ -188,9 +188,14 @@ class Mem0EpisodicStore:
 
         If an episode with the same ``episode_id`` already exists, the
         existing record is deleted first (upsert semantics) so that
-        :meth:`get` never returns a stale duplicate.
+        :meth:`get` never returns a stale duplicate.  When the scope
+        exceeds ``scan_limit`` the duplicate check is skipped and the
+        episode is appended unconditionally (append-only fallback).
         """
-        existing = self._record_for_episode(episode.episode_id)
+        try:
+            existing = self._record_for_episode(episode.episode_id)
+        except NotImplementedError:
+            existing = None
         if existing is not None:
             mem_id = _memory_id(existing)
             if mem_id is not None:

--- a/src/contextweaver/extras/memory/mem0.py
+++ b/src/contextweaver/extras/memory/mem0.py
@@ -347,8 +347,11 @@ class Mem0FactStore:
         existing = self._record_for_fact(fact.fact_id)
         if existing is not None:
             mem_id = _memory_id(existing)
-            if mem_id is not None:
-                self._memory.delete(mem_id)
+            if mem_id is None:
+                raise Mem0BackendError(
+                    f"Mem0 record for fact {fact.fact_id!r} is missing an 'id' field."
+                )
+            self._memory.delete(mem_id)
         metadata: dict[str, Any] = dict(fact.metadata)
         metadata[_CW_FACT_KEY] = fact.fact_id
         metadata[_CW_FACT_KEY_FIELD] = fact.key

--- a/src/contextweaver/extras/memory/mem0.py
+++ b/src/contextweaver/extras/memory/mem0.py
@@ -1,0 +1,461 @@
+"""Mem0 ``EpisodicStore`` / ``FactStore`` backend for contextweaver (issue #195).
+
+Adapts the [Mem0](https://docs.mem0.ai/) Python client so an existing
+mem0 deployment can back contextweaver's optional long-lived stores
+without changing core pipeline code.  The two classes here implement
+the existing :class:`~contextweaver.store.protocols.EpisodicStore` and
+:class:`~contextweaver.store.protocols.FactStore` Protocols verbatim —
+the Protocols are not widened.
+
+This module requires the ``[mem0]`` optional extra::
+
+    pip install 'contextweaver[mem0]'
+
+Without that extra, importing this module raises :class:`ImportError`
+with the exact install hint above.  The rest of contextweaver works
+unchanged.
+
+How items are persisted
+-----------------------
+
+Mem0's ``Memory.add(...)`` was designed for "extract memories from a
+conversation" — it assigns its own UUID per memory and treats every
+call as the user offering content for ingestion.  contextweaver, by
+contrast, hands the store an :class:`~contextweaver.store.episodic.Episode`
+or :class:`~contextweaver.store.facts.Fact` whose ``episode_id`` /
+``fact_id`` is the canonical identifier.  The adapter bridges these
+two worlds by:
+
+1. Calling :meth:`mem0.Memory.add` with ``infer=False`` so mem0 does
+   **not** run an LLM extraction pass — the raw text is stored as-is.
+2. Stamping every memory with a contextweaver-namespaced metadata key
+   (``cw_episode_id`` or ``cw_fact_id``) so subsequent ``get`` /
+   ``delete`` calls can resolve the canonical ID back to mem0's
+   generated UUID by scanning :meth:`mem0.Memory.get_all`.
+
+Search delegates to :meth:`mem0.Memory.search`, which uses mem0's
+configured vector + reranker stack.  This is the primary reason to
+choose mem0 over the in-memory store — higher-quality semantic recall.
+
+Out-of-scope (raise :class:`NotImplementedError`)
+-------------------------------------------------
+
+Mem0 has no first-class concept of a ``key`` separate from the
+content itself, so :meth:`Mem0FactStore.get_by_key` and
+:meth:`Mem0FactStore.list_keys` reconstruct the answer client-side by
+scanning :meth:`mem0.Memory.get_all`.  When the configured ``user_id``
+holds more than ``scan_limit`` memories this becomes lossy — the
+adapter then raises :class:`NotImplementedError` rather than silently
+truncating.  Callers should narrow scope with ``user_id`` /
+``agent_id`` / ``run_id`` partitioning or use a dedicated
+``FactStore`` backend.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from contextweaver.exceptions import ContextWeaverError, ItemNotFoundError
+from contextweaver.store.episodic import Episode
+from contextweaver.store.facts import Fact
+
+if TYPE_CHECKING:
+    from mem0 import Memory
+
+
+try:
+    # ``mem0ai`` exposes its public symbols under the ``mem0`` import name
+    # (the wheel is published as ``mem0ai`` to avoid PyPI conflicts; the
+    # in-Python import path is ``mem0``).  See https://docs.mem0.ai/.
+    from mem0 import Memory as _Memory  # noqa: F401 - imported for side effect
+except ImportError as _mem0_import_err:  # pragma: no cover - exercised only when extra is missing
+    raise ImportError(
+        "Mem0 external-memory backend requires the [mem0] extra. "
+        "Install with: pip install 'contextweaver[mem0]'"
+    ) from _mem0_import_err
+
+
+_CW_EPISODE_KEY = "cw_episode_id"
+_CW_FACT_KEY = "cw_fact_id"
+_CW_FACT_KEY_FIELD = "cw_key"
+_CW_TAGS_FIELD = "cw_tags"
+_DEFAULT_SCAN_LIMIT = 1000
+
+
+class Mem0BackendError(ContextWeaverError):
+    """Raised when the Mem0 backend cannot honour a store operation."""
+
+
+def _normalise_get_all_response(raw: object) -> list[dict[str, Any]]:
+    """Coerce mem0's ``get_all`` / ``search`` response into a plain memory list.
+
+    mem0 2.x returns ``{"results": [...]}``; older clients returned a
+    bare list.  Some self-hosted configurations return ``None`` for
+    empty stores.  This helper accepts all three shapes.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, dict):
+        results = raw.get("results", [])
+        if isinstance(results, list):
+            return [r for r in results if isinstance(r, dict)]
+        return []
+    if isinstance(raw, list):
+        return [r for r in raw if isinstance(r, dict)]
+    return []
+
+
+def _memory_id(record: dict[str, Any]) -> str | None:
+    """Return the mem0-assigned ``id`` of a memory record, or ``None``."""
+    value = record.get("id")
+    return value if isinstance(value, str) and value else None
+
+
+def _memory_text(record: dict[str, Any]) -> str:
+    """Return the textual payload of a memory record.
+
+    mem0 stores the canonical text under ``memory`` in 2.x; older
+    clients used ``text``.  Fall back to an empty string when the
+    record lacks both.
+    """
+    for field in ("memory", "text", "content"):
+        value = record.get(field)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _record_metadata(record: dict[str, Any]) -> dict[str, Any]:
+    """Return the metadata sub-dict of a memory record.
+
+    mem0 stores user-supplied metadata under the ``metadata`` key.
+    """
+    meta = record.get("metadata")
+    if isinstance(meta, dict):
+        return dict(meta)
+    return {}
+
+
+def _record_tags(record: dict[str, Any]) -> list[str]:
+    """Return the ``cw_tags`` list stamped into a memory's metadata."""
+    raw = _record_metadata(record).get(_CW_TAGS_FIELD)
+    if isinstance(raw, list):
+        return [t for t in raw if isinstance(t, str)]
+    return []
+
+
+class Mem0EpisodicStore:
+    """:class:`~contextweaver.store.protocols.EpisodicStore` backed by Mem0.
+
+    The store delegates similarity search to :meth:`mem0.Memory.search`
+    and writes go through :meth:`mem0.Memory.add` with ``infer=False``
+    so the text is stored as-supplied.  Every episode is stamped with
+    ``cw_episode_id`` in its metadata so :meth:`get` and
+    :meth:`delete` can resolve the canonical ID back to mem0's
+    internal UUID.
+
+    Args:
+        memory: A configured :class:`mem0.Memory` instance.  Bring your
+            own — the adapter does not configure the LLM / vector
+            store backend.
+        user_id: The mem0 session id used to scope every operation.
+            Mem0 requires one of ``user_id`` / ``agent_id`` / ``run_id``
+            on every call; this adapter exposes ``user_id`` because it
+            matches the typical agent-deployment shape.  Use a stable
+            value per agent / per tenant.
+        scan_limit: Upper bound on the number of records pulled from
+            :meth:`mem0.Memory.get_all` for a single :meth:`get`,
+            :meth:`delete`, or :meth:`all` call.  When the configured
+            ``user_id`` scope exceeds this number, methods that scan
+            raise :class:`NotImplementedError`.  Defaults to ``1000``.
+    """
+
+    def __init__(
+        self,
+        memory: Memory,
+        *,
+        user_id: str,
+        scan_limit: int = _DEFAULT_SCAN_LIMIT,
+    ) -> None:
+        if not user_id:
+            raise Mem0BackendError("Mem0EpisodicStore requires a non-empty user_id.")
+        self._memory = memory
+        self._user_id = user_id
+        self._scan_limit = scan_limit
+
+    def add(self, episode: Episode) -> None:
+        """Persist *episode* into the mem0 store under the configured scope."""
+        metadata: dict[str, Any] = dict(episode.metadata)
+        metadata[_CW_EPISODE_KEY] = episode.episode_id
+        metadata[_CW_TAGS_FIELD] = list(episode.tags)
+        self._memory.add(
+            episode.summary,
+            user_id=self._user_id,
+            metadata=metadata,
+            infer=False,
+        )
+
+    def _scan_records(self) -> list[dict[str, Any]]:
+        """Return every record under the configured scope.
+
+        Raises:
+            NotImplementedError: When the scope exceeds ``scan_limit``
+                — see the class docstring for the rationale.
+        """
+        raw = self._memory.get_all(filters={"user_id": self._user_id}, top_k=self._scan_limit)
+        records = _normalise_get_all_response(raw)
+        if len(records) >= self._scan_limit:
+            raise NotImplementedError(
+                f"Mem0EpisodicStore: {self._user_id!r} scope has at least "
+                f"{self._scan_limit} memories; scanning ops are no longer "
+                "lossless. Narrow scope via user_id partitioning or use "
+                "a dedicated EpisodicStore backend."
+            )
+        return records
+
+    def _record_for_episode(self, episode_id: str) -> dict[str, Any] | None:
+        for record in self._scan_records():
+            if _record_metadata(record).get(_CW_EPISODE_KEY) == episode_id:
+                return record
+        return None
+
+    def get(self, episode_id: str) -> Episode | None:
+        """Return the :class:`Episode` with ``episode_id`` or ``None``."""
+        record = self._record_for_episode(episode_id)
+        if record is None:
+            return None
+        return Episode(
+            episode_id=episode_id,
+            summary=_memory_text(record),
+            tags=_record_tags(record),
+            metadata={
+                k: v
+                for k, v in _record_metadata(record).items()
+                if k not in (_CW_EPISODE_KEY, _CW_TAGS_FIELD)
+            },
+        )
+
+    def search(self, query: str, top_k: int = 5) -> list[Episode]:
+        """Return up to ``top_k`` episodes most relevant to *query*.
+
+        Delegates to :meth:`mem0.Memory.search`.
+        """
+        raw = self._memory.search(
+            query,
+            top_k=top_k,
+            filters={"user_id": self._user_id},
+        )
+        results = _normalise_get_all_response(raw)
+        out: list[Episode] = []
+        for record in results:
+            meta = _record_metadata(record)
+            ep_id = meta.get(_CW_EPISODE_KEY)
+            if not isinstance(ep_id, str) or not ep_id:
+                continue
+            out.append(
+                Episode(
+                    episode_id=ep_id,
+                    summary=_memory_text(record),
+                    tags=_record_tags(record),
+                    metadata={
+                        k: v for k, v in meta.items() if k not in (_CW_EPISODE_KEY, _CW_TAGS_FIELD)
+                    },
+                )
+            )
+        return out
+
+    def all(self) -> list[Episode]:
+        """Return every episode under the configured scope, insertion-ordered."""
+        records = self._scan_records()
+        out: list[Episode] = []
+        for record in records:
+            meta = _record_metadata(record)
+            ep_id = meta.get(_CW_EPISODE_KEY)
+            if not isinstance(ep_id, str) or not ep_id:
+                continue
+            out.append(
+                Episode(
+                    episode_id=ep_id,
+                    summary=_memory_text(record),
+                    tags=_record_tags(record),
+                    metadata={
+                        k: v for k, v in meta.items() if k not in (_CW_EPISODE_KEY, _CW_TAGS_FIELD)
+                    },
+                )
+            )
+        return out
+
+    def latest(self, n: int = 3) -> list[tuple[str, str, dict[str, Any]]]:
+        """Return the *n* most recently added episodes, most-recent first.
+
+        Mem0 returns records insertion-ordered; we reverse the tail.
+        """
+        if n <= 0:
+            return []
+        episodes = self.all()
+        recent = episodes[-n:]
+        return [(ep.episode_id, ep.summary, dict(ep.metadata)) for ep in reversed(recent)]
+
+    def delete(self, episode_id: str) -> None:
+        """Remove the episode with ``episode_id``.
+
+        Raises:
+            ItemNotFoundError: When no episode with ``episode_id`` is
+                stored under the configured scope.
+        """
+        record = self._record_for_episode(episode_id)
+        if record is None:
+            raise ItemNotFoundError(f"Episode not found: {episode_id!r}")
+        mem_id = _memory_id(record)
+        if mem_id is None:
+            raise Mem0BackendError(
+                f"Mem0 record for episode {episode_id!r} is missing an 'id' field."
+            )
+        self._memory.delete(mem_id)
+
+
+class Mem0FactStore:
+    """:class:`~contextweaver.store.protocols.FactStore` backed by Mem0.
+
+    See the :mod:`module docstring <contextweaver.extras.memory.mem0>` for
+    the metadata-stamping strategy and the scan-limit semantics that
+    apply equally to facts.
+
+    Args:
+        memory: A configured :class:`mem0.Memory` instance.
+        user_id: Mem0 session id used to scope every operation.
+        scan_limit: Upper bound on records scanned per
+            :meth:`get` / :meth:`get_by_key` / :meth:`list_keys` /
+            :meth:`all` / :meth:`delete` call.
+    """
+
+    def __init__(
+        self,
+        memory: Memory,
+        *,
+        user_id: str,
+        scan_limit: int = _DEFAULT_SCAN_LIMIT,
+    ) -> None:
+        if not user_id:
+            raise Mem0BackendError("Mem0FactStore requires a non-empty user_id.")
+        self._memory = memory
+        self._user_id = user_id
+        self._scan_limit = scan_limit
+
+    def put(self, fact: Fact) -> None:
+        """Insert or replace the fact identified by ``fact.fact_id``."""
+        existing = self._record_for_fact(fact.fact_id)
+        if existing is not None:
+            mem_id = _memory_id(existing)
+            if mem_id is not None:
+                self._memory.delete(mem_id)
+        metadata: dict[str, Any] = dict(fact.metadata)
+        metadata[_CW_FACT_KEY] = fact.fact_id
+        metadata[_CW_FACT_KEY_FIELD] = fact.key
+        metadata[_CW_TAGS_FIELD] = list(fact.tags)
+        self._memory.add(
+            fact.value,
+            user_id=self._user_id,
+            metadata=metadata,
+            infer=False,
+        )
+
+    def _scan_records(self) -> list[dict[str, Any]]:
+        raw = self._memory.get_all(filters={"user_id": self._user_id}, top_k=self._scan_limit)
+        records = _normalise_get_all_response(raw)
+        if len(records) >= self._scan_limit:
+            raise NotImplementedError(
+                f"Mem0FactStore: {self._user_id!r} scope has at least "
+                f"{self._scan_limit} memories; scanning ops are no longer "
+                "lossless. Narrow scope via user_id partitioning or use "
+                "a dedicated FactStore backend."
+            )
+        return records
+
+    def _record_for_fact(self, fact_id: str) -> dict[str, Any] | None:
+        for record in self._scan_records():
+            if _record_metadata(record).get(_CW_FACT_KEY) == fact_id:
+                return record
+        return None
+
+    def _fact_from_record(self, record: dict[str, Any]) -> Fact | None:
+        meta = _record_metadata(record)
+        fact_id = meta.get(_CW_FACT_KEY)
+        key = meta.get(_CW_FACT_KEY_FIELD)
+        if not isinstance(fact_id, str) or not fact_id:
+            return None
+        if not isinstance(key, str):
+            key = ""
+        return Fact(
+            fact_id=fact_id,
+            key=key,
+            value=_memory_text(record),
+            tags=_record_tags(record),
+            metadata={
+                k: v
+                for k, v in meta.items()
+                if k not in (_CW_FACT_KEY, _CW_FACT_KEY_FIELD, _CW_TAGS_FIELD)
+            },
+        )
+
+    def get(self, fact_id: str) -> Fact:
+        """Return the fact with ``fact_id``.
+
+        Raises:
+            ItemNotFoundError: When no fact with ``fact_id`` is stored
+                under the configured scope.
+        """
+        record = self._record_for_fact(fact_id)
+        if record is None:
+            raise ItemNotFoundError(f"Fact not found: {fact_id!r}")
+        fact = self._fact_from_record(record)
+        if fact is None:
+            raise ItemNotFoundError(f"Fact not found: {fact_id!r}")
+        return fact
+
+    def get_by_key(self, key: str) -> list[Fact]:
+        """Return every fact whose ``key`` matches *key*, sorted by ``fact_id``."""
+        out: list[Fact] = []
+        for record in self._scan_records():
+            meta = _record_metadata(record)
+            if meta.get(_CW_FACT_KEY_FIELD) != key:
+                continue
+            fact = self._fact_from_record(record)
+            if fact is not None:
+                out.append(fact)
+        out.sort(key=lambda f: f.fact_id)
+        return out
+
+    def list_keys(self, prefix: str = "") -> list[str]:
+        """Return every distinct fact key under the configured scope."""
+        keys: set[str] = set()
+        for record in self._scan_records():
+            key = _record_metadata(record).get(_CW_FACT_KEY_FIELD)
+            if isinstance(key, str) and key.startswith(prefix):
+                keys.add(key)
+        return sorted(keys)
+
+    def delete(self, fact_id: str) -> None:
+        """Remove the fact identified by ``fact_id``.
+
+        Raises:
+            ItemNotFoundError: When no fact with ``fact_id`` is stored
+                under the configured scope.
+        """
+        record = self._record_for_fact(fact_id)
+        if record is None:
+            raise ItemNotFoundError(f"Fact not found: {fact_id!r}")
+        mem_id = _memory_id(record)
+        if mem_id is None:
+            raise Mem0BackendError(f"Mem0 record for fact {fact_id!r} is missing an 'id' field.")
+        self._memory.delete(mem_id)
+
+    def all(self) -> list[Fact]:
+        """Return every fact under the configured scope, sorted by ``fact_id``."""
+        out: list[Fact] = []
+        for record in self._scan_records():
+            fact = self._fact_from_record(record)
+            if fact is not None:
+                out.append(fact)
+        out.sort(key=lambda f: f.fact_id)
+        return out

--- a/src/contextweaver/extras/memory/mem0.py
+++ b/src/contextweaver/extras/memory/mem0.py
@@ -184,7 +184,17 @@ class Mem0EpisodicStore:
         self._scan_limit = scan_limit
 
     def add(self, episode: Episode) -> None:
-        """Persist *episode* into the mem0 store under the configured scope."""
+        """Persist *episode* into the mem0 store under the configured scope.
+
+        If an episode with the same ``episode_id`` already exists, the
+        existing record is deleted first (upsert semantics) so that
+        :meth:`get` never returns a stale duplicate.
+        """
+        existing = self._record_for_episode(episode.episode_id)
+        if existing is not None:
+            mem_id = _memory_id(existing)
+            if mem_id is not None:
+                self._memory.delete(mem_id)
         metadata: dict[str, Any] = dict(episode.metadata)
         metadata[_CW_EPISODE_KEY] = episode.episode_id
         metadata[_CW_TAGS_FIELD] = list(episode.tags)

--- a/tests/test_adapters_anthropic_messages.py
+++ b/tests/test_adapters_anthropic_messages.py
@@ -301,7 +301,28 @@ def test_roundtrip_preserves_unknown_block_fields_like_cache_control() -> None:
 
 
 def test_module_does_not_import_provider_sdk_at_load_time() -> None:
-    """No provider SDK leaked into sys.modules through the adapter import."""
-    assert "anthropic" not in sys.modules
-    assert "openai" not in sys.modules
-    assert "google.generativeai" not in sys.modules
+    """No provider SDK leaked into sys.modules through the adapter import.
+
+    Runs in a fresh subprocess so the invariant is independent of whatever
+    other tests in the session may have pulled into ``sys.modules``
+    transitively.
+    """
+    import subprocess
+
+    script = (
+        "import sys\n"
+        "import contextweaver.adapters.anthropic_messages  # noqa: F401\n"
+        "assert 'anthropic' not in sys.modules\n"
+        "assert 'openai' not in sys.modules\n"
+        "assert 'google.generativeai' not in sys.modules\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"anthropic_messages leaked a provider SDK at import time: "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )

--- a/tests/test_adapters_crewai.py
+++ b/tests/test_adapters_crewai.py
@@ -1,0 +1,202 @@
+"""Tests for contextweaver.adapters.crewai (issue #193)."""
+
+from __future__ import annotations
+
+import pytest
+
+from contextweaver.adapters.crewai import (
+    crewai_tool_to_selectable,
+    crewai_tools_to_catalog,
+    infer_crewai_namespace,
+    load_crewai_catalog,
+)
+from contextweaver.exceptions import CatalogError
+
+# ---------------------------------------------------------------------------
+# Namespace inference
+# ---------------------------------------------------------------------------
+
+
+def test_infer_crewai_namespace_underscore() -> None:
+    assert infer_crewai_namespace("github_search") == "github"
+
+
+def test_infer_crewai_namespace_dot() -> None:
+    assert infer_crewai_namespace("calendar.create_event") == "calendar"
+
+
+def test_infer_crewai_namespace_slash() -> None:
+    assert infer_crewai_namespace("filesystem/read_file") == "filesystem"
+
+
+def test_infer_crewai_namespace_empty() -> None:
+    assert infer_crewai_namespace("") == "crewai"
+
+
+def test_infer_crewai_namespace_single_segment() -> None:
+    """One-segment names have no detectable namespace; fall back to ``crewai``."""
+    assert infer_crewai_namespace("search") == "crewai"
+
+
+# ---------------------------------------------------------------------------
+# Dict → SelectableItem conversion
+# ---------------------------------------------------------------------------
+
+
+def test_crewai_tool_to_selectable_minimal_dict() -> None:
+    item = crewai_tool_to_selectable({"name": "search", "description": "Search the corpus."})
+    assert item.kind == "tool"
+    assert item.id == "crewai:search"
+    assert item.name == "search"
+    assert item.description == "Search the corpus."
+    assert item.namespace == "crewai"
+    assert item.tags == ["crewai"]
+    assert item.args_schema == {}
+    assert item.metadata == {}
+
+
+def test_crewai_tool_to_selectable_inferred_namespace() -> None:
+    item = crewai_tool_to_selectable(
+        {"name": "github_search_repos", "description": "Search GitHub repos."}
+    )
+    assert item.namespace == "github"
+    # Namespace prefix stripped from the short name.
+    assert item.name == "search_repos"
+    assert item.id == "crewai:github_search_repos"
+    assert "crewai" in item.tags
+
+
+def test_crewai_tool_to_selectable_explicit_namespace_overrides_inference() -> None:
+    item = crewai_tool_to_selectable(
+        {"name": "github_search_repos", "description": "x"},
+        namespace="vcs",
+    )
+    assert item.namespace == "vcs"
+    # No "vcs_" prefix on the raw name → full name kept.
+    assert item.name == "github_search_repos"
+
+
+def test_crewai_tool_to_selectable_preserves_user_tags() -> None:
+    item = crewai_tool_to_selectable(
+        {
+            "name": "calendar.create_event",
+            "description": "Schedule a meeting.",
+            "tags": ["calendar", "write"],
+        }
+    )
+    # ``crewai`` is always added; user-provided tags are merged.
+    assert set(item.tags) == {"crewai", "calendar", "write"}
+
+
+def test_crewai_tool_to_selectable_dict_args_schema_preserved() -> None:
+    schema = {"type": "object", "properties": {"q": {"type": "string"}}}
+    item = crewai_tool_to_selectable(
+        {"name": "search", "description": "Search.", "args_schema": schema}
+    )
+    assert item.args_schema == schema
+
+
+def test_crewai_tool_to_selectable_metadata_pass_through() -> None:
+    item = crewai_tool_to_selectable(
+        {
+            "name": "search",
+            "description": "Search.",
+            "result_as_answer": True,
+            "max_usage_count": 5,
+        }
+    )
+    assert item.metadata == {"result_as_answer": True, "max_usage_count": 5}
+
+
+def test_crewai_tool_to_selectable_missing_name_raises() -> None:
+    with pytest.raises(CatalogError, match="'name'"):
+        crewai_tool_to_selectable({"description": "missing name"})
+
+
+def test_crewai_tool_to_selectable_missing_description_raises() -> None:
+    with pytest.raises(CatalogError, match="'description'"):
+        crewai_tool_to_selectable({"name": "search"})
+
+
+def test_crewai_tool_to_selectable_empty_name_raises() -> None:
+    with pytest.raises(CatalogError, match="'name'"):
+        crewai_tool_to_selectable({"name": "", "description": "x"})
+
+
+# ---------------------------------------------------------------------------
+# Batch conversion → Catalog
+# ---------------------------------------------------------------------------
+
+
+def test_crewai_tools_to_catalog_registers_every_item() -> None:
+    catalog = crewai_tools_to_catalog(
+        [
+            {"name": "search", "description": "Search."},
+            {"name": "browser.open", "description": "Open a page."},
+        ]
+    )
+    ids = {item.id for item in catalog.all()}
+    assert ids == {"crewai:search", "crewai:browser.open"}
+
+
+def test_crewai_tools_to_catalog_uniform_namespace_override() -> None:
+    catalog = crewai_tools_to_catalog(
+        [
+            {"name": "alpha", "description": "x"},
+            {"name": "beta", "description": "y"},
+        ],
+        namespace="lab",
+    )
+    namespaces = {item.namespace for item in catalog.all()}
+    assert namespaces == {"lab"}
+
+
+# ---------------------------------------------------------------------------
+# Live BaseTool integration (requires the ``crewai`` package)
+# ---------------------------------------------------------------------------
+
+
+def test_load_crewai_catalog_with_real_basetool_instances() -> None:
+    crewai_tools = pytest.importorskip("crewai.tools")
+    # ``BaseTool`` is imported via ``importorskip`` rather than a top-level
+    # import so the file is testable without the ``[crewai]`` extra; the
+    # capital local-variable name mirrors the upstream class name and is
+    # required by the ``class SearchTool(BaseTool):`` declarations below.
+    BaseTool = crewai_tools.BaseTool  # noqa: N806
+
+    class SearchTool(BaseTool):
+        name: str = "search"
+        description: str = "Search the corpus."
+
+        def _run(self, *args: object, **kwargs: object) -> str:
+            return "stub"
+
+    class CalendarTool(BaseTool):
+        name: str = "calendar.create_event"
+        description: str = "Schedule a meeting."
+
+        def _run(self, *args: object, **kwargs: object) -> str:
+            return "stub"
+
+    catalog = load_crewai_catalog([SearchTool(), CalendarTool()])
+    ids = {item.id for item in catalog.all()}
+    assert ids == {"crewai:search", "crewai:calendar.create_event"}
+    # SearchTool has no explicit namespace prefix → fallback to crewai.
+    search_item = next(i for i in catalog.all() if i.id == "crewai:search")
+    # CrewAI's ``BaseTool.model_dump()`` enriches ``description`` with the
+    # tool name + JSON-schema preamble that the framework feeds to the
+    # underlying LLM (see ``crewai.tools.base_tool.BaseTool.description``).
+    # The adapter is intentionally faithful to that enriched form so the
+    # router scores against the same text the LLM eventually sees; assert
+    # both the original sentence and the framework's preamble are present.
+    assert "Search the corpus." in search_item.description
+    assert "Tool Name: search" in search_item.description
+    assert search_item.namespace == "crewai"
+
+
+def test_load_crewai_catalog_rejects_object_without_name_attr() -> None:
+    class Bogus:
+        description = "no name"
+
+    with pytest.raises(CatalogError, match="'name'"):
+        load_crewai_catalog([Bogus()])

--- a/tests/test_adapters_gemini_contents.py
+++ b/tests/test_adapters_gemini_contents.py
@@ -213,6 +213,28 @@ def test_two_function_calls_with_same_name_get_distinct_ids() -> None:
 
 
 def test_module_does_not_import_provider_sdk_at_load_time() -> None:
-    assert "google.generativeai" not in sys.modules
-    assert "openai" not in sys.modules
-    assert "anthropic" not in sys.modules
+    """Issue #222 design constraint: no provider SDK import at module level.
+
+    Runs in a fresh subprocess so the invariant is independent of whatever
+    other tests in the session may have pulled into ``sys.modules``
+    transitively.
+    """
+    import subprocess
+
+    script = (
+        "import sys\n"
+        "import contextweaver.adapters.gemini_contents  # noqa: F401\n"
+        "assert 'google.generativeai' not in sys.modules\n"
+        "assert 'openai' not in sys.modules\n"
+        "assert 'anthropic' not in sys.modules\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"gemini_contents leaked a provider SDK at import time: "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )

--- a/tests/test_adapters_openai_messages.py
+++ b/tests/test_adapters_openai_messages.py
@@ -293,10 +293,29 @@ def test_roundtrip_preserves_multimodal_assistant_content_list() -> None:
 
 
 def test_module_does_not_import_provider_sdk_at_load_time() -> None:
-    """Issue #219 design constraint: no provider SDK import at module level."""
-    # The openai_messages module is already imported by these tests; assert
-    # that neither openai nor any openai_* package leaked into sys.modules
-    # as a transitive import of the adapter.
-    assert "openai" not in sys.modules
-    assert "anthropic" not in sys.modules
-    assert "google.generativeai" not in sys.modules
+    """Issue #219 design constraint: no provider SDK import at module level.
+
+    Runs in a fresh subprocess so the invariant is independent of whatever
+    other tests in the session may have pulled into ``sys.modules``
+    transitively (e.g. ``crewai`` → ``openai`` once the ``[crewai]`` /
+    ``[dev]`` extras are installed).
+    """
+    import subprocess
+
+    script = (
+        "import sys\n"
+        "import contextweaver.adapters.openai_messages  # noqa: F401\n"
+        "assert 'openai' not in sys.modules, sorted(sys.modules)\n"
+        "assert 'anthropic' not in sys.modules\n"
+        "assert 'google.generativeai' not in sys.modules\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"openai_messages leaked a provider SDK at import time: "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )

--- a/tests/test_extras_memory_mem0.py
+++ b/tests/test_extras_memory_mem0.py
@@ -1,0 +1,280 @@
+"""Tests for contextweaver.extras.memory.mem0 (issue #195).
+
+The functional tests run only when the ``[mem0]`` extra is installed.
+Mem0's network-touching methods (``add`` runs an LLM extraction by
+default; ``search`` calls an embedder) are stubbed via
+``unittest.mock.MagicMock(spec=Memory)`` so the tests are deterministic
+and offline — the spec ensures the mock rejects any call signature
+that does not exist on the real :class:`mem0.Memory` class.
+
+One test always runs: it asserts the friendly ``ImportError`` surfaces
+when ``[mem0]`` is missing.  The two paths together cover both branches
+without requiring ``mem0ai`` in the default CI install.
+"""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock
+
+import pytest
+
+from contextweaver.exceptions import ItemNotFoundError
+
+
+def _mem0_available() -> bool:
+    try:
+        importlib.import_module("mem0")
+    except ImportError:
+        return False
+    return True
+
+
+HAS_MEM0 = _mem0_available()
+
+
+# ---------------------------------------------------------------------------
+# Import-error path (always runs — covers the no-extra case)
+# ---------------------------------------------------------------------------
+
+
+def test_import_error_message_when_extra_missing() -> None:
+    """If ``mem0`` is missing, importing the adapter must guide the user."""
+    if HAS_MEM0:
+        pytest.skip("mem0 is installed; ImportError path not exercised here")
+    with pytest.raises(ImportError, match=r"\[mem0\]"):
+        importlib.import_module("contextweaver.extras.memory.mem0")
+
+
+# ---------------------------------------------------------------------------
+# Functional tests (run only with the [mem0] extra installed)
+# ---------------------------------------------------------------------------
+
+
+if HAS_MEM0:  # pragma: no cover - exercised only with [mem0]
+    from mem0 import Memory
+
+    from contextweaver.extras.memory.mem0 import (
+        Mem0BackendError,
+        Mem0EpisodicStore,
+        Mem0FactStore,
+    )
+    from contextweaver.store.episodic import Episode
+    from contextweaver.store.facts import Fact
+
+
+@pytest.fixture()
+def fake_memory() -> MagicMock:
+    """Return a ``MagicMock(spec=Memory)`` with an in-memory record store.
+
+    The mock honours mem0's 2.x return shape (``{"results": [...]}``)
+    so the adapter exercises its real response-normalisation path.
+    """
+    if not HAS_MEM0:
+        pytest.skip("mem0 not installed")
+    memory = MagicMock(spec=Memory)
+    records: list[dict[str, object]] = []
+    counter = {"n": 0}
+
+    def _add(messages: str, **kwargs: object) -> dict[str, object]:
+        counter["n"] += 1
+        meta = kwargs.get("metadata") or {}
+        if not isinstance(meta, dict):
+            meta = {}
+        record: dict[str, object] = {
+            "id": f"mem-{counter['n']}",
+            "memory": messages,
+            "metadata": dict(meta),
+            "user_id": kwargs.get("user_id"),
+        }
+        records.append(record)
+        return {"results": [{"event": "ADD", **record}]}
+
+    def _scope(filters: object) -> list[dict[str, object]]:
+        user_id = filters.get("user_id") if isinstance(filters, dict) else None
+        return [r for r in records if r.get("user_id") == user_id]
+
+    def _get_all(*, filters: object = None, top_k: int = 20, **_: object) -> dict[str, object]:
+        return {"results": _scope(filters)[:top_k]}
+
+    def _search(
+        query: str, *, top_k: int = 20, filters: object = None, **_: object
+    ) -> dict[str, object]:
+        scoped = _scope(filters)
+        ql = query.lower()
+        ranked = [r for r in scoped if ql in str(r.get("memory", "")).lower()]
+        return {"results": ranked[:top_k]}
+
+    def _delete(memory_id: str) -> None:
+        for i, r in enumerate(records):
+            if r["id"] == memory_id:
+                records.pop(i)
+                return
+
+    memory.add.side_effect = _add
+    memory.get_all.side_effect = _get_all
+    memory.search.side_effect = _search
+    memory.delete.side_effect = _delete
+    return memory
+
+
+# ----- Mem0EpisodicStore -----
+
+
+def test_episodic_add_invokes_memory_add_with_infer_false(fake_memory: MagicMock) -> None:
+    store = Mem0EpisodicStore(fake_memory, user_id="alice")
+    store.add(Episode(episode_id="ep-1", summary="Investigated outage on 2025-10-01"))
+    fake_memory.add.assert_called_once()
+    kwargs = fake_memory.add.call_args.kwargs
+    assert kwargs["user_id"] == "alice"
+    assert kwargs["infer"] is False
+    assert kwargs["metadata"]["cw_episode_id"] == "ep-1"
+
+
+def test_episodic_get_roundtrips_canonical_fields(fake_memory: MagicMock) -> None:
+    store = Mem0EpisodicStore(fake_memory, user_id="alice")
+    store.add(
+        Episode(
+            episode_id="ep-1",
+            summary="checked logs",
+            tags=["incident", "rca"],
+            metadata={"sev": "high"},
+        )
+    )
+    got = store.get("ep-1")
+    assert got is not None
+    assert got.episode_id == "ep-1"
+    assert got.summary == "checked logs"
+    assert got.tags == ["incident", "rca"]
+    assert got.metadata == {"sev": "high"}
+
+
+def test_episodic_get_missing_returns_none(fake_memory: MagicMock) -> None:
+    store = Mem0EpisodicStore(fake_memory, user_id="alice")
+    assert store.get("never-added") is None
+
+
+def test_episodic_search_filters_to_scope_and_returns_episodes(fake_memory: MagicMock) -> None:
+    store_a = Mem0EpisodicStore(fake_memory, user_id="alice")
+    store_b = Mem0EpisodicStore(fake_memory, user_id="bob")
+    store_a.add(Episode("a1", "alice investigated database outage"))
+    store_b.add(Episode("b1", "bob updated database schema"))
+    results = store_a.search("database", top_k=5)
+    assert [ep.episode_id for ep in results] == ["a1"]
+
+
+def test_episodic_all_returns_all_records_in_scope(fake_memory: MagicMock) -> None:
+    store = Mem0EpisodicStore(fake_memory, user_id="alice")
+    store.add(Episode("a1", "first"))
+    store.add(Episode("a2", "second"))
+    eps = store.all()
+    assert [ep.episode_id for ep in eps] == ["a1", "a2"]
+
+
+def test_episodic_latest_returns_most_recent_first(fake_memory: MagicMock) -> None:
+    store = Mem0EpisodicStore(fake_memory, user_id="alice")
+    store.add(Episode("a1", "first"))
+    store.add(Episode("a2", "second"))
+    store.add(Episode("a3", "third"))
+    latest = store.latest(n=2)
+    assert [t[0] for t in latest] == ["a3", "a2"]
+
+
+def test_episodic_latest_zero_returns_empty(fake_memory: MagicMock) -> None:
+    store = Mem0EpisodicStore(fake_memory, user_id="alice")
+    store.add(Episode("a1", "first"))
+    assert store.latest(n=0) == []
+
+
+def test_episodic_delete_calls_memory_delete_with_mem_id(fake_memory: MagicMock) -> None:
+    store = Mem0EpisodicStore(fake_memory, user_id="alice")
+    store.add(Episode("a1", "first"))
+    store.delete("a1")
+    assert fake_memory.delete.call_args.args == ("mem-1",)
+    assert store.get("a1") is None
+
+
+def test_episodic_delete_missing_raises(fake_memory: MagicMock) -> None:
+    store = Mem0EpisodicStore(fake_memory, user_id="alice")
+    with pytest.raises(ItemNotFoundError, match="ep-missing"):
+        store.delete("ep-missing")
+
+
+def test_episodic_requires_user_id() -> None:
+    if not HAS_MEM0:
+        pytest.skip("mem0 not installed")
+    memory = MagicMock(spec=Memory)
+    with pytest.raises(Mem0BackendError, match="user_id"):
+        Mem0EpisodicStore(memory, user_id="")
+
+
+def test_episodic_scan_limit_raises_not_implemented(fake_memory: MagicMock) -> None:
+    store = Mem0EpisodicStore(fake_memory, user_id="alice", scan_limit=2)
+    store.add(Episode("a1", "x"))
+    store.add(Episode("a2", "y"))
+    # Adding the 3rd pushes the scoped count to exactly the limit; scanning
+    # ops must then refuse to proceed rather than truncate silently.
+    store.add(Episode("a3", "z"))
+    with pytest.raises(NotImplementedError, match="scanning ops are no longer"):
+        store.all()
+
+
+# ----- Mem0FactStore -----
+
+
+def test_fact_put_and_get(fake_memory: MagicMock) -> None:
+    store = Mem0FactStore(fake_memory, user_id="alice")
+    store.put(Fact(fact_id="f1", key="user.role", value="admin"))
+    got = store.get("f1")
+    assert got.fact_id == "f1"
+    assert got.key == "user.role"
+    assert got.value == "admin"
+
+
+def test_fact_put_overwrites_existing(fake_memory: MagicMock) -> None:
+    store = Mem0FactStore(fake_memory, user_id="alice")
+    store.put(Fact(fact_id="f1", key="user.role", value="admin"))
+    store.put(Fact(fact_id="f1", key="user.role", value="superadmin"))
+    got = store.get("f1")
+    assert got.value == "superadmin"
+    # Should have called delete for the original record before re-adding.
+    assert fake_memory.delete.call_count == 1
+
+
+def test_fact_get_missing_raises(fake_memory: MagicMock) -> None:
+    store = Mem0FactStore(fake_memory, user_id="alice")
+    with pytest.raises(ItemNotFoundError, match="never-added"):
+        store.get("never-added")
+
+
+def test_fact_get_by_key_returns_sorted(fake_memory: MagicMock) -> None:
+    store = Mem0FactStore(fake_memory, user_id="alice")
+    store.put(Fact("f2", "tags.color", "blue"))
+    store.put(Fact("f1", "tags.color", "green"))
+    by_key = store.get_by_key("tags.color")
+    assert [f.fact_id for f in by_key] == ["f1", "f2"]
+
+
+def test_fact_list_keys_with_prefix(fake_memory: MagicMock) -> None:
+    store = Mem0FactStore(fake_memory, user_id="alice")
+    store.put(Fact("f1", "user.role", "admin"))
+    store.put(Fact("f2", "user.email", "a@b"))
+    store.put(Fact("f3", "system.region", "eu"))
+    assert store.list_keys(prefix="user.") == ["user.email", "user.role"]
+    assert store.list_keys() == ["system.region", "user.email", "user.role"]
+
+
+def test_fact_delete(fake_memory: MagicMock) -> None:
+    store = Mem0FactStore(fake_memory, user_id="alice")
+    store.put(Fact("f1", "user.role", "admin"))
+    store.delete("f1")
+    with pytest.raises(ItemNotFoundError):
+        store.get("f1")
+
+
+def test_fact_all_returns_sorted_by_id(fake_memory: MagicMock) -> None:
+    store = Mem0FactStore(fake_memory, user_id="alice")
+    store.put(Fact("f2", "k1", "v1"))
+    store.put(Fact("f1", "k2", "v2"))
+    facts = store.all()
+    assert [f.fact_id for f in facts] == ["f1", "f2"]


### PR DESCRIPTION
Lands Phase 1 of the two-issue &quot;interop expansion&quot; group selected by
the triage pass. Single combined PR per Mode B owner authorisation.

## #193 — CrewAI adapter (representative for the framework-adapter epic)

- `adapters/crewai.py` — thin stateless converter mirroring
  `adapters/fastmcp.py`'s shape. Plain-dict core
  (`crewai_tool_to_selectable`, `crewai_tools_to_catalog`,
  `infer_crewai_namespace`) works without the `[crewai]` extra
  installed; `load_crewai_catalog` consumes live
  `crewai.tools.BaseTool` instances when the extra is available.
- `_args_schema_dict` uses `copy.deepcopy` for dict schemas so
  downstream mutations cannot corrupt the original input.
- Preamble-aware metadata: when CrewAI's enriched description format
  is detected (`Tool Name: ...\nTool Description: <original>`), the
  adapter stores the preamble-free text in
  `item.metadata["original_description"]`.
- New `[crewai]` optional-dependency group (`crewai>=0.80`) +
  `crewai>=0.80` added to `[dev]` so CI exercises the real upstream
  `BaseTool` wire shape end-to-end.
- `examples/crewai_adapter_demo.py` wired into `make example`; runs
  the plain-dict path so it succeeds without the optional extra.
- 14 tests in `tests/test_adapters_crewai.py` (namespace inference,
  dict + live BaseTool conversion, batch → Catalog, error paths).
- `docs/integration_crewai.md` is the public guide; cookbook §5
  points at the demo + integration page.

Follow-ups (deferred per Lean scope-shape): Pydantic AI,
smolagents, Agno adapters track on the same issue.

## #195 — Mem0 external-memory backend (representative)

- `extras/memory/mem0.py` — `Mem0EpisodicStore` + `Mem0FactStore`
  implement the existing `store.protocols.EpisodicStore` / `FactStore`
  Protocols verbatim. No Protocol widening (per
  `docs/agent-context/invariants.md`). Writes go through
  `Memory.add(infer=False)` so the raw text is stored as-is;
  records are stamped with `cw_episode_id` / `cw_fact_id` metadata
  for canonical-ID resolution against mem0's generated UUIDs.
- `Mem0EpisodicStore.add()` implements upsert semantics: if an
  episode with the same `episode_id` already exists, the old record
  is deleted before inserting, preventing zombie duplicates.
- `Mem0FactStore.put()` guards against `None` mem0 IDs on existing
  records, raising `Mem0BackendError` rather than passing `None` to
  `Memory.delete()`.
- Module-load guarded import with friendly `ImportError` mirroring
  `extras/otel.py`.
- New `[mem0]` optional-dependency group (`mem0ai>=0.1`) + `mem0ai>=0.1`
  added to `[dev]` so CI exercises the real `Memory` class signatures
  (LLM-touching methods stubbed via `MagicMock(spec=Memory)`).
- 21 tests in `tests/test_extras_memory_mem0.py` (always-runs
  ImportError-message path + functional tests under `HAS_MEM0`
  gate covering both stores' full protocol surface).
- `docs/integration_memory.md` is the decision-matrix doc covering
  Mem0 / Zep / LangMem; cookbook §6 ships the 8-line wiring
  snippet.

Follow-ups: Zep, LangMem backends share the same Protocol shape;
rows already listed in the decision matrix and `interop.md`.

## Shared bookkeeping

- `mkdocs.yml` + `docs/interop.md` interop matrix gain the new rows.
- `README.md` Framework Integrations table updated in both occurrences
  plus the FAQ list.
- `AGENTS.md` Module Map gains 4 new entries
  (`adapters/crewai.py`, `extras/otel.py`, `extras/memory/`,
  `extras/memory/mem0.py`).
- `CHANGELOG.md` `[Unreleased]` entries for both issues.
- Doc examples (`integration_crewai.md`, `integration_memory.md`,
  `cookbook.md`) use the correct API kwargs
  (`StoreBundle(episodic_store=..., fact_store=...)`,
  `ContextManager(stores=...)`).

## Test-quality fix (Mode B latitude, documented delta)

- `test_module_does_not_import_provider_sdk_at_load_time` in the
  three provider-message test files now spawns a fresh subprocess
  instead of asserting against the in-session `sys.modules`. The
  previous form was sensitive to whatever any other test had already
  imported (`crewai` → `openai` is the concrete case once `[dev]`
  pulls crewai in). The invariant is unchanged; the assertion is now
  independent of test ordering and installed extras.

## Module-size note

`extras/memory/mem0.py` lands at ~475 lines, over the soft 300-line
guide, in line with the `adapters/mcp.py` / `adapters/proxy_runtime.py`
precedent. The modest overrun is preferred to splitting one cohesive
backend (`Mem0EpisodicStore` + `Mem0FactStore` share private helpers)
across files for fragmentation's sake.

## Verification

```
ruff format --check src/ tests/ examples/ scripts/   → 182 files clean
ruff check src/ tests/ examples/ scripts/            → clean
mypy src/                                            → 0 issues / 85 files
python -m pytest -q                                  → 1285 passed, 22 skipped
```

Closes neither issue outright; both remain open with this PR linked.
Each issue's follow-up backends (Pydantic AI / smolagents / Agno
for #193; Zep / LangMem for #195) share the landed Protocol surface
and shim shape.