### PR TITLE
docs: add Contributor Covenant 2.1 Code of Conduct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1, linked from `CONTRIBUTING.md` (#249).
+
 ## [0.6.0] - 2026-05-17
 
 ### Fixed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at diogofcul@hotmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,3 +67,7 @@ All CI checks must pass before a PR can be merged.
 2. Export it from `src/contextweaver/store/__init__.py`.
 3. Add tests in `tests/test_store_<name>.py`.
 4. Update `StoreBundle` in `store/__init__.py` if appropriate.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold it.


### PR DESCRIPTION
## Summary

Adds the Contributor Covenant v2.1 verbatim as `CODE_OF_CONDUCT.md`, links it from the bottom of `CONTRIBUTING.md`, and notes the addition under `## [Unreleased] / ### Added` in `CHANGELOG.md`.

Fixes #249

## Why

GitHub's community-standards check has a slot for `CODE_OF_CONDUCT.md` and the repo already ships every other green-checkmark file (`CONTRIBUTING.md`, `SECURITY.md`, an issue-template directory, and a PR template). Without the code of conduct the project misses the green checkmark, and first-time contributors arriving at a v0.7 launch traffic spike look for that file as a trust signal before they decide to file an issue or open a pull request. The fix is governance-only, but the absence of the file is exactly the kind of thing that nudges a hesitant first-time contributor to bounce.

## Changes

The Covenant text was fetched verbatim from the canonical source at `EthicalSource/contributor_covenant` (`release/content/version/2/1/code_of_conduct.md`), the Hugo `+++` front matter was stripped, and the standard `[INSERT CONTACT METHOD]` reporting placeholder was replaced with `diogofcul@hotmail.com`, taken from the maintainer entry at `pyproject.toml:11` to match the issue's wording.

`CONTRIBUTING.md` gets a short `## Code of Conduct` section at the bottom linking to the new file, matching the issue's "Link from the bottom of CONTRIBUTING.md" requirement and keeping the contributor onboarding path discoverable.

`CHANGELOG.md` gets a one-line `Added` entry under `[Unreleased]` so the addition lands cleanly in the next release notes.

## Checklist

- [ ] Tests added or updated for every new/changed public function - N/A (docs only).
- [ ] `make ci` passes locally (fmt + lint + type + test + example + demo) - N/A (no source change).
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [ ] Docstrings added for all new public APIs (Google-style) - N/A.
- [x] Every modified module stays ≤ 300 lines (or a decomposition issue is linked above)
- [x] Related issue linked in the summary above
- [x] Agent-facing docs updated if pipeline, API, or conventions changed - N/A (governance only).

## Notes for reviewers

The Covenant text is unmodified except for the standard placeholder substitution; this is the form GitHub's community-standards check recognizes for the green checkmark. The issue references branch `launch/v0.7-mcp-context-gateway` which isn't on `upstream` yet, so this targets `main` per the repo's default; happy to retarget if the launch branch is preferred.

## Reproducibility (scoring / context-pipeline changes)

Not applicable. This PR touches only governance files (`CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `CHANGELOG.md`) and does not change routing, scoring, tokenisation, or the context pipeline. No benchmark matrix delta to report.
