### PR TITLE
docs: clarify routing query behavior

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -36,11 +36,11 @@ Different phases emphasise different item kinds — for example, the
 `route` phase prioritises tool descriptions.
 
 ### User Query vs Routing Query
-Production agents may transform raw user input into a routing query prior to retrieval or context selection. Routing queries tend to be more compact and intent-matched.
+Production agents may transform raw user input into a routing query prior to retrieval or context selection. Routing queries remove conversational context so retrievers can match tools and context more precisely.
 
 `Router.route(query)` takes a query that is formatted like a routing query, not the actual user input query.
 ContextWeaver does not mandate what happens during the query transformation step. Different applications might adopt different strategies, such as LLM rewriting, classification, templates, or custom middleware.
-Check out the MCP context gateway example  [MCP gateway example](../examples/architectures/mcp_context_gateway/main.py) for a worked example.
+Check out the MCP context gateway example [MCP gateway example](../examples/mcp_gateway_demo.py) for a worked example.
 
 ## Selectable Item (ToolCard)
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -35,6 +35,13 @@ Different phases emphasise different item kinds — for example, the
 `answer` phase prioritises user turns and tool results, while the
 `route` phase prioritises tool descriptions.
 
+### User Query vs Routing Query
+Production agents may transform raw user input into a routing query prior to retrieval or context selection. Routing queries tend to be more compact and intent-matched.
+
+`Router.route(query)` takes a query that is formatted like a routing query, not the actual user input query.
+ContextWeaver does not mandate what happens during the query transformation step. Different applications might adopt different strategies, such as LLM rewriting, classification, templates, or custom middleware.
+Check out the MCP context gateway example  [MCP gateway example](../examples/architectures/mcp_context_gateway/main.py) for a worked example.
+
 ## Selectable Item (ToolCard)
 
 A `SelectableItem` is the unified representation of anything the Routing

--- a/docs/integration_mcp.md
+++ b/docs/integration_mcp.md
@@ -294,6 +294,8 @@ upstream MCP servers.  Both share the
 [`ProxyRuntime`](../src/contextweaver/adapters/proxy_runtime.py) core and
 satisfy the contracts in [`docs/gateway_spec.md`](gateway_spec.md):
 
+Production MCP gateway deployments commonly transform raw user input into routing-oriented queries before calling `Router.route(query)`. ContextWeaver does not require a specific rewriting strategy and accepts whichever routing-shaped query your gateway produces.
+
 | Mode | Discovery channel | Invocation channel | Schema exposure |
 |------|-------------------|--------------------|-----------------|
 | `ExposureMode.TRANSPARENT` (#13) | Stripped `tools/list` — one entry per upstream tool with sentinel `inputSchema: {"type": "object"}` | `tool_hydrate(tool_id)` + `tool_execute(tool_id, args)` | On demand via `tool_hydrate` |

--- a/docs/integration_mcp.md
+++ b/docs/integration_mcp.md
@@ -294,7 +294,11 @@ upstream MCP servers.  Both share the
 [`ProxyRuntime`](../src/contextweaver/adapters/proxy_runtime.py) core and
 satisfy the contracts in [`docs/gateway_spec.md`](gateway_spec.md):
 
-Production MCP gateway deployments commonly transform raw user input into routing-oriented queries before calling `Router.route(query)`. ContextWeaver does not require a specific rewriting strategy and accepts whichever routing-shaped query your gateway produces.
+Production MCP gateway deployments commonly transform raw
+user input into routing-oriented queries before calling
+`Router.route(query)`. ContextWeaver does not require a
+specific rewriting strategy and accepts whichever
+routing-shaped query your gateway produces.
 
 | Mode | Discovery channel | Invocation channel | Schema exposure |
 |------|-------------------|--------------------|-----------------|


### PR DESCRIPTION
Adds documentation clarifying the distinction between raw user queries and routing-shaped queries for `Router.route(query)`.

Fixes #265

## Changes

* Added "User Query vs Routing Query" subsection in `docs/concepts.md`
* Clarified that production agents may transform raw user input before routing
* Documented that ContextWeaver does not prescribe a query rewriting strategy
* Added MCP gateway integration note in `docs/integration_mcp.md`
