### PR TITLE
Add budget-check CLI command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ It prepares context and routes tools but never calls models or executes tools.
 | `extras/otel.py` | OpenTelemetry GenAI integration (`OTelEventHook` — `invoke_agent` / `execute_tool` spans + GenAI SemConv attributes, gated behind the `[otel]` extra, issue #224). |
 | `extras/memory/` | External-memory backend adapters that implement `EpisodicStore` / `FactStore` against an existing long-lived memory deployment without widening the Protocols (issue #195). |
 | `extras/memory/mem0.py` | `Mem0EpisodicStore` + `Mem0FactStore` — wrap a `mem0.Memory` instance scoped by `user_id`; writes go through `Memory.add(infer=False)` and items are stamped with `cw_episode_id` / `cw_fact_id` metadata for canonical-ID resolution. Gated behind the `[mem0]` extra (issue #195). |
-| `__main__.py` | CLI: 8 subcommands (`demo`, `build`, `route`, `print-tree`, `init`, `ingest`, `replay`, `stats`). Typer + Rich (both core deps as of v0.5, issue #221). |
+| `__main__.py` | CLI: 9 subcommands (`demo`, `build`, `route`, `print-tree`, `init`, `ingest`, `replay`, `stats`, `budget-check`). Typer + Rich (both core deps as of v0.5, issue #221). |
 
 ## Pipelines (summary)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CLI budget regression checks** (#276). New `contextweaver budget-check`
+  command rebuilds an ingested session for a selected phase, compares the
+  rendered prompt token count against `--max-tokens`, exits 1 on budget
+  overruns, and supports `--breakdown`, `--json`, and `--ratchet` baseline
+  workflows for CI.
+
 ## [0.8.0] - 2026-05-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -496,6 +496,8 @@ contextweaver route --graph g.json --query "send email"
 contextweaver print-tree --graph g.json
 contextweaver ingest --events session.jsonl --out session.json
 contextweaver replay --session session.json --phase answer
+contextweaver stats --session session.json --format text
+contextweaver budget-check --session session.json --phase answer --max-tokens 4000
 ```
 
 ## Examples

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -334,6 +334,24 @@ total_estimated_tokens = (
 mgr = ContextManager(token_estimator=TiktokenEstimator(model="gpt-4"))
 ```
 
+**CI regression check:** after serialising a session with `contextweaver ingest`,
+pin a ceiling with `budget-check` so prompt-size regressions fail before they
+reach production:
+
+```bash
+contextweaver budget-check \
+  --session session.json \
+  --phase answer \
+  --query "current user task" \
+  --max-tokens 4000 \
+  --breakdown
+```
+
+The command exits 0 when the rendered prompt is within the ceiling and exits 1
+when it is over. Add `--json` for CI parsers, or `--ratchet` to write the
+default `.budget-baseline.json` baseline and fail future runs that grow beyond
+it. Use `--ratchet-path path/to/baseline.json` when CI needs a different file.
+
 ---
 
 ### Issue 9: Graph Build Fails (`GraphBuildError`)

--- a/src/contextweaver/__main__.py
+++ b/src/contextweaver/__main__.py
@@ -1,6 +1,6 @@
 """Command-line interface for contextweaver.
 
-Provides eight sub-commands:
+Provides nine sub-commands:
 
 demo        Run a built-in demonstration of both engines.
 build       Build a routing graph from a catalog JSON file.
@@ -11,6 +11,9 @@ ingest      Ingest a JSONL session into a serialised session file.
 replay      Replay a session and build context for a given phase.
 stats       Render a human-readable :class:`BuildStats` diagnostic report
             from an ingested session (issue #106).
+budget-check
+            Assert an ingested session's rendered prompt stays under a
+            token ceiling for CI regression checks (issue #276).
 
 Invocable as ``python -m contextweaver`` or ``contextweaver`` (via
 ``[project.scripts]``).  Exempt from the 300-line module limit.
@@ -115,17 +118,22 @@ def _load_jsonl(path: str) -> list[ContextItem]:
     return items
 
 
-def _restore_manager_from_session(session_path: str, budget_tokens: int) -> ContextManager:
+def _restore_manager_from_session(
+    session_path: str, budget_tokens: int | None = None
+) -> ContextManager:
     """Rebuild a :class:`ContextManager` from a session JSON written by ``ingest``."""
     session: dict[str, Any] = json.loads(Path(session_path).read_text(encoding="utf-8"))
-    mgr = ContextManager(
-        budget=ContextBudget(
-            route=budget_tokens,
-            call=budget_tokens,
-            interpret=budget_tokens,
-            answer=budget_tokens,
+    if budget_tokens is None:
+        mgr = ContextManager()
+    else:
+        mgr = ContextManager(
+            budget=ContextBudget(
+                route=budget_tokens,
+                call=budget_tokens,
+                interpret=budget_tokens,
+                answer=budget_tokens,
+            )
         )
-    )
     for idx, raw_event in enumerate(session.get("events", []), 1):
         try:
             item = ContextItem.from_dict(raw_event)
@@ -137,6 +145,27 @@ def _restore_manager_from_session(session_path: str, budget_tokens: int) -> Cont
     for ep in session.get("episodes", []):
         mgr.add_episode(ep["episode_id"], ep["summary"])
     return mgr
+
+
+def _write_budget_baseline(
+    path: Path,
+    *,
+    phase: str,
+    query: str,
+    max_tokens: int,
+    prompt_tokens: int,
+    tokens_per_section: dict[str, int],
+) -> None:
+    """Write a deterministic budget baseline payload for ``budget-check --ratchet``."""
+    payload = {
+        "version": 1,
+        "phase": phase,
+        "query": query,
+        "max_tokens": max_tokens,
+        "prompt_tokens": prompt_tokens,
+        "tokens_per_section": dict(sorted(tokens_per_section.items())),
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -451,6 +480,115 @@ def stats(
         _console.print(pack.stats.report(format="rich", phase=phase.value, budget=budget))
     else:
         print(pack.stats.report(format="text", phase=phase.value, budget=budget))
+
+
+@app.command("budget-check")
+def budget_check(
+    session: Annotated[Path, typer.Option(..., help="Path to the session JSON file.")],
+    max_tokens: Annotated[
+        int, typer.Option("--max-tokens", help="Maximum allowed rendered prompt tokens.")
+    ],
+    phase: Annotated[
+        _PhaseChoice, typer.Option(help="Phase to build before checking.")
+    ] = _PhaseChoice.answer,
+    query: Annotated[
+        str, typer.Option(help="Query passed to ContextManager.build_sync().")
+    ] = "budget-check",
+    breakdown: Annotated[
+        bool, typer.Option("--breakdown", help="Print per-section token usage.")
+    ] = False,
+    json_output: Annotated[
+        bool, typer.Option("--json", help="Emit machine-readable JSON.")
+    ] = False,
+    ratchet: Annotated[
+        bool,
+        typer.Option(
+            "--ratchet",
+            help=(
+                "Read/write a baseline JSON file and fail if prompt token usage grows "
+                "above the stored baseline."
+            ),
+        ),
+    ] = False,
+    ratchet_path: Annotated[
+        Path,
+        typer.Option(
+            "--ratchet-path",
+            help="Baseline JSON path used by --ratchet.",
+        ),
+    ] = Path(".budget-baseline.json"),
+) -> None:
+    """Fail CI when a rendered context build exceeds a token ceiling (issue #276)."""
+    if max_tokens < 1:
+        raise typer.BadParameter("--max-tokens must be greater than 0", param_hint="--max-tokens")
+    if not session.exists():
+        raise typer.BadParameter(f"session file not found: {session}", param_hint="--session")
+
+    mgr = _restore_manager_from_session(str(session))
+    pack = mgr.build_sync(phase=Phase(phase.value), query=query)
+    total = pack.stats.prompt_tokens
+    over = max(total - max_tokens, 0)
+    utilization = total / max_tokens
+    budget_ok = total <= max_tokens
+
+    ratchet_ok = True
+    ratchet_baseline: int | None = None
+    ratchet_path_output: str | None = None
+    ratchet_written = False
+    if ratchet:
+        ratchet_file = ratchet_path
+        ratchet_path_output = str(ratchet_file)
+        if ratchet_file.exists():
+            baseline: dict[str, Any] = json.loads(ratchet_file.read_text(encoding="utf-8"))
+            ratchet_baseline = int(baseline.get("prompt_tokens", 0))
+            ratchet_ok = total <= ratchet_baseline
+        if budget_ok and ratchet_ok:
+            _write_budget_baseline(
+                ratchet_file,
+                phase=phase.value,
+                query=query,
+                max_tokens=max_tokens,
+                prompt_tokens=total,
+                tokens_per_section=pack.stats.tokens_per_section,
+            )
+            ratchet_written = True
+
+    ok = budget_ok and ratchet_ok
+    payload: dict[str, Any] = {
+        "ok": ok,
+        "phase": phase.value,
+        "query": query,
+        "prompt_tokens": total,
+        "max_tokens": max_tokens,
+        "utilization": round(utilization, 4),
+        "over": over,
+        "tokens_per_section": dict(sorted(pack.stats.tokens_per_section.items())),
+        "ratchet": {
+            "path": ratchet_path_output,
+            "baseline_prompt_tokens": ratchet_baseline,
+            "written": ratchet_written,
+            "ok": ratchet_ok,
+        },
+    }
+
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        if budget_ok:
+            print(f"OK total={total} budget={max_tokens} utilization={utilization:.1%}")
+        else:
+            print(f"FAIL total={total} budget={max_tokens} over={over}")
+        if ratchet:
+            if ratchet_baseline is not None and not ratchet_ok:
+                print(f"Ratchet failed: total={total} baseline={ratchet_baseline}")
+            elif ratchet_written:
+                print(f"Ratchet baseline written: {ratchet_path}")
+        if breakdown:
+            print("Token breakdown:")
+            for name, tokens in sorted(pack.stats.tokens_per_section.items()):
+                print(f"  {name}: {tokens}")
+
+    raise typer.Exit(0 if ok else 1)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -296,3 +296,149 @@ def test_stats_subcommand_rich_format(tmp_path: Path) -> None:
     # Rich-rendered output strips markup but keeps the headers.
     assert "Context Build Report" in result.stdout
     assert "Candidates" in result.stdout
+
+
+# ------------------------------------------------------------------
+# budget-check (issue #276)
+# ------------------------------------------------------------------
+
+
+def test_budget_check_under_budget_passes(tmp_path: Path) -> None:
+    jsonl_path = _write_session_jsonl(tmp_path)
+    ingested_path = tmp_path / "ingested.json"
+    _run("ingest", "--events", str(jsonl_path), "--out", str(ingested_path))
+
+    result = _run(
+        "budget-check",
+        "--session",
+        str(ingested_path),
+        "--max-tokens",
+        "1000",
+        "--query",
+        "status",
+    )
+    assert result.returncode == 0
+    assert "OK total=" in result.stdout
+    assert "budget=1000" in result.stdout
+
+
+def test_budget_check_over_budget_fails(tmp_path: Path) -> None:
+    jsonl_path = _write_session_jsonl(tmp_path)
+    ingested_path = tmp_path / "ingested.json"
+    _run("ingest", "--events", str(jsonl_path), "--out", str(ingested_path))
+
+    result = _run(
+        "budget-check",
+        "--session",
+        str(ingested_path),
+        "--max-tokens",
+        "1",
+        "--query",
+        "status",
+    )
+    assert result.returncode == 1
+    assert "FAIL total=" in result.stdout
+    assert "over=" in result.stdout
+
+
+def test_budget_check_missing_session_file_is_usage_error(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+
+    result = _run("budget-check", "--session", str(missing), "--max-tokens", "1000")
+
+    assert result.returncode == 2
+    assert "session file not found" in result.stderr
+
+
+def test_budget_check_breakdown_output(tmp_path: Path) -> None:
+    jsonl_path = _write_session_jsonl(tmp_path)
+    ingested_path = tmp_path / "ingested.json"
+    _run("ingest", "--events", str(jsonl_path), "--out", str(ingested_path))
+
+    result = _run(
+        "budget-check",
+        "--session",
+        str(ingested_path),
+        "--max-tokens",
+        "1000",
+        "--breakdown",
+    )
+    assert result.returncode == 0
+    assert "Token breakdown:" in result.stdout
+
+
+def test_budget_check_json_output(tmp_path: Path) -> None:
+    jsonl_path = _write_session_jsonl(tmp_path)
+    ingested_path = tmp_path / "ingested.json"
+    _run("ingest", "--events", str(jsonl_path), "--out", str(ingested_path))
+
+    result = _run(
+        "budget-check",
+        "--session",
+        str(ingested_path),
+        "--max-tokens",
+        "1000",
+        "--json",
+    )
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True
+    assert payload["prompt_tokens"] <= payload["max_tokens"]
+    assert payload["tokens_per_section"]
+
+
+def test_budget_check_ratchet_write_and_compare(tmp_path: Path) -> None:
+    jsonl_path = _write_session_jsonl(tmp_path)
+    ingested_path = tmp_path / "ingested.json"
+    _run("ingest", "--events", str(jsonl_path), "--out", str(ingested_path))
+    baseline_path = tmp_path / ".budget-baseline.json"
+
+    first = _run(
+        "budget-check",
+        "--session",
+        str(ingested_path),
+        "--max-tokens",
+        "1000",
+        "--ratchet",
+        "--ratchet-path",
+        str(baseline_path),
+    )
+    assert first.returncode == 0
+    assert baseline_path.exists()
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    assert baseline["prompt_tokens"] > 0
+
+    baseline["prompt_tokens"] = 0
+    baseline_path.write_text(json.dumps(baseline), encoding="utf-8")
+
+    second = _run(
+        "budget-check",
+        "--session",
+        str(ingested_path),
+        "--max-tokens",
+        "1000",
+        "--ratchet",
+        "--ratchet-path",
+        str(baseline_path),
+    )
+    assert second.returncode == 1
+    assert "Ratchet failed:" in second.stdout
+
+
+def test_budget_check_ratchet_uses_default_baseline_path(tmp_path: Path) -> None:
+    jsonl_path = _write_session_jsonl(tmp_path)
+    ingested_path = tmp_path / "ingested.json"
+    _run("ingest", "--events", str(jsonl_path), "--out", str(ingested_path))
+
+    result = _run(
+        "budget-check",
+        "--session",
+        str(ingested_path),
+        "--max-tokens",
+        "1000",
+        "--ratchet",
+        cwd=str(tmp_path),
+    )
+
+    assert result.returncode == 0
+    assert (tmp_path / ".budget-baseline.json").exists()


### PR DESCRIPTION
## Summary

- add `contextweaver budget-check` for CI token-budget regression checks over ingested sessions
- support text output, `--json`, `--breakdown`, and `--ratchet` with the default `.budget-baseline.json` path plus `--ratchet-path`
- document the command in the README, troubleshooting guide, and changelog

Closes #276.

## Validation

- `uv run --extra dev python -m pytest tests/test_cli.py -q`
- `uv run --extra dev pytest -q`
- `uv run --extra dev ruff check src/ tests/ examples/ scripts/`
- `uv run --extra dev ruff format --check src/ tests/ examples/ scripts/`
- `uv run --extra dev mypy src/`
- `uv run --extra dev python scripts/gen_schemas.py --check`
- `uv run --extra dev python -m contextweaver budget-check --help`
- `uv run --extra docs mkdocs build --clean`
- `git diff --check`
- `git diff | gitleaks stdin --no-banner --redact --timeout 30`

Manual smoke against `benchmarks/scenarios/long_conversation.jsonl`:

- `contextweaver ingest` wrote a session with 82 events.
- `budget-check --phase answer --max-tokens 10000 --breakdown` exited 0 with `OK total=2643 budget=10000`.
- `budget-check --phase answer --max-tokens 1` exited 1 with `FAIL total=2643 budget=1 over=2642`.
- `budget-check --phase answer --max-tokens 10000 --ratchet --ratchet-path ... --json` exited 0 and wrote the baseline.

## Notes

- `uv run --extra docs mkdocs build --strict` is still blocked by existing broken docs anchors/links outside this change; the non-strict project docs build exits 0.
