### PR TITLE
[codex] fix(docs): refresh onboarding docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **README / Quickstart onboarding docs refresh** — fixes the README CLI
+  `route` example to include required `--catalog`, updates stale version and
+  extras tables for the 0.10.x line, documents default sensitivity drops in
+  the Quickstart, and explains the offline `tiktoken` fallback /
+  `TIKTOKEN_CACHE_DIR` workflow. Issues #307, #309, #310, #311, #312.
+
 ## [0.10.0] - 2026-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -137,21 +137,30 @@ pip install contextweaver
 ```
 
 `contextweaver` ships with a minimal, opinionated core: `tiktoken`,
-`PyYAML`, and `rank-bm25`. These power accurate token budgeting, YAML
-catalog/config files, and the default lexical retrieval backend.
+`PyYAML`, `rank-bm25`, `mcp`, `jsonschema`, Typer, and Rich. These power
+token budgeting, YAML catalog/config files, the default lexical retrieval
+backend, the MCP proxy/gateway runtime, schema validation, and the CLI.
 
 Optional capabilities are gated behind extras so the core install stays small:
 
 | Extra | What it adds |
 |---|---|
-| `contextweaver[cli]` | Rich-formatted CLI rendering (rich) |
-| `contextweaver[retrieval]` | Fuzzy lexical matching backend (rapidfuzz) |
+| `contextweaver[weaver-spec]` | Weaver Stack contract adapters (`weaver_contracts`) |
+| `contextweaver[fastmcp]` | FastMCP catalog adapter and discovery helpers |
+| `contextweaver[crewai]` | CrewAI runtime integration |
+| `contextweaver[langchain]` | LangChain integration helpers |
+| `contextweaver[voice]` | Pipecat voice-agent integration |
+| `contextweaver[retrieval]` | Fuzzy lexical matching backend (`rapidfuzz`) |
+| `contextweaver[embeddings]` | Sentence-transformers embedding backend |
+| `contextweaver[sqlite]` | SQLite store install contract (stdlib-backed today) |
+| `contextweaver[mem0]` | Mem0 external-memory backend |
 | `contextweaver[otel]` | OpenTelemetry tracing + metrics export |
+| `contextweaver[e2e-eval]` | Optional real-model benchmark hook (no dependency today) |
+| `contextweaver[docs]` | MkDocs documentation toolchain |
+| `contextweaver[dev]` | Test, lint, type-check, and fixture toolchain |
 | `contextweaver[ann]` | Approximate-nearest-neighbour backend (reserved) |
 | `contextweaver[graph]` | NetworkX-backed graph ops (reserved) |
-| `contextweaver[fastmcp]` | FastMCP catalog adapter |
-| `contextweaver[langchain]` | LangChain integration helpers |
-| `contextweaver[all]` | All optional capabilities |
+| `contextweaver[all]` | Convenience bundle for broad optional runtime capabilities |
 
 Or from source:
 
@@ -263,6 +272,7 @@ Looking for "where does contextweaver fit alongside my runtime?" — start with 
 | Concept | Description |
 |---|---|
 | `ContextItem` | Atomic event log entry: user turn, agent message, tool call, tool result, fact, plan state. |
+| `Sensitivity` | `ContextItem.sensitivity` defaults to `public`; the default policy drops `confidential` and `restricted` items before they reach the prompt. |
 | `Phase` | `route` / `call` / `interpret` / `answer` — each with its own token budget. |
 | `ContextFirewall` | Intercepts tool results: stores raw bytes out-of-band, injects compact summary (with truncation for large outputs). |
 | `ChoiceGraph` | Bounded DAG over the tool catalog. Router beam-searches it; LLM sees only a focused shortlist. |
@@ -400,10 +410,9 @@ contextweaver follows [Semantic Versioning](https://semver.org/):
 
 | Version | Status | Notes |
 |---|---|---|
-| **0.1.x** | ✅ Current | Foundation engines (context + routing), MCP/A2A adapters, CLI, sensitivity |
-| **0.2.0** | 🚧 In progress (Q2 2026) | Framework integration guides, benchmark suite, distributed stores |
-| **0.3.0** | 📋 Planned (Q3 2026) | DAG visualization, merge compression, LLM-assisted labeler |
-| **1.0.0** | 📋 Planned (Q4 2026) | API freeze, production benchmarks, enterprise features |
+| **0.1.x – 0.9.x** | Shipped | Foundation engines, benchmark scorecards, integration guides, MCP gateway/proxy runtime, provider adapters, persistent stores, reference architectures |
+| **0.10.x** | Current | Experimental `contextweaver mcp serve`, schema hydration helpers, full MCP Context Gateway demos, context-build explanations, launch fixtures |
+| **1.0.0** | Planned | API freeze and long-term compatibility commitments after the 0.x launch-polish line |
 
 > Adopting a library is a long-term commitment. contextweaver's versioning policy ensures you
 > can upgrade safely, and the roadmap shows where it's headed.
@@ -443,32 +452,19 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 
 ### 6. Roadmap & Community
 
-**v0.1 (✅ Complete)**
+**Current release train**
 
-- Context Engine: 8-stage pipeline (candidates → closure → sensitivity → firewall → score → dedup → select → render)
-- Routing Engine: Catalog, DAG builder, beam-search router, choice cards
-- Protocol adapters: MCP (full content types, structured content, output schemas) and A2A
-- Stores: `EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore` with protocol-based interfaces
-- 1100+ passing tests, mypy strict, ruff clean, minimal core dependencies
-
-**v0.2 (🚧 In Progress — Q2 2026)**
-
-- Framework integration guides: LlamaIndex, LangChain, LangGraph, OpenAI Agents SDK, Google ADK, Pipecat
-- Benchmark suite: token reduction, latency, and accuracy vs. naive concatenation
-- Distributed stores: Redis-backed `EventLog`, S3-backed `ArtifactStore`
-
-**v0.3 (📋 Planned — Q3 2026)**
-
-- DAG visualization: interactive routing graph inspector
-- Merge compression: deduplicate similar tool results across turns
-- LLM-based labeler: auto-generate namespace labels for tool catalogs
-- LLM-based extractor: structured fact extraction with prompt-based schema
-
-**v1.0 (📋 Planned — Q4 2026)**
-
-- API freeze: no breaking changes in 1.x releases
-- Production benchmarks: 1M+ turn deployments
-- Enterprise features: audit logging, compliance tags, PII redaction
+- **v0.1–v0.4 shipped the core platform:** context and routing engines,
+  deterministic scorecards, framework integration guides, MCP gateway/proxy
+  runtime, weaver-spec interop, and schema drift gates.
+- **v0.5–v0.8 expanded adopter surfaces:** persistent stores, build/report
+  explanations, Typer + Rich CLI, OTel, provider-message adapters, explicit
+  routing pipeline, reference architectures, CrewAI, and Mem0.
+- **v0.9–v0.10 are the launch-polish line:** budget checks, real/recorded MCP
+  gateway demos, `contextweaver mcp serve`, schema hydration helpers,
+  sensitivity fixtures, and golden prompt/ingestion fixtures.
+- **v1.0 remains the API-stability milestone:** the goal is a frozen public
+  surface and long-term compatibility commitments after the current 0.x line.
 
 **Community:**
 
@@ -476,8 +472,9 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 - [GitHub Issues](https://github.com/dgenio/contextweaver/issues) — report bugs, request features
 - [CHANGELOG](CHANGELOG.md) — track every release
 
-> contextweaver is under active development with a clear roadmap. v0.1 is feature-complete
-> for basic use cases; v0.2 adds production-ready integrations; v1.0 is the API stability milestone.
+> contextweaver is under active development with a clear roadmap. The current
+> 0.10.x line is focused on launch polish and gateway ergonomics; v1.0 is the
+> API stability milestone.
 
 ### Comparison
 
@@ -487,7 +484,7 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 
 | Approach | Tool routing | History compaction | Sensitivity firewall | Deterministic | MCP-native |
 |---|---|---|---|---|---|
-| **contextweaver** (this repo, [v0.9.0](https://pypi.org/project/contextweaver/0.9.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42–75 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
+| **contextweaver** (this repo, [v0.10.0](https://pypi.org/project/contextweaver/0.10.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42–75 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
 | **Naïve concat-everything** | ❌ No router · prompt carries every tool schema | ❌ No compaction · prompt grows with turn count | ❌ Raw outputs in the prompt | ⚠️ Only if the upstream LLM is | ⚠️ Compatible but no shaping |
 | **LangGraph memory** ([0.6.x](https://github.com/langchain-ai/langgraph/releases)) | ❌ Out of scope — LangGraph routes state, not tools | ⚠️ Optional via `ConversationSummaryMemory` (LLM-based, non-deterministic) [^lg-mem] | ❌ Not provided | ⚠️ Workflow yes; memory summarizer no | ⚠️ Possible via custom adapter, not first-class |
 | **LlamaIndex retrievers** ([0.11.x](https://github.com/run-llama/llama_index/releases)) | ⚠️ Tool retrieval via `ObjectIndex` is unranked similarity, no bounded routing | ⚠️ `ChatMemoryBuffer` token-bounded · no phase awareness [^li-mem] | ❌ Not provided · large outputs flow through verbatim | ⚠️ Retriever yes; summarizer no | ⚠️ Possible via custom tool wrapper |
@@ -515,7 +512,7 @@ contextweaver ships with a CLI for quick experimentation:
 contextweaver demo                                    # end-to-end demonstration
 contextweaver init                                    # scaffold config + sample catalog
 contextweaver build --catalog c.json --out g.json    # build routing graph
-contextweaver route --graph g.json --query "send email"
+contextweaver route --graph g.json --catalog c.json --query "send email"
 contextweaver print-tree --graph g.json
 contextweaver ingest --events session.jsonl --out session.json
 contextweaver replay --session session.json --phase answer
@@ -576,7 +573,10 @@ is the canonical starting point.
 Typically 10–50 ms for a context build (depends on event log size and deduplication).
 For real-time / async agents, run `build_sync()` in a worker thread (e.g.
 `await asyncio.to_thread(mgr.build_sync, phase, query)`) so the synchronous
-pipeline does not block the event loop.
+pipeline does not block the event loop. If an offline or air-gapped run prints a
+`tiktoken cl100k_base encoding unavailable` warning, see the
+[troubleshooting note](docs/troubleshooting.md#offline-air-gapped-tiktoken-warning);
+the fallback keeps budget enforcement deterministic.
 
 See [docs/troubleshooting.md](docs/troubleshooting.md) for the full troubleshooting
 guide, debugging techniques, optimisation tips, and 10+ common issues with solutions.
@@ -611,7 +611,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions.
 | **v0.6 — Adopter surface** (2026-05-17) | ✅ complete | Typer + Rich CLI rewrite, OTel GenAI semconv, provider message adapters (OpenAI / Anthropic / Gemini), 5-line adoption snippet |
 | **v0.7 — Reference architectures + routing pipeline** (2026-05-18) | ✅ complete | Explicit routing pipeline, embedding backend, history-aware routing, code-review bot + voice agent architectures, FastMCP CodeMode hooks |
 | **v0.8 — CrewAI + Mem0** (2026-05-19) | ✅ complete | CrewAI adapter (Phase 1), Mem0 external-memory backend, provider-SDK-leak invariant tests |
-| **v0.9 — Launch polish + adapters** (2026-05) | 🚧 in progress | `contextweaver mcp serve` CLI, full MCP Context Gateway architecture, CrewAI/Pydantic AI/smolagents/Agno adapter Phase 2 |
+| **v0.9 — Launch polish + adapters** (2026-05-20) | ✅ complete | Budget checks, provider adapters, benchmark transparency suite, launch polish |
+| **v0.10 — MCP serve + gateway polish** (2026-05-22) | ✅ current | `contextweaver mcp serve`, schema hydration helpers, full MCP Context Gateway demos, context-build explanations |
 | **v1.0 — API stability** | 📋 planned | API freeze, semantic-versioning commitment, long-term support window |
 | **Future** | 📋 planned | DAG visualization, LLM-assisted labeler, distributed stores, multi-agent coordination |
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ Optional capabilities are gated behind extras so the core install stays small:
 | `contextweaver[weaver-spec]` | Weaver Stack contract adapters (`weaver_contracts`) |
 | `contextweaver[fastmcp]` | FastMCP catalog adapter and discovery helpers |
 | `contextweaver[crewai]` | CrewAI runtime integration |
+| `contextweaver[pydantic-ai]` | Pydantic AI runtime integration |
+| `contextweaver[smolagents]` | Hugging Face smolagents runtime integration |
+| `contextweaver[agno]` | Agno runtime integration |
 | `contextweaver[langchain]` | LangChain integration helpers |
 | `contextweaver[voice]` | Pipecat voice-agent integration |
 | `contextweaver[retrieval]` | Fuzzy lexical matching backend (`rapidfuzz`) |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -132,8 +132,10 @@ Three options, in order of effort:
 - **Token estimator is `CharDivFourEstimator`** in the benchmark, not
   real `tiktoken.cl100k_base`. Production paths can pass a real
   `tiktoken` estimator; the benchmark uses chars-÷-4 to stay
-  network-independent. Parity check is tracked under
-  [issue #268](https://github.com/dgenio/contextweaver/issues/268).
+  network-independent. The scorecard includes a token-estimator parity
+  section when `cl100k_base` is available, and the
+  [troubleshooting guide](troubleshooting.md#offline-air-gapped-tiktoken-warning)
+  explains the offline fallback warning.
 
 ## See also
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -130,6 +130,15 @@ If you are working from a repository checkout instead, install the package in ed
 pip install -e ".[dev]"
 ```
 
+If your network blocks `openaipublic.blob.core.windows.net`, the demo or
+token-budget helpers may print `tiktoken cl100k_base encoding unavailable`.
+That warning is harmless: contextweaver falls back to the deterministic
+chars/4 estimator and keeps enforcing budgets. To suppress it while keeping
+exact `tiktoken` counts, pre-warm a `TIKTOKEN_CACHE_DIR` on a connected
+machine and copy that cache into the offline environment; the
+[troubleshooting guide](troubleshooting.md#offline-air-gapped-tiktoken-warning)
+has the full workflow.
+
 ## 3. Your First Context Build (3 minutes)
 
 Scenario: an agent receives a question, decides to query a database, and builds
@@ -201,6 +210,47 @@ What just happened:
 - You ingested four events into the event log.
 - `build_sync()` ran the context pipeline for the `answer` phase.
 - The prompt was compiled from the most relevant items and returned with build stats.
+
+### Sensitivity & Default Drops
+
+Every `ContextItem` has a `sensitivity` level. It defaults to `public`, and
+the default policy is conservative: items at or above
+`Sensitivity.confidential` are dropped before scoring and rendering.
+
+```python
+from contextweaver.config import ContextPolicy
+from contextweaver.context.manager import ContextManager
+from contextweaver.types import ContextItem, ItemKind, Phase, Sensitivity
+
+mgr = ContextManager()
+mgr.ingest(ContextItem(id="u1", kind=ItemKind.user_turn, text="public"))
+mgr.ingest(
+    ContextItem(
+        id="c1",
+        kind=ItemKind.user_turn,
+        text="confidential",
+        sensitivity=Sensitivity.confidential,
+    )
+)
+
+pack = mgr.build_sync(phase=Phase.answer, query="any")
+print(pack.stats.dropped_reasons.get("sensitivity", 0))  # 1
+```
+
+If you want to keep `confidential` items but still drop `restricted` items,
+raise the floor:
+
+```python
+policy = ContextPolicy(sensitivity_floor=Sensitivity.restricted)
+mgr = ContextManager(policy=policy)
+```
+
+If you want sensitive items to remain visible only as masks, use redact mode:
+
+```python
+policy = ContextPolicy(sensitivity_action="redact")
+mgr = ContextManager(policy=policy)
+```
 
 ## 4. Try the Context Firewall (4 minutes)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -334,6 +334,41 @@ total_estimated_tokens = (
 mgr = ContextManager(token_estimator=TiktokenEstimator(model="gpt-4"))
 ```
 
+#### Offline / Air-gapped Tiktoken Warning
+
+**Symptom:**
+```text
+tiktoken cl100k_base encoding unavailable (...); falling back to chars/4 token estimate
+```
+
+**Cause:** `tiktoken` is installed, but it downloads encoding data on first use.
+Sandboxes, corporate networks, and CI containers that block
+`openaipublic.blob.core.windows.net` cannot fetch `cl100k_base` on demand.
+contextweaver then falls back to `CharDivFourEstimator`, which preserves
+deterministic budget enforcement but is less exact than the real encoding.
+
+**Solution — pre-warm a cache on a connected machine, then copy it:**
+
+PowerShell:
+```powershell
+$env:TIKTOKEN_CACHE_DIR = "C:\path\to\tiktoken-cache"
+python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
+```
+
+Bash:
+```bash
+export TIKTOKEN_CACHE_DIR=/path/to/tiktoken-cache
+python -c "import tiktoken; tiktoken.get_encoding('cl100k_base')"
+```
+
+Copy that cache directory into the offline environment and set
+`TIKTOKEN_CACHE_DIR` to the copied path before running contextweaver.
+
+If exact `tiktoken` parity is not required, no action is needed. The committed
+scorecard's headline context metrics intentionally use `CharDivFourEstimator`
+for network-independent reproducibility; the separate token-estimator parity
+section reports or skips `cl100k_base` drift depending on cache availability.
+
 **CI regression check:** after serialising a session with `contextweaver ingest`,
 pin a ceiling with `budget-check` so prompt-size regressions fail before they
 reach production:

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -208,6 +208,9 @@ Optional capabilities are gated behind extras so the core install stays small:
 | `contextweaver[weaver-spec]` | Weaver Stack contract adapters (`weaver_contracts`) |
 | `contextweaver[fastmcp]` | FastMCP catalog adapter and discovery helpers |
 | `contextweaver[crewai]` | CrewAI runtime integration |
+| `contextweaver[pydantic-ai]` | Pydantic AI runtime integration |
+| `contextweaver[smolagents]` | Hugging Face smolagents runtime integration |
+| `contextweaver[agno]` | Agno runtime integration |
 | `contextweaver[langchain]` | LangChain integration helpers |
 | `contextweaver[voice]` | Pipecat voice-agent integration |
 | `contextweaver[retrieval]` | Fuzzy lexical matching backend (`rapidfuzz`) |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -165,21 +165,30 @@ pip install contextweaver
 ```
 
 `contextweaver` ships with a minimal, opinionated core: `tiktoken`,
-`PyYAML`, and `rank-bm25`. These power accurate token budgeting, YAML
-catalog/config files, and the default lexical retrieval backend.
+`PyYAML`, `rank-bm25`, `mcp`, `jsonschema`, Typer, and Rich. These power
+token budgeting, YAML catalog/config files, the default lexical retrieval
+backend, the MCP proxy/gateway runtime, schema validation, and the CLI.
 
 Optional capabilities are gated behind extras so the core install stays small:
 
 | Extra | What it adds |
 |---|---|
-| `contextweaver[cli]` | Rich-formatted CLI rendering (rich) |
-| `contextweaver[retrieval]` | Fuzzy lexical matching backend (rapidfuzz) |
+| `contextweaver[weaver-spec]` | Weaver Stack contract adapters (`weaver_contracts`) |
+| `contextweaver[fastmcp]` | FastMCP catalog adapter and discovery helpers |
+| `contextweaver[crewai]` | CrewAI runtime integration |
+| `contextweaver[langchain]` | LangChain integration helpers |
+| `contextweaver[voice]` | Pipecat voice-agent integration |
+| `contextweaver[retrieval]` | Fuzzy lexical matching backend (`rapidfuzz`) |
+| `contextweaver[embeddings]` | Sentence-transformers embedding backend |
+| `contextweaver[sqlite]` | SQLite store install contract (stdlib-backed today) |
+| `contextweaver[mem0]` | Mem0 external-memory backend |
 | `contextweaver[otel]` | OpenTelemetry tracing + metrics export |
+| `contextweaver[e2e-eval]` | Optional real-model benchmark hook (no dependency today) |
+| `contextweaver[docs]` | MkDocs documentation toolchain |
+| `contextweaver[dev]` | Test, lint, type-check, and fixture toolchain |
 | `contextweaver[ann]` | Approximate-nearest-neighbour backend (reserved) |
 | `contextweaver[graph]` | NetworkX-backed graph ops (reserved) |
-| `contextweaver[fastmcp]` | FastMCP catalog adapter |
-| `contextweaver[langchain]` | LangChain integration helpers |
-| `contextweaver[all]` | All optional capabilities |
+| `contextweaver[all]` | Convenience bundle for broad optional runtime capabilities |
 
 Or from source:
 
@@ -291,6 +300,7 @@ Looking for "where does contextweaver fit alongside my runtime?" — start with 
 | Concept | Description |
 |---|---|
 | `ContextItem` | Atomic event log entry: user turn, agent message, tool call, tool result, fact, plan state. |
+| `Sensitivity` | `ContextItem.sensitivity` defaults to `public`; the default policy drops `confidential` and `restricted` items before they reach the prompt. |
 | `Phase` | `route` / `call` / `interpret` / `answer` — each with its own token budget. |
 | `ContextFirewall` | Intercepts tool results: stores raw bytes out-of-band, injects compact summary (with truncation for large outputs). |
 | `ChoiceGraph` | Bounded DAG over the tool catalog. Router beam-searches it; LLM sees only a focused shortlist. |
@@ -428,10 +438,9 @@ contextweaver follows [Semantic Versioning](https://semver.org/):
 
 | Version | Status | Notes |
 |---|---|---|
-| **0.1.x** | ✅ Current | Foundation engines (context + routing), MCP/A2A adapters, CLI, sensitivity |
-| **0.2.0** | 🚧 In progress (Q2 2026) | Framework integration guides, benchmark suite, distributed stores |
-| **0.3.0** | 📋 Planned (Q3 2026) | DAG visualization, merge compression, LLM-assisted labeler |
-| **1.0.0** | 📋 Planned (Q4 2026) | API freeze, production benchmarks, enterprise features |
+| **0.1.x – 0.9.x** | Shipped | Foundation engines, benchmark scorecards, integration guides, MCP gateway/proxy runtime, provider adapters, persistent stores, reference architectures |
+| **0.10.x** | Current | Experimental `contextweaver mcp serve`, schema hydration helpers, full MCP Context Gateway demos, context-build explanations, launch fixtures |
+| **1.0.0** | Planned | API freeze and long-term compatibility commitments after the 0.x launch-polish line |
 
 > Adopting a library is a long-term commitment. contextweaver's versioning policy ensures you
 > can upgrade safely, and the roadmap shows where it's headed.
@@ -471,32 +480,19 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 
 ### 6. Roadmap & Community
 
-**v0.1 (✅ Complete)**
+**Current release train**
 
-- Context Engine: 8-stage pipeline (candidates → closure → sensitivity → firewall → score → dedup → select → render)
-- Routing Engine: Catalog, DAG builder, beam-search router, choice cards
-- Protocol adapters: MCP (full content types, structured content, output schemas) and A2A
-- Stores: `EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore` with protocol-based interfaces
-- 1100+ passing tests, mypy strict, ruff clean, minimal core dependencies
-
-**v0.2 (🚧 In Progress — Q2 2026)**
-
-- Framework integration guides: LlamaIndex, LangChain, LangGraph, OpenAI Agents SDK, Google ADK, Pipecat
-- Benchmark suite: token reduction, latency, and accuracy vs. naive concatenation
-- Distributed stores: Redis-backed `EventLog`, S3-backed `ArtifactStore`
-
-**v0.3 (📋 Planned — Q3 2026)**
-
-- DAG visualization: interactive routing graph inspector
-- Merge compression: deduplicate similar tool results across turns
-- LLM-based labeler: auto-generate namespace labels for tool catalogs
-- LLM-based extractor: structured fact extraction with prompt-based schema
-
-**v1.0 (📋 Planned — Q4 2026)**
-
-- API freeze: no breaking changes in 1.x releases
-- Production benchmarks: 1M+ turn deployments
-- Enterprise features: audit logging, compliance tags, PII redaction
+- **v0.1–v0.4 shipped the core platform:** context and routing engines,
+  deterministic scorecards, framework integration guides, MCP gateway/proxy
+  runtime, weaver-spec interop, and schema drift gates.
+- **v0.5–v0.8 expanded adopter surfaces:** persistent stores, build/report
+  explanations, Typer + Rich CLI, OTel, provider-message adapters, explicit
+  routing pipeline, reference architectures, CrewAI, and Mem0.
+- **v0.9–v0.10 are the launch-polish line:** budget checks, real/recorded MCP
+  gateway demos, `contextweaver mcp serve`, schema hydration helpers,
+  sensitivity fixtures, and golden prompt/ingestion fixtures.
+- **v1.0 remains the API-stability milestone:** the goal is a frozen public
+  surface and long-term compatibility commitments after the current 0.x line.
 
 **Community:**
 
@@ -504,8 +500,9 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 - [GitHub Issues](https://github.com/dgenio/contextweaver/issues) — report bugs, request features
 - [CHANGELOG](CHANGELOG.md) — track every release
 
-> contextweaver is under active development with a clear roadmap. v0.1 is feature-complete
-> for basic use cases; v0.2 adds production-ready integrations; v1.0 is the API stability milestone.
+> contextweaver is under active development with a clear roadmap. The current
+> 0.10.x line is focused on launch polish and gateway ergonomics; v1.0 is the
+> API stability milestone.
 
 ### Comparison
 
@@ -515,7 +512,7 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 
 | Approach | Tool routing | History compaction | Sensitivity firewall | Deterministic | MCP-native |
 |---|---|---|---|---|---|
-| **contextweaver** (this repo, [v0.9.0](https://pypi.org/project/contextweaver/0.9.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42–75 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
+| **contextweaver** (this repo, [v0.10.0](https://pypi.org/project/contextweaver/0.10.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42–75 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
 | **Naïve concat-everything** | ❌ No router · prompt carries every tool schema | ❌ No compaction · prompt grows with turn count | ❌ Raw outputs in the prompt | ⚠️ Only if the upstream LLM is | ⚠️ Compatible but no shaping |
 | **LangGraph memory** ([0.6.x](https://github.com/langchain-ai/langgraph/releases)) | ❌ Out of scope — LangGraph routes state, not tools | ⚠️ Optional via `ConversationSummaryMemory` (LLM-based, non-deterministic) [^lg-mem] | ❌ Not provided | ⚠️ Workflow yes; memory summarizer no | ⚠️ Possible via custom adapter, not first-class |
 | **LlamaIndex retrievers** ([0.11.x](https://github.com/run-llama/llama_index/releases)) | ⚠️ Tool retrieval via `ObjectIndex` is unranked similarity, no bounded routing | ⚠️ `ChatMemoryBuffer` token-bounded · no phase awareness [^li-mem] | ❌ Not provided · large outputs flow through verbatim | ⚠️ Retriever yes; summarizer no | ⚠️ Possible via custom tool wrapper |
@@ -543,7 +540,7 @@ contextweaver ships with a CLI for quick experimentation:
 contextweaver demo                                    # end-to-end demonstration
 contextweaver init                                    # scaffold config + sample catalog
 contextweaver build --catalog c.json --out g.json    # build routing graph
-contextweaver route --graph g.json --query "send email"
+contextweaver route --graph g.json --catalog c.json --query "send email"
 contextweaver print-tree --graph g.json
 contextweaver ingest --events session.jsonl --out session.json
 contextweaver replay --session session.json --phase answer
@@ -604,7 +601,10 @@ is the canonical starting point.
 Typically 10–50 ms for a context build (depends on event log size and deduplication).
 For real-time / async agents, run `build_sync()` in a worker thread (e.g.
 `await asyncio.to_thread(mgr.build_sync, phase, query)`) so the synchronous
-pipeline does not block the event loop.
+pipeline does not block the event loop. If an offline or air-gapped run prints a
+`tiktoken cl100k_base encoding unavailable` warning, see the
+[troubleshooting note](docs/troubleshooting.md#offline-air-gapped-tiktoken-warning);
+the fallback keeps budget enforcement deterministic.
 
 See [docs/troubleshooting.md](docs/troubleshooting.md) for the full troubleshooting
 guide, debugging techniques, optimisation tips, and 10+ common issues with solutions.
@@ -639,7 +639,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions.
 | **v0.6 — Adopter surface** (2026-05-17) | ✅ complete | Typer + Rich CLI rewrite, OTel GenAI semconv, provider message adapters (OpenAI / Anthropic / Gemini), 5-line adoption snippet |
 | **v0.7 — Reference architectures + routing pipeline** (2026-05-18) | ✅ complete | Explicit routing pipeline, embedding backend, history-aware routing, code-review bot + voice agent architectures, FastMCP CodeMode hooks |
 | **v0.8 — CrewAI + Mem0** (2026-05-19) | ✅ complete | CrewAI adapter (Phase 1), Mem0 external-memory backend, provider-SDK-leak invariant tests |
-| **v0.9 — Launch polish + adapters** (2026-05) | 🚧 in progress | `contextweaver mcp serve` CLI, full MCP Context Gateway architecture, CrewAI/Pydantic AI/smolagents/Agno adapter Phase 2 |
+| **v0.9 — Launch polish + adapters** (2026-05-20) | ✅ complete | Budget checks, provider adapters, benchmark transparency suite, launch polish |
+| **v0.10 — MCP serve + gateway polish** (2026-05-22) | ✅ current | `contextweaver mcp serve`, schema hydration helpers, full MCP Context Gateway demos, context-build explanations |
 | **v1.0 — API stability** | 📋 planned | API freeze, semantic-versioning commitment, long-term support window |
 | **Future** | 📋 planned | DAG visualization, LLM-assisted labeler, distributed stores, multi-agent coordination |
 
@@ -1080,6 +1081,15 @@ If you are working from a repository checkout instead, install the package in ed
 pip install -e ".[dev]"
 ```
 
+If your network blocks `openaipublic.blob.core.windows.net`, the demo or
+token-budget helpers may print `tiktoken cl100k_base encoding unavailable`.
+That warning is harmless: contextweaver falls back to the deterministic
+chars/4 estimator and keeps enforcing budgets. To suppress it while keeping
+exact `tiktoken` counts, pre-warm a `TIKTOKEN_CACHE_DIR` on a connected
+machine and copy that cache into the offline environment; the
+[troubleshooting guide](troubleshooting.md#offline-air-gapped-tiktoken-warning)
+has the full workflow.
+
 ## 3. Your First Context Build (3 minutes)
 
 Scenario: an agent receives a question, decides to query a database, and builds
@@ -1151,6 +1161,47 @@ What just happened:
 - You ingested four events into the event log.
 - `build_sync()` ran the context pipeline for the `answer` phase.
 - The prompt was compiled from the most relevant items and returned with build stats.
+
+### Sensitivity & Default Drops
+
+Every `ContextItem` has a `sensitivity` level. It defaults to `public`, and
+the default policy is conservative: items at or above
+`Sensitivity.confidential` are dropped before scoring and rendering.
+
+```python
+from contextweaver.config import ContextPolicy
+from contextweaver.context.manager import ContextManager
+from contextweaver.types import ContextItem, ItemKind, Phase, Sensitivity
+
+mgr = ContextManager()
+mgr.ingest(ContextItem(id="u1", kind=ItemKind.user_turn, text="public"))
+mgr.ingest(
+    ContextItem(
+        id="c1",
+        kind=ItemKind.user_turn,
+        text="confidential",
+        sensitivity=Sensitivity.confidential,
+    )
+)
+
+pack = mgr.build_sync(phase=Phase.answer, query="any")
+print(pack.stats.dropped_reasons.get("sensitivity", 0))  # 1
+```
+
+If you want to keep `confidential` items but still drop `restricted` items,
+raise the floor:
+
+```python
+policy = ContextPolicy(sensitivity_floor=Sensitivity.restricted)
+mgr = ContextManager(policy=policy)
+```
+
+If you want sensitive items to remain visible only as masks, use redact mode:
+
+```python
+policy = ContextPolicy(sensitivity_action="redact")
+mgr = ContextManager(policy=policy)
+```
 
 ## 4. Try the Context Firewall (4 minutes)
 


### PR DESCRIPTION
## Summary

Refresh the newcomer-facing onboarding docs so the first copied commands, install guidance, version status, sensitivity defaults, and offline token-estimator guidance match the current 0.10.x repository state. The goal is to remove first-run trust breakers without changing runtime behavior, public APIs, sensitivity defaults, or token-estimator fallback behavior.

Fixes #307
Fixes #309
Fixes #310
Fixes #311
Fixes #312

## Changes

- `README.md` — fixes the CLI `route` example by adding required `--catalog`, updates core dependency wording, refreshes version/roadmap/comparison rows for 0.10.x, and makes the optional-extras table match the functional extras in `pyproject.toml`.
- `docs/quickstart.md` — adds the harmless offline `tiktoken` fallback note and a sensitivity-defaults walkthrough covering `dropped_reasons`, `sensitivity_floor`, and `sensitivity_action="redact"`.
- `docs/troubleshooting.md` and `docs/faq.md` — explain the `TIKTOKEN_CACHE_DIR` pre-warm workflow and cross-link the offline fallback guidance.
- `CHANGELOG.md` — records the onboarding docs fix under `## [Unreleased]`.
- `llms-full.txt` — regenerated from canonical docs so the AI-facing bundle mirrors the README and Quickstart updates.

## Checklist

- [x] N/A — Tests added or updated for every new/changed public function (docs-only; no public functions changed)
- [x] `make ci` equivalent / hosted CI passes (GNU make is unavailable in this Windows shell; see verification below)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] N/A — Docstrings added for all new public APIs (docs-only; no public APIs changed)
- [x] N/A — Every modified module stays ≤ 300 lines (no Python modules modified)
- [x] Related issue linked in the summary above
- [x] N/A — Agent-facing docs updated if pipeline, API, or conventions changed (no pipeline/API/convention change)

## Notes for reviewers

- The optional-extras table is now aligned with the current functional extras in `pyproject.toml`, including Pydantic AI, smolagents, Agno, CrewAI, FastMCP, Weaver Stack contracts, voice, memory, retrieval, embeddings, docs, and dev tooling.
- Sensitivity behavior is documentation-only: the default floor remains `confidential`, and the default action remains `drop`.
- The offline `tiktoken` docs describe the existing fallback path and cache workflow; no estimator logic changed.
- `llms-full.txt` accounts for most of the generated diff and is kept in sync by `scripts/gen_llms.py --check`.
- Scope is limited to docs/onboarding cleanup for #307, #309, #310, #311, and #312.

Verification:

- `.\\.venv\\Scripts\\python.exe scripts\\gen_llms.py --check` — `llms.txt` and `llms-full.txt` are up to date
- `git diff --check` — passed
- `.\\.venv\\Scripts\\python.exe -m mkdocs build --clean` — documentation built successfully; existing unrelated link warnings remain
- GitHub Actions CI run 405 — success for Python 3.10, 3.11, and 3.12, including format, lint, type check, tests, examples, demo, scorecard drift check, schema drift check, weaver-spec conformance, benchmark, and benchmark delta comment update

## Reproducibility (scoring / context-pipeline changes)

N/A — this PR does not touch routing, scoring, tokenisation, or context-pipeline behavior. The benchmark delta is green across accuracy markers and context-pipeline scenarios.