### PR TITLE
docs: sharpen adopter positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Adopter positioning docs** — new adopter-facing benchmark report,
+  ecosystem comparison map, stability / Beta / 1.0 readiness checklist, and
+  launch kit for reusable public copy and asset links. Issues #323, #324,
+  #327, #328, #329.
+
+### Changed
+
+- **README / docs / PyPI positioning** — sharpened the first-screen category
+  around "context firewall + tool router for MCP and tool-heavy agents", added
+  quick use-fit framing, and aligned package/site descriptions with the same
+  wording. Issue #321.
+
 ## [0.10.0] - 2026-05-22
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,6 +218,10 @@ the most useful first reads (in order) are:
 3. `AGENTS.md` Module Map (around line 18).
 4. `docs/architecture.md` — pipeline detail.
 
+If you are writing about contextweaver publicly, use
+[`docs/launch_kit.md`](docs/launch_kit.md) for reusable copy, asset links,
+and responsible-claims guardrails.
+
 **Good first tasks for an agent on launch day:**
 
 - Pick up a [`good first issue`](https://github.com/dgenio/contextweaver/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)

--- a/README.md
+++ b/README.md
@@ -7,11 +7,24 @@
 [![Docs](https://img.shields.io/badge/docs-mkdocs--material-blue.svg)](https://dgenio.github.io/contextweaver)
 [![GitHub Discussions](https://img.shields.io/github/discussions/dgenio/contextweaver)](https://github.com/dgenio/contextweaver/discussions)
 
-> **Context firewall + tool router for tool-heavy AI agents.** Phase-specific,
-> budget-aware **context engineering** with a deterministic core — large tool
-> outputs stay out of the prompt, large catalogs collapse to a few
-> `ChoiceCard`s, and your token bill drops 42–75 % on the committed
-> benchmarks.
+> **Context firewall + tool router for MCP and tool-heavy agents.** Keep huge
+> tool catalogs, tool schemas, tool results, and long histories out of the
+> prompt without losing the context your agent needs. Phase-specific,
+> budget-aware **context engineering** with a deterministic core: large
+> catalogs collapse to a few `ChoiceCard`s, large outputs stay artifact-backed,
+> and prompt tokens drop 42-84 % on the committed benchmarks.
+
+| If your agent has... | contextweaver gives you... |
+|---|---|
+| Too many MCP / FastMCP / Python tools | A bounded `ChoiceCard` shortlist instead of dumping every schema into the route prompt. |
+| Huge JSON, logs, tables, or binary tool results | An artifact-backed context firewall: compact summary in the prompt, raw bytes out of band. |
+| Long tool-using conversations | Phase-specific context packs with budgeted selection and dependency closure. |
+
+| Use this when... | Do not use this when... |
+|---|---|
+| You already have an agent loop and need runtime context control. | You need an agent framework, LLM SDK, or tool executor. |
+| Your model-visible tool list or tool-result payloads are getting too large. | Your agent has a handful of tiny tools and no context-budget pressure. |
+| You want deterministic prompt budgeting and traceable drops. | You only need long-term memory, RAG, or observability by itself. |
 
 <p align="center">
   <img src="docs/assets/hero.svg" alt="contextweaver architecture: Context Engine plus Routing Engine, with the Context Firewall storing large tool outputs out of band and the Routing Engine narrowing a 100-tool catalog to 5 ChoiceCards."/>
@@ -32,7 +45,7 @@ python -m contextweaver demo     # 5-step end-to-end demo
   <img src="docs/assets/before_after.svg" alt="Before vs after token comparison from examples/before_after.py: 417 raw prompt tokens without contextweaver vs 126 final prompt tokens with contextweaver — a 70 percent reduction, 291 tokens saved, budget compliant."/>
 </p>
 
-[📖 Documentation](https://dgenio.github.io/contextweaver) · [🧭 Which pattern fits my use case?](docs/which_pattern.md) · [📊 Benchmark scorecard](benchmarks/scorecard.md) · [🎬 Replay demo (.cast)](docs/assets/demo.cast)
+[📖 Documentation](https://dgenio.github.io/contextweaver) · [🧭 Which pattern fits my use case?](docs/which_pattern.md) · [📊 Adopter benchmark report](docs/benchmark_report.md) · [🗺️ Ecosystem map](docs/ecosystem.md) · [🎬 Replay demo (.cast)](docs/assets/demo.cast)
 
 ---
 
@@ -73,12 +86,12 @@ Agent hallucinates tool calls, repeats questions, forgets context
 Route phase:  5 tool cards (≈500 tokens), no full schemas
 Answer phase: 3 relevant turns + dependency closure (≈2k tokens)
 Result:       2.5k tokens, complete context, deterministic
-Cost:         41.6%–74.5% fewer prompt tokens [^naive-baseline]  ·  Latency: sub-second  ·  Quality: relevant context only
+Cost:         41.6 %-84.3 % fewer prompt tokens [^naive-baseline]  ·  Latency: sub-second  ·  Quality: relevant context only
 ```
 
 [^naive-baseline]: Measured against the "concatenate all tool schemas + full
-    conversation history" baseline using `tiktoken.cl100k_base` on the four
-    committed benchmark scenarios. Range 41.6 %–74.5 %, average 55.8 %.
+    conversation history" baseline using `tiktoken.cl100k_base` on the six
+    committed benchmark scenarios. Range 41.6 %-84.3 %, average 64.3 %.
     Reproducible via `make benchmark-matrix && make scorecard` — see the
     *vs. naïve concat baseline* section of
     [`benchmarks/scorecard.md`](benchmarks/scorecard.md) and the
@@ -136,15 +149,16 @@ contextweaver provides two cooperating engines:
 pip install contextweaver
 ```
 
-`contextweaver` ships with a minimal, opinionated core: `tiktoken`,
-`PyYAML`, and `rank-bm25`. These power accurate token budgeting, YAML
-catalog/config files, and the default lexical retrieval backend.
+`contextweaver` ships with a small, opinionated core: `tiktoken`,
+`PyYAML`, `rank-bm25`, `mcp`, `jsonschema`, `typer`, and `rich`. These power
+accurate token budgeting, YAML catalog/config files, the default lexical
+retrieval backend, MCP gateway/proxy surfaces, schema validation, and the CLI.
 
 Optional capabilities are gated behind extras so the core install stays small:
 
 | Extra | What it adds |
 |---|---|
-| `contextweaver[cli]` | Rich-formatted CLI rendering (rich) |
+| `contextweaver[cli]` | Deprecated no-op alias; Typer/Rich now ship in core |
 | `contextweaver[retrieval]` | Fuzzy lexical matching backend (rapidfuzz) |
 | `contextweaver[otel]` | OpenTelemetry tracing + metrics export |
 | `contextweaver[ann]` | Approximate-nearest-neighbour backend (reserved) |
@@ -291,9 +305,10 @@ contextweaver is built for production use with comprehensive quality gates:
   produce identical outputs. Configurable retrieval backends (TF-IDF, BM25, fuzzy)
   preserve determinism within each mode.
 - **Public benchmark scorecard** — top-k recall, token savings, and routing latency at
-  catalog sizes 50 / 83 / 1000, plus context pipeline metrics across three reference
+  catalog sizes 50 / 83 / 1000, plus context pipeline metrics across six reference
   scenarios. See [`benchmarks/scorecard.md`](benchmarks/scorecard.md) (regenerate with
-  `make scorecard`).
+  `make scorecard`) and the adopter-facing
+  [`benchmark report`](docs/benchmark_report.md).
 
 Run the full suite yourself:
 
@@ -354,9 +369,9 @@ ChainWeaver, agent-kernel):
   (the source the gate fetches; the same documents are also published at
   `https://weaver-spec.dev/contracts/v0/`)
 
-> contextweaver is positioned to become the standard context management layer for AI agents.
-> Supporting MCP, A2A, and weaver-spec now means your codebase is future-proof as these
-> protocols mature and gain wider adoption.
+> contextweaver is designed as a protocol-friendly context management layer for
+> tool-using agents. Supporting MCP, A2A, and weaver-spec keeps the integration
+> boundary explicit as these protocols mature.
 
 - [MCP Integration](docs/integration_mcp.md)
 - [A2A Integration](docs/integration_a2a.md)
@@ -389,24 +404,24 @@ contextweaver works with any LLM provider and any agent framework:
 > You are not locked into a specific framework or LLM provider. contextweaver is a layer
 > *beneath* frameworks — context management as a composable primitive.
 
-### 5. Versioning & Compatibility
+### 5. Stability & Compatibility
 
-contextweaver follows [Semantic Versioning](https://semver.org/):
+contextweaver is currently **Alpha** in package metadata because the project is
+still clarifying its pre-1.0 stability boundary. The core context/routing APIs
+are intentionally deterministic and heavily tested; newer runtime surfaces such
+as gateway commands, adapters, and extras are called out as experimental where
+appropriate. See the detailed [stability and 1.0 readiness checklist](docs/stability.md).
 
-- **Breaking changes** to public APIs only in major versions
-- **Deprecation policy**: deprecated public APIs are warned for at least one minor version and removed only in a later major release
-- **API stability**: public APIs in `contextweaver.*` are stable; internal `_*` modules may change
-- **Python support**: 3.10+ (aligned with Python's active security support lifecycle)
-
-| Version | Status | Notes |
+| Surface | Current promise | Notes |
 |---|---|---|
-| **0.1.x** | ✅ Current | Foundation engines (context + routing), MCP/A2A adapters, CLI, sensitivity |
-| **0.2.0** | 🚧 In progress (Q2 2026) | Framework integration guides, benchmark suite, distributed stores |
-| **0.3.0** | 📋 Planned (Q3 2026) | DAG visualization, merge compression, LLM-assisted labeler |
-| **1.0.0** | 📋 Planned (Q4 2026) | API freeze, production benchmarks, enterprise features |
+| Documented public APIs | Change deliberately, with changelog/migration notes when behavior changes. | Dataclasses, stores, context/routing APIs, and documented adapters. |
+| Experimental runtime surfaces | May change before 1.0. | MCP gateway/proxy commands, newer optional extras, and reference architecture variants. |
+| Internal modules | No compatibility promise. | Modules beginning with `_` and test helpers are implementation details. |
+| Python support | Python 3.10+. | Aligned with the package metadata and CI matrix. |
 
-> Adopting a library is a long-term commitment. contextweaver's versioning policy ensures you
-> can upgrade safely, and the roadmap shows where it's headed.
+> Adopting a library is a long-term commitment. The stability page makes the
+> Alpha/Beta/1.0 line explicit so teams can decide which surfaces are ready for
+> their risk tolerance.
 
 #### Weaver Spec Compatibility
 
@@ -443,32 +458,17 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 
 ### 6. Roadmap & Community
 
-**v0.1 (✅ Complete)**
+Current package version: **0.10.0**.
 
-- Context Engine: 8-stage pipeline (candidates → closure → sensitivity → firewall → score → dedup → select → render)
-- Routing Engine: Catalog, DAG builder, beam-search router, choice cards
-- Protocol adapters: MCP (full content types, structured content, output schemas) and A2A
-- Stores: `EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore` with protocol-based interfaces
-- 1100+ passing tests, mypy strict, ruff clean, minimal core dependencies
+Recent milestones:
 
-**v0.2 (🚧 In Progress — Q2 2026)**
-
-- Framework integration guides: LlamaIndex, LangChain, LangGraph, OpenAI Agents SDK, Google ADK, Pipecat
-- Benchmark suite: token reduction, latency, and accuracy vs. naive concatenation
-- Distributed stores: Redis-backed `EventLog`, S3-backed `ArtifactStore`
-
-**v0.3 (📋 Planned — Q3 2026)**
-
-- DAG visualization: interactive routing graph inspector
-- Merge compression: deduplicate similar tool results across turns
-- LLM-based labeler: auto-generate namespace labels for tool catalogs
-- LLM-based extractor: structured fact extraction with prompt-based schema
-
-**v1.0 (📋 Planned — Q4 2026)**
-
-- API freeze: no breaking changes in 1.x releases
-- Production benchmarks: 1M+ turn deployments
-- Enterprise features: audit logging, compliance tags, PII redaction
+| Milestone | Status | Highlights |
+|---|---|---|
+| **v0.8** | ✅ complete | CrewAI adapter Phase 1, Mem0 external-memory backend, provider-SDK-leak tests |
+| **v0.9** | ✅ complete | Provider message adapters, cache-stable routing, launch polish |
+| **v0.10** | ✅ complete | `contextweaver mcp serve`, MCP Context Gateway architecture, gateway benchmark suite, route/context explanations |
+| **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
+| **v1.0** | 📋 planned | API freeze, documented deprecation policy, long-term compatibility window |
 
 **Community:**
 
@@ -476,8 +476,10 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 - [GitHub Issues](https://github.com/dgenio/contextweaver/issues) — report bugs, request features
 - [CHANGELOG](CHANGELOG.md) — track every release
 
-> contextweaver is under active development with a clear roadmap. v0.1 is feature-complete
-> for basic use cases; v0.2 adds production-ready integrations; v1.0 is the API stability milestone.
+> contextweaver is under active development with a clear roadmap. The core is
+> usable today; the project remains Alpha until the
+> [Beta readiness checklist](docs/stability.md#beta-readiness-checklist) is
+> complete or intentionally revised.
 
 ### Comparison
 
@@ -487,14 +489,14 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 
 | Approach | Tool routing | History compaction | Sensitivity firewall | Deterministic | MCP-native |
 |---|---|---|---|---|---|
-| **contextweaver** (this repo, [v0.9.0](https://pypi.org/project/contextweaver/0.9.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42–75 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
+| **contextweaver** (this repo, [v0.10.0](https://pypi.org/project/contextweaver/0.10.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42-84 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
 | **Naïve concat-everything** | ❌ No router · prompt carries every tool schema | ❌ No compaction · prompt grows with turn count | ❌ Raw outputs in the prompt | ⚠️ Only if the upstream LLM is | ⚠️ Compatible but no shaping |
 | **LangGraph memory** ([0.6.x](https://github.com/langchain-ai/langgraph/releases)) | ❌ Out of scope — LangGraph routes state, not tools | ⚠️ Optional via `ConversationSummaryMemory` (LLM-based, non-deterministic) [^lg-mem] | ❌ Not provided | ⚠️ Workflow yes; memory summarizer no | ⚠️ Possible via custom adapter, not first-class |
 | **LlamaIndex retrievers** ([0.11.x](https://github.com/run-llama/llama_index/releases)) | ⚠️ Tool retrieval via `ObjectIndex` is unranked similarity, no bounded routing | ⚠️ `ChatMemoryBuffer` token-bounded · no phase awareness [^li-mem] | ❌ Not provided · large outputs flow through verbatim | ⚠️ Retriever yes; summarizer no | ⚠️ Possible via custom tool wrapper |
 | **Raw MCP** ([modelcontextprotocol v0.1](https://modelcontextprotocol.io)) | ❌ Servers expose tools; routing across many servers is the client's problem | ❌ Out of scope for the protocol | ❌ Out of scope for the protocol | ✅ Wire protocol is deterministic | ✅ — _is_ the protocol |
 
 [^cw-route]: `contextweaver.routing.router.Router` ships a four-stage pipeline (`retrieve → rerank → navigate → pack`) with deterministic tie-break by `id`. Locked by `tests/test_cards.py::test_make_choice_cards_byte_identical_stable_order`.
-[^cw-bench]: Range from the committed scorecard ([`benchmarks/scorecard.md`](benchmarks/scorecard.md)) using `tiktoken.cl100k_base` against the naïve baseline ([`scripts/baseline_naive.py`](scripts/baseline_naive.py)). Average 55.8 %; min 41.6 % on the smallest scenario; max 74.5 % on `stress_conversation.jsonl`.
+[^cw-bench]: Range from the committed scorecard ([`benchmarks/scorecard.md`](benchmarks/scorecard.md)) using `tiktoken.cl100k_base` against the naïve baseline ([`scripts/baseline_naive.py`](scripts/baseline_naive.py)). Average 64.3 %; min 41.6 % on `long_conversation.jsonl`; max 84.3 % on `tiny_payload.jsonl`.
 [^cw-fire]: `contextweaver.context.firewall.apply_firewall` plus `ArtifactRef` drilldown selectors (`head` / `lines` / `json_keys` / `rows`). See [`docs/context_firewall.md`](docs/context_firewall.md) and the [`firewall_drilldown_recipe`](examples/cookbook/firewall_drilldown_recipe.py).
 [^cw-det]: Determinism is an invariant — see `docs/agent-context/invariants.md` and `make scorecard-check` in the CI gate.
 [^cw-mcp]: `src/contextweaver/adapters/mcp_proxy.py`, `mcp_gateway.py`, `mcp_proxy_server.py`, `mcp_gateway_server.py`. Bound by `docs/gateway_spec.md`.
@@ -611,8 +613,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions.
 | **v0.6 — Adopter surface** (2026-05-17) | ✅ complete | Typer + Rich CLI rewrite, OTel GenAI semconv, provider message adapters (OpenAI / Anthropic / Gemini), 5-line adoption snippet |
 | **v0.7 — Reference architectures + routing pipeline** (2026-05-18) | ✅ complete | Explicit routing pipeline, embedding backend, history-aware routing, code-review bot + voice agent architectures, FastMCP CodeMode hooks |
 | **v0.8 — CrewAI + Mem0** (2026-05-19) | ✅ complete | CrewAI adapter (Phase 1), Mem0 external-memory backend, provider-SDK-leak invariant tests |
-| **v0.9 — Launch polish + adapters** (2026-05) | 🚧 in progress | `contextweaver mcp serve` CLI, full MCP Context Gateway architecture, CrewAI/Pydantic AI/smolagents/Agno adapter Phase 2 |
-| **v1.0 — API stability** | 📋 planned | API freeze, semantic-versioning commitment, long-term support window |
+| **v0.9 — Launch polish + adapters** (2026-05) | ✅ complete | Provider message adapters, cache-stable routing, launch polish |
+| **v0.10 — MCP gateway runtime + audit surfaces** (2026-05) | ✅ complete | `contextweaver mcp serve`, full MCP Context Gateway architecture, gateway benchmark suite, route/context explanations |
+| **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
+| **v1.0 — API stability** | 📋 planned | API freeze, documented deprecation policy, long-term compatibility window |
 | **Future** | 📋 planned | DAG visualization, LLM-assisted labeler, distributed stores, multi-agent coordination |
 
 See [CHANGELOG.md](CHANGELOG.md) for the detailed release history.

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 
 ### 6. Roadmap & Community
 
-Current package version: **0.10.0**.
+Current package version: **0.11.0**.
 
 Recent milestones:
 
@@ -520,6 +520,7 @@ Recent milestones:
 | **v0.8** | ✅ complete | CrewAI adapter Phase 1, Mem0 external-memory backend, provider-SDK-leak tests |
 | **v0.9** | ✅ complete | Provider message adapters, cache-stable routing, launch polish |
 | **v0.10** | ✅ complete | `contextweaver mcp serve`, MCP Context Gateway architecture, gateway benchmark suite, route/context explanations |
+| **v0.11** | ✅ complete | Memory-source adapter interface, session-handoff context pack, "when not to use" guidance |
 | **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
 | **v1.0** | 📋 planned | API freeze, documented deprecation policy, long-term compatibility window |
 
@@ -680,7 +681,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions.
 | **v0.7 — Reference architectures + routing pipeline** (2026-05-18) | ✅ complete | Explicit routing pipeline, embedding backend, history-aware routing, code-review bot + voice agent architectures, FastMCP CodeMode hooks |
 | **v0.8 — CrewAI + Mem0** (2026-05-19) | ✅ complete | CrewAI adapter (Phase 1), Mem0 external-memory backend, provider-SDK-leak invariant tests |
 | **v0.9 — Launch polish + adapters** (2026-05-20) | ✅ complete | Budget checks, provider adapters, benchmark transparency suite, launch polish |
-| **v0.10 — MCP serve + gateway polish** (2026-05-22) | ✅ current | `contextweaver mcp serve`, schema hydration helpers, full MCP Context Gateway demos, context-build explanations |
+| **v0.10 — MCP serve + gateway polish** (2026-05-22) | ✅ complete | `contextweaver mcp serve`, schema hydration helpers, full MCP Context Gateway demos, context-build explanations |
+| **v0.11 — Memory source + session handoff** (2026-05-27) | ✅ current | `MemorySource` protocol + `JsonFixtureMemorySource`, session-handoff context pack, "when not to use" section |
 | **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
 | **v1.0 — API stability** | 📋 planned | API freeze, semantic-versioning commitment, long-term support window |
 | **Future** | 📋 planned | DAG visualization, LLM-assisted labeler, distributed stores, multi-agent coordination |

--- a/docs/assets/hero.svg
+++ b/docs/assets/hero.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 440" width="960" height="440" role="img" aria-label="contextweaver architecture — Context Engine and Routing Engine bridging an agent loop and tool catalog">
-  <title>contextweaver — context firewall + tool router for tool-using agents</title>
+  <title>contextweaver - context firewall + tool router for MCP and tool-heavy agents</title>
   <desc>The agent talks to two engines: the Context Engine compiles a phase-aware prompt under a token budget while the Context Firewall stores raw tool outputs out of band; the Routing Engine narrows a 100-tool catalog to five ChoiceCards via bounded beam search. Both engines feed compact tokens back to the LLM.</desc>
 
   <defs>
@@ -27,7 +27,7 @@
   <rect width="100%" height="100%" rx="14" fill="url(#bgGrad)"/>
 
   <!-- Title -->
-  <text x="480" y="40" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="700" fill="#c9d1d9">contextweaver — context firewall + tool router for tool-heavy agents</text>
+  <text x="480" y="40" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="700" fill="#c9d1d9">contextweaver - context firewall + tool router for MCP/tool-heavy agents</text>
   <text x="480" y="62" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#8b949e">phase-aware, budget-bounded context · deterministic routing over large catalogs</text>
 
   <!-- Agent (left) -->
@@ -90,7 +90,7 @@
   <g>
     <rect x="290" y="370" width="380" height="44" rx="8" fill="#161b22" stroke="#30363d"/>
     <text x="480" y="392" text-anchor="middle" font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" font-weight="600" fill="#c9d1d9">Compact prompt + ChoiceCards → LLM</text>
-    <text x="480" y="408" text-anchor="middle" font-family="ui-monospace, monospace" font-size="11" fill="#8b949e">42–75 % fewer tokens vs naive concat · deterministic by default</text>
+    <text x="480" y="408" text-anchor="middle" font-family="ui-monospace, monospace" font-size="11" fill="#8b949e">42-84 % fewer prompt tokens vs naive concat · deterministic by default</text>
   </g>
   <line x1="480" y1="340" x2="480" y2="370" stroke="#8b949e" stroke-width="1.5" marker-end="url(#arrow)"/>
   <line x1="480" y1="200" x2="480" y2="240" stroke="#8b949e" stroke-width="1.5" stroke-dasharray="3,3" marker-end="url(#arrow)"/>

--- a/docs/benchmark_report.md
+++ b/docs/benchmark_report.md
@@ -1,0 +1,137 @@
+# Adopter Benchmark Report
+
+> A decision-oriented companion to the generated
+> [benchmark scorecard](https://github.com/dgenio/contextweaver/blob/main/benchmarks/scorecard.md).
+> The scorecard is the source of truth for raw numbers; this page explains what
+> those numbers mean for an engineering lead evaluating contextweaver.
+
+## Executive Summary
+
+contextweaver helps most when an existing agent already works, but its prompt is
+being crowded by tool schemas, tool results, or long tool-use history.
+
+| Best fit | Why contextweaver helps |
+|---|---|
+| MCP / FastMCP / Python agents with many tools | The Routing Engine shows the model a bounded `ChoiceCard` shortlist instead of the whole tool catalog. |
+| Tools that return large JSON, logs, tables, CSV, or binary payloads | The context firewall stores raw output as artifacts and injects compact summaries. |
+| Long multi-turn agents with tool calls/results | Phase-specific context builds keep dependency chains intact while dropping lower-value context first. |
+
+| Poor fit | Why it may not help |
+|---|---|
+| A small agent with 3-5 tiny tools and short conversations | There may be no prompt-budget pressure to relieve. |
+| A team looking for an agent framework or model SDK | contextweaver does not run the loop or call the LLM. |
+| A pure RAG or long-term-memory problem | Use a retrieval or memory system first; contextweaver can budget their outputs later. |
+| A very large catalog with sparse metadata and only lexical scoring | Default recall degrades at large catalog sizes; use a stronger retriever or improve catalog metadata. |
+
+## Prompt-Size and Cost Model
+
+The committed scorecard compares contextweaver against a naive baseline that
+concatenates all tool schemas plus full conversation history. The token counts
+below come from `benchmarks/results/latest.json` and are rendered in
+`benchmarks/scorecard.md`.
+
+Cost math is intentionally model-agnostic:
+
+```text
+cost_per_1k_turns = tokens_per_turn * 1000 * input_price_per_1m_tokens / 1_000_000
+```
+
+Use your own provider's input-token price. The worked example below uses an
+illustrative `input_price_per_1m_tokens = $1.00`.
+
+| Scenario | Naive tokens | contextweaver tokens | Reduction | Cost / 1k turns naive | Cost / 1k turns cw |
+|---|---:|---:|---:|---:|---:|
+| `large_catalog` | 2,767 | 1,514 | 45.28 % | $2.77 | $1.51 |
+| `long_conversation` | 4,365 | 2,548 | 41.63 % | $4.37 | $2.55 |
+| `mixed_payload` | 2,277 | 497 | 78.17 % | $2.28 | $0.50 |
+| `short_conversation` | 1,946 | 496 | 74.51 % | $1.95 | $0.50 |
+| `stress_conversation` | 17,482 | 6,651 | 61.96 % | $17.48 | $6.65 |
+| `tiny_payload` | 1,704 | 267 | 84.33 % | $1.70 | $0.27 |
+
+Average across the six committed scenarios: 5,090 naive tokens vs 1,996
+contextweaver tokens per answer-phase build. At the illustrative price above,
+that is about `$5.09` vs `$2.00` per 1,000 similarly-shaped turns.
+
+**Important:** this is a prompt-input estimate, not an end-to-end production
+cost guarantee. Completion tokens, model latency, retries, tool latency, cache
+hits, and business logic all live outside this offline harness.
+
+## Latency Model
+
+Latency numbers in the scorecard are hardware-dependent. Treat them as ordering
+and scale signals, not as service-level objectives.
+
+| Catalog size | Queries | Recall@5 | MRR | p50 route latency | p95 route latency | p99 route latency |
+|---:|---:|---:|---:|---:|---:|---:|
+| 50 | 131 | 0.5649 | 0.4978 | 0.423 ms | 0.548 ms | 0.759 ms |
+| 83 | 200 | 0.3825 | 0.3242 | 0.667 ms | 0.779 ms | 1.134 ms |
+| 1000 | 200 | 0.1475 | 0.1456 | 36.007 ms | 37.467 ms | 41.711 ms |
+
+The context-build side is measured as token output and budget behavior rather
+than wall-clock latency in the public scorecard. For real deployments, measure
+your own event-log shape with OpenTelemetry or a wrapper around
+`ContextManager.build_sync(...)`.
+
+## Routing-Quality Model
+
+The default routing backends are deterministic and transparent. They are also
+not magic: lexical scoring degrades as catalog size and noise increase.
+
+| Observation | What it means |
+|---|---|
+| Recall@5 is 0.5649 at 50 tools and 0.1475 at 1000 tools in the headline run. | Routing-only adoption is strongest for small-to-medium catalogs or catalogs with strong metadata. |
+| The scorecard includes `tfidf`, `bm25`, `embedding_hashing`, and skipped optional backends. | Backends are swappable; compare them on your catalog rather than assuming the default is best. |
+| The mixed-shape 500-tool catalog reports lower recall than the uniform catalog. | Real catalogs with head-heavy namespaces and long tails need better metadata or a retriever-first shortlist. |
+
+Recommended mitigation path for large catalogs:
+
+1. Improve `SelectableItem.description`, `tags`, and `namespace` quality.
+2. Compare `tfidf`, `bm25`, and `embedding_hashing` with
+   `make benchmark-matrix`.
+3. Add a retriever-first shortlist through the `Retriever` protocol when the
+   catalog is too large or too semantically sparse for lexical ranking alone.
+
+## Failure Modes Avoided
+
+| Failure mode | What contextweaver does |
+|---|---|
+| Giant tool output pasted raw into the answer prompt | Stores the raw payload as an `ArtifactRef` and injects a summary. |
+| Full schema catalog injected on every route turn | Exposes compact `ChoiceCard`s and hydrates full schema only when needed. |
+| Manual history trimming drops a parent tool call | Dependency closure keeps selected tool results paired with their parent calls. |
+| Confidential context crosses a policy boundary | Sensitivity filtering drops or redacts according to `ContextPolicy`. |
+| Debugging prompt changes becomes guesswork | `BuildStats`, route traces, and explanations show what was included, dropped, and why. |
+
+## Reproduce
+
+```bash
+make benchmark-matrix
+make scorecard
+make scorecard-check
+```
+
+Source files:
+
+| File | Role |
+|---|---|
+| [`benchmarks/results/latest.json`](https://github.com/dgenio/contextweaver/blob/main/benchmarks/results/latest.json) | Machine-readable benchmark output. |
+| [`benchmarks/scorecard.md`](https://github.com/dgenio/contextweaver/blob/main/benchmarks/scorecard.md) | Generated scorecard and methodology. |
+| [`benchmarks/benchmark.py`](https://github.com/dgenio/contextweaver/blob/main/benchmarks/benchmark.py) | Harness implementation. |
+| [`benchmarks/scenarios/`](https://github.com/dgenio/contextweaver/tree/main/benchmarks/scenarios) | Context-pipeline fixtures. |
+| [`benchmarks/routing_gold.json`](https://github.com/dgenio/contextweaver/blob/main/benchmarks/routing_gold.json) | Routing gold set. |
+
+Deterministic metrics: recall, drops, dedup counts, token counts, artifact
+counts, and compaction ratios.
+
+Hardware-dependent metrics: p50/p95/p99 latency.
+
+## How to Decide
+
+Adopt a small proof-of-concept if at least one of these is true:
+
+- Your prompt regularly includes more tools than the model should reason about.
+- A single tool can return enough data to dominate the prompt.
+- Your agent history includes tool-call chains that manual truncation breaks.
+- You need deterministic context budgeting and inspectable drop reasons.
+
+Defer contextweaver if none of those are true yet. Keep the scorecard commands
+around, then re-run them once the agent grows into the problem.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -7,6 +7,7 @@
 
 | What | Where |
 |---|---|
+| The adopter-facing interpretation | [`docs/benchmark_report.md`](benchmark_report.md) — cost, prompt-size, latency, and failure-mode framing |
 | The numbers | [`benchmarks/scorecard.md`](https://github.com/dgenio/contextweaver/blob/main/benchmarks/scorecard.md) — committed, regeneratable in one command |
 | The raw output | [`benchmarks/results/latest.json`](https://github.com/dgenio/contextweaver/blob/main/benchmarks/results/latest.json) — machine-readable |
 | The harness | [`benchmarks/benchmark.py`](https://github.com/dgenio/contextweaver/blob/main/benchmarks/benchmark.py) |
@@ -65,7 +66,7 @@ something different and degrades under different conditions:
 Two practical reading rules:
 
 1. **Treat `recall@5` at catalog_size 1000 as a baseline number, not a ceiling.** The default `tfidf` and `bm25` scorers are lexical; they trade recall for transparency and zero-network determinism. A retriever-first shortlist (embedding ANN or LLM rerank) is the documented way to recover recall at scale — tracked under issue [#8](https://github.com/dgenio/contextweaver/issues/8).
-2. **Token-reduction percentages are scenario-bound.** "41.6%–74.5%" is the *range across the four committed scenarios*, not a guarantee for any specific workload. The right number for your agent is whatever you measure on your own event logs using `scripts/baseline_naive.py`.
+2. **Token-reduction percentages are scenario-bound.** "41.6 %-84.3 %" is the *range across the six committed scenarios*, not a guarantee for any specific workload. The right number for your agent is whatever you measure on your own event logs using `scripts/baseline_naive.py`.
 
 ## Known limits and honest framing
 
@@ -74,7 +75,7 @@ configuration does on the **default** benchmark fixtures. The
 following are deliberate, documented gaps — not bugs:
 
 - **Routing recall degrades with catalog size.** At catalog_size 50, `recall@5` is ~0.56. At 1000, it falls to ~0.15 with both `tfidf` and `bm25`. This is the well-known lexical-retrieval ceiling on large tool catalogs. contextweaver's response is to make the scorer **pluggable** (see `Router(scorer_backend=...)` and the `Retriever` protocol on the `EngineRegistry`), not to claim the default scorer is sufficient at scale. The scorecard exists so you can see this drop yourself, swap in a stronger backend, and re-measure.
-- **Token reduction is scenario-driven.** All percentages above are measured against the four committed scenarios under `benchmarks/scenarios/`. If your real conversations or tool outputs differ materially in shape (much shorter turns, much larger results, very different namespace distribution), expect different percentages.
+- **Token reduction is scenario-driven.** All percentages above are measured against the six committed scenarios under `benchmarks/scenarios/`. If your real conversations or tool outputs differ materially in shape (much shorter turns, much larger results, very different namespace distribution), expect different percentages.
 - **Latency is informational.** Treat the latency numbers as ordering between catalog sizes, not as a service-level objective for production deployments.
 - **No claim is made** about end-to-end agent cost, answer quality, or accuracy — those depend on the model and the agent loop, not on contextweaver alone.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -11,6 +11,10 @@ not an agent framework, not a memory database, not an LLM SDK, and not a
 generic RAG library. The point of this page is to make those boundaries
 concrete.
 
+For an adopter-facing decision matrix with more public-positioning language,
+see the [Ecosystem Map](ecosystem.md). This page stays closer to the technical
+boundaries between layers.
+
 ## TL;DR
 
 ```text
@@ -151,6 +155,8 @@ summarised before the next turn.
 
 - [Showcase](showcase.md) — four runnable demos that exercise the above
   primitives in under a minute each.
+- [Ecosystem Map](ecosystem.md) — adopter-facing comparison and decision
+  matrix for agent frameworks, MCP, memory, RAG, and observability.
 - [Which pattern fits?](which_pattern.md) — symptom-driven routing into
   the right contextweaver primitive.
 - [How contextweaver fits (deeper)](interop.md) — policy-vs-execution

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,0 +1,149 @@
+# Ecosystem Map
+
+> contextweaver is a runtime context-compilation layer. It sits inside an
+> existing agent loop and decides what context the model sees this turn.
+
+This page is the adopter-facing version of [Where contextweaver fits](comparison.md).
+The short version: keep your framework, MCP servers, memory system, retriever,
+model SDK, and observability stack. Add contextweaver when the prompt itself
+needs bounded, deterministic context control.
+
+## Decision Matrix
+
+| If you are evaluating... | contextweaver relationship | You probably need contextweaver when... |
+|---|---|---|
+| Agent frameworks | Complementary | The framework runs the loop, but prompt assembly is still too large or too manual. |
+| MCP / FastMCP | Complementary | The server exposes many tools or returns large payloads that should not all reach the model. |
+| Memory systems | Complementary | Long-lived memory exists, but each turn still needs budgeted selection. |
+| RAG / vector retrieval | Complementary | Retrieved docs compete with tool results, facts, and history for the same prompt budget. |
+| Observability | Instrumented by it | You need diagnostics for prompt construction, not another dashboard. |
+| LLM SDKs | Upstream consumer | You want a `ContextPack.prompt` to hand to OpenAI, Anthropic, Gemini, or local models. |
+
+| You probably do not need contextweaver if... | Better first step |
+|---|---|
+| You have not built an agent loop yet. | Pick an agent framework or write the loop first. |
+| You only need document retrieval. | Start with RAG or a vector database. |
+| You only need durable user memory. | Start with Mem0, Zep, LangMem, or your own memory store. |
+| You only need traces, dashboards, or cost reporting. | Start with OpenTelemetry or your existing observability stack. |
+| Your tool catalog and tool outputs are tiny. | Keep the simple prompt path until context pressure appears. |
+
+## Agent Frameworks
+
+Frameworks such as LangGraph, CrewAI, Pydantic AI, OpenAI Agents SDK, Google
+ADK, and custom loops own control flow:
+
+- when to call the model
+- when to call a tool
+- how to retry
+- when the task is finished
+
+contextweaver owns a narrower question:
+
+```text
+Given the current phase and budget, which events, facts, tool cards, and tool
+results should enter the prompt?
+```
+
+Use both when your framework has a working loop but still leaves you hand-
+rolling truncation, tool shortlist prompts, or large-result summaries.
+
+Concrete paths:
+
+| Runtime | Start here |
+|---|---|
+| LangChain / LangGraph | [LangChain + LangGraph guide](integration_langchain.md) |
+| OpenAI Agents SDK | [OpenAI Agents SDK guide](integration_openai_adk.md) |
+| Google ADK / Vertex AI | [Google ADK guide](integration_google_adk.md) |
+| CrewAI | [CrewAI guide](integration_crewai.md) |
+| Pipecat | [Pipecat guide](integration_pipecat.md) |
+
+## MCP and FastMCP
+
+MCP exposes tools and data. It does not decide which of 60, 600, or 6,000 tool
+definitions should be shown to a model on a specific turn, and it does not make
+large tool results prompt-safe by itself.
+
+contextweaver can sit in front of MCP-style tools in two ways:
+
+| Pattern | What happens |
+|---|---|
+| Adapter + routing-only | Convert tool definitions to `SelectableItem`s, then route to a small `ChoiceCard` set. |
+| Gateway/proxy runtime | Expose `tool_browse`, `tool_execute`, and `tool_view` meta-tools over MCP-shaped payloads. |
+
+Start with the [MCP integration guide](integration_mcp.md), the
+[FastMCP cookbook recipe](cookbook.md), or the
+[MCP Context Gateway architecture](architectures/mcp_context_gateway.md).
+
+## Memory Systems
+
+Memory systems persist knowledge across sessions. contextweaver decides what
+from memory, history, facts, and tool results earns space in the current
+prompt.
+
+| System | Primary job | contextweaver job |
+|---|---|---|
+| Mem0 | Extract and retrieve durable memories. | Budget retrieved memories alongside current events. |
+| Zep / Graphiti | Maintain temporal knowledge graphs. | Pull relevant facts into a phase-specific prompt. |
+| LangMem | Structure semantic, episodic, and procedural memory for LangGraph. | Compile selected memories with tool context and dependency chains. |
+| SQLite / custom stores | Persist events and artifacts. | Query, score, filter, firewall, and render. |
+
+See [External Memory Backends](integration_memory.md) for the protocol shape.
+Issue [#195](https://github.com/dgenio/contextweaver/issues/195) tracks the
+remaining first-class memory adapters.
+
+## RAG and Vector Retrieval
+
+RAG retrieves documents. contextweaver compiles agent context.
+
+They compose cleanly:
+
+1. Run RAG against your document corpus.
+2. Ingest retrieved chunks as `ContextItem(kind=doc_snippet, ...)`.
+3. Let contextweaver score those chunks against facts, tool results, and recent
+   history under the same token budget.
+
+This is useful when retrieved documents are not the only thing the model needs.
+For example, an answer may need a document chunk, the tool result that produced
+an incident ID, and the parent tool call that explains where that result came
+from.
+
+## Observability
+
+contextweaver is not an observability product. It does emit useful diagnostics:
+
+| Diagnostic | What it explains |
+|---|---|
+| `BuildStats` | Included, dropped, deduplicated, and token usage counts. |
+| Route traces | How routing expanded the graph and ranked candidates. |
+| Context explanations | Per-candidate scoring and drop reasons when requested. |
+| OpenTelemetry integration | GenAI semantic-convention attributes for existing backends. |
+
+Use [OpenTelemetry](integration_otel.md) or your existing dashboard stack to
+store and visualize these signals across production traffic.
+
+## Positioning Boundaries
+
+contextweaver claims:
+
+- bounded tool-card routing
+- artifact-backed context firewalling
+- phase-specific prompt compilation
+- deterministic, LLM-free core execution
+- inspectable build and routing diagnostics
+
+contextweaver does not claim:
+
+- to replace your framework, MCP servers, memory layer, RAG stack, model SDK, or
+  observability system
+- to guarantee answer-quality improvements
+- to guarantee a fixed cost reduction for every workload
+- to make lexical retrieval sufficient for every large catalog
+
+## See Also
+
+- [Which pattern fits?](which_pattern.md) - symptom-driven adoption paths.
+- [Adopter Benchmark Report](benchmark_report.md) - prompt-size, cost, latency,
+  and failure-mode framing.
+- [FAQ](faq.md) - shorter answers to common positioning questions.
+- [Showcase](showcase.md) - deterministic demos of routing, firewalling, long
+  history, and MCP gateway patterns.

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -98,7 +98,7 @@ RAG retrieves documents. contextweaver compiles agent context.
 They compose cleanly:
 
 1. Run RAG against your document corpus.
-2. Ingest retrieved chunks as `ContextItem(kind=doc_snippet, ...)`.
+2. Ingest retrieved chunks as `ContextItem(kind=ItemKind.doc_snippet, ...)`.
 3. Let contextweaver score those chunks against facts, tool results, and recent
    history under the same token budget.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -135,6 +135,16 @@ Three options, in order of effort:
   network-independent. Parity check is tracked under
   [issue #268](https://github.com/dgenio/contextweaver/issues/268).
 
+## Is this related to similarly named ContextWeaver projects or research?
+
+Not intentionally. This repository is the Python package
+[`dgenio/contextweaver`](https://github.com/dgenio/contextweaver), positioned
+as a context firewall and tool router for MCP and tool-heavy agents. The name
+"context weaver" is descriptive enough that other projects or papers may use
+similar phrasing. When citing this project publicly, use `dgenio/contextweaver`
+or `contextweaver` on PyPI and include the subtitle "context firewall + tool
+router for MCP and tool-heavy agents" to avoid confusion.
+
 ## See also
 
 - [Showcase](showcase.md) — four runnable demos in under a minute each.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,8 @@
 # contextweaver
 
-> **Context firewall + tool router for tool-heavy AI agents.** Phase-specific,
-> budget-aware **context engineering** with a deterministic core.
+> **Context firewall + tool router for MCP and tool-heavy agents.**
+> Phase-specific, budget-aware **context engineering** with a deterministic
+> core.
 
 ![contextweaver architecture overview](assets/hero.svg)
 
@@ -26,6 +27,11 @@ problem for tool-using AI agents:
   catalogs, producing compact LLM-friendly `ChoiceCard`s. See the
   [Tool Router](tool_router.md) page.
 
+Use it when your agent has too many MCP / FastMCP / Python tools, too much
+tool-result data, or a long history competing for the same prompt budget. Do
+not use it as a replacement for your agent framework, model SDK, memory
+database, RAG system, or observability stack.
+
 ## Get started
 
 [10-Minute Quickstart](quickstart.md){ .md-button .md-button--primary }
@@ -39,6 +45,10 @@ problem for tool-using AI agents:
 |---|---|
 | [Quickstart](quickstart.md) | Install, first context build, firewall demo, routing demo |
 | [Concepts](concepts.md) | Core type glossary: `ContextItem`, `Phase`, `ChoiceGraph`, … |
+| [Ecosystem Map](ecosystem.md) | How contextweaver compares with agent frameworks, MCP, memory, RAG, and observability |
+| [Adopter Benchmark Report](benchmark_report.md) | Cost, prompt-size, latency, routing-quality, and failure-mode framing |
+| [Stability](stability.md) | Alpha/Beta/1.0 readiness and public API stability boundaries |
+| [Launch Kit](launch_kit.md) | Reusable public copy, assets, and responsible-claims checklist |
 | [Runtime Loop](guide_agent_loop.md) | Four-phase flow diagram and pseudo-code |
 | [MCP Integration](integration_mcp.md) | Tool conversion, session loading, firewall with MCP |
 | [A2A Integration](integration_a2a.md) | Agent cards and multi-agent sessions |

--- a/docs/launch_kit.md
+++ b/docs/launch_kit.md
@@ -1,0 +1,146 @@
+# Launch Kit
+
+> Reusable copy and assets for explaining `dgenio/contextweaver` accurately.
+> Use this for README snippets, PyPI copy, posts, slides, conference abstracts,
+> and ecosystem discussions.
+
+The goal is consistency, not hype. Every claim below should be traceable to a
+repo file, a docs page, or a reproducible command.
+
+## One-Sentence Descriptions
+
+| Audience | Copy |
+|---|---|
+| Technical | contextweaver is a context firewall and tool router for MCP and tool-heavy Python agents. |
+| Product / adopter | Keep huge tool catalogs, tool schemas, tool results, and long histories out of the prompt without losing the context your agent needs. |
+| OSS / community | A deterministic Python context-compilation layer that sits inside your existing agent loop and works alongside frameworks, MCP servers, memory systems, RAG, and model SDKs. |
+
+## Short Copy Blocks
+
+### 280 Characters
+
+```text
+contextweaver is a context firewall + tool router for MCP and tool-heavy agents.
+It turns large catalogs into compact ChoiceCards, stores huge tool outputs out
+of band, and builds deterministic phase-specific prompts for your existing
+agent loop.
+```
+
+### LinkedIn Paragraph
+
+```text
+contextweaver is a Python context firewall and tool router for MCP and
+tool-heavy agents. It does not run your agent or call an LLM. Instead, it sits
+inside your existing loop and decides what the model should see this turn:
+compact ChoiceCards for routing, artifact-backed summaries for large tool
+results, and phase-specific context packs for long histories.
+```
+
+### GitHub Repo Blurb
+
+```text
+Context firewall + tool router for MCP and tool-heavy AI agents. Deterministic
+phase-specific context engineering for large tool catalogs, huge tool results,
+and long agent histories.
+```
+
+### PyPI Short Description
+
+```text
+Context firewall + tool router for MCP and tool-heavy AI agents.
+```
+
+## Visual and Demo Assets
+
+| Asset | Use |
+|---|---|
+| [`docs/assets/hero.svg`](assets/hero.svg) | Architecture overview for README, talks, and posts. |
+| [`docs/assets/before_after.svg`](assets/before_after.svg) | Social-ready prompt-budget before/after visual. |
+| [`docs/assets/demo.svg`](assets/demo.svg) | Animated demo image for docs pages and posts. |
+| [`docs/assets/demo.cast`](assets/demo.cast) | Terminal recording of the default demo. |
+| [`docs/assets/casts/large-catalog.cast`](assets/casts/large-catalog.cast) | Large catalog to compact `ChoiceCard`s. |
+| [`docs/assets/casts/huge-tool-output.cast`](assets/casts/huge-tool-output.cast) | Huge tool output through the context firewall. |
+| [`docs/assets/casts/mcp-gateway-full.cast`](assets/casts/mcp-gateway-full.cast) | Full MCP Context Gateway narrative. |
+
+Do not invent fake dashboards, production metrics, customer logos, or screenshots.
+If a visual shows a number, it should come from a committed example, scorecard,
+or deterministic demo.
+
+## FAQ Snippets
+
+| Question | Snippet |
+|---|---|
+| Does it replace LangGraph or CrewAI? | No. Your framework owns control flow; contextweaver owns prompt/context compilation. |
+| Is it memory? | Not by itself. It can use memory backends, but its job is deciding what memory and event context enters this turn's prompt. |
+| Is it RAG? | No. RAG retrieves documents; contextweaver budgets documents alongside tool results, facts, and history. |
+| Does it call the LLM? | No. Core paths are deterministic, LLM-free, and network-free. |
+| When should I not use it? | If your tools, outputs, and histories are already tiny, keep the simple prompt path. |
+| Is it MCP? | It is not the protocol itself. It can consume MCP-shaped tools/results and can run MCP gateway/proxy patterns. |
+
+## Responsible Claims Checklist
+
+Claims you can make:
+
+- "Reduces prompt tokens by 41.6 %-84.3 % on the six committed benchmark
+  scenarios."
+- "Routes large catalogs to compact `ChoiceCard` shortlists."
+- "Stores large tool outputs out of band and injects summaries."
+- "Runs deterministic, LLM-free core context and routing paths."
+- "Works alongside MCP, FastMCP, LangGraph, LangChain, LlamaIndex, OpenAI
+  Agents SDK, Google ADK, Pipecat, CrewAI, memory systems, and model SDKs."
+
+Claims to avoid:
+
+- "Makes agents 84 % cheaper."
+- "Improves answer quality by X %."
+- "Solves tool selection at any scale."
+- "Replaces MCP, LangGraph, RAG, memory, or observability."
+- "Production-ready 1.0 API."
+- "Guarantees latency or cost reduction for your workload."
+
+How to cite numbers:
+
+```text
+On the committed benchmark scenarios, contextweaver reduces prompt tokens by
+41.6 %-84.3 % versus a naive concat-all baseline. Reproduce with:
+make benchmark-matrix && make scorecard
+```
+
+Link to the [Adopter Benchmark Report](benchmark_report.md) for cost and
+latency framing, and to the generated
+[benchmark scorecard](https://github.com/dgenio/contextweaver/blob/main/benchmarks/scorecard.md)
+for raw numbers.
+
+## Name and SEO Guidance
+
+Use `dgenio/contextweaver` when ambiguity matters. The package/repo should be
+described with a subtitle on first mention:
+
+```text
+contextweaver - context firewall + tool router for MCP and tool-heavy agents
+```
+
+Helpful discovery phrases to use naturally:
+
+| Phrase | Use when |
+|---|---|
+| context firewall | Describing large tool-result handling. |
+| MCP context gateway | Describing gateway/proxy patterns. |
+| tool-heavy agents | Describing many-tool catalogs. |
+| prompt budgeting | Describing phase-specific token control. |
+| tool result firewall | Describing artifact-backed summaries. |
+| ChoiceCards | Describing compact routing cards. |
+
+Avoid implying ownership of the broader phrase "context weaver." If someone
+asks about similarly named projects, point them to the FAQ entry:
+[Is this related to similarly named ContextWeaver projects or research?](faq.md#is-this-related-to-similarly-named-contextweaver-projects-or-research)
+
+## Useful Links
+
+- [Quickstart](quickstart.md)
+- [Showcase](showcase.md)
+- [Which pattern fits?](which_pattern.md)
+- [Ecosystem Map](ecosystem.md)
+- [Adopter Benchmark Report](benchmark_report.md)
+- [Stability and 1.0 Readiness](stability.md)
+- [MCP Context Gateway architecture](architectures/mcp_context_gateway.md)

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,0 +1,123 @@
+# Stability and 1.0 Readiness
+
+> contextweaver is still marked **Alpha** in package metadata. This page
+> explains what that means, which surfaces are stable enough to adopt today,
+> and what remains before Beta and 1.0.
+
+The short version: the core context and routing engines are deterministic,
+typed, tested, and used by the examples and benchmark harness. The project
+remains Alpha because several adopter-facing boundaries are still being
+clarified before a stronger public stability promise.
+
+## Current Maturity
+
+| Surface | Status | Compatibility expectation |
+|---|---|---|
+| Core dataclasses and enums | Public | Changes are deliberate and documented in the changelog. |
+| Context Engine APIs | Public | `ContextManager`, `ContextPack`, `BuildStats`, `ContextPolicy`, and related documented types are intended for real use. |
+| Routing Engine APIs | Public | `Catalog`, `TreeBuilder`, `Router`, `ChoiceCard`, `RouteResult`, and routing config types are intended for real use. |
+| Store protocols | Public | Protocol-based store design is a core invariant. |
+| Provider and protocol adapters | Public but still hardening | MCP, A2A, OpenAI, Anthropic, Gemini, FastMCP, CrewAI adapters are documented, but some edge cases remain pre-1.0. |
+| MCP gateway/proxy runtime | Experimental | Useful and tested, but marked experimental while the CLI/runtime surface settles. |
+| Optional extras | Mixed | Extras are available, but third-party API churn can affect adapter stability. |
+| Reference architectures | Compatibility fixtures | They are runnable examples, not a production framework. |
+| Internal modules | Internal | Modules beginning with `_` can change without notice. |
+
+## Why Alpha
+
+Alpha does not mean "untested." It means the project is not yet ready to make
+a full Beta or 1.0 compatibility promise.
+
+Current reasons to keep Alpha:
+
+| Reason | Tracking |
+|---|---|
+| Provider-message adapter rendering has a known prompt-legibility bug. | [#308](https://github.com/dgenio/contextweaver/issues/308) |
+| Community standards are not complete. | [#249](https://github.com/dgenio/contextweaver/issues/249) |
+| Adopter-facing benchmark packaging is being added. | [#323](https://github.com/dgenio/contextweaver/issues/323) |
+| Public API stability levels need to be visible in docs. | This page |
+| Experimental runtime commands need clear labeling before a broader launch. | `contextweaver mcp serve`, gateway/proxy runtime |
+
+## Beta Readiness Checklist
+
+Beta means the project is ready for broader adopter trials, while still
+allowing some pre-1.0 API refinement.
+
+| Item | Status |
+|---|---|
+| Provider adapter drop-in path fixed and tested. | Open: [#308](https://github.com/dgenio/contextweaver/issues/308) |
+| Community standards complete. | Open: [#249](https://github.com/dgenio/contextweaver/issues/249) |
+| Adopter benchmark report published and linked. | In progress: [#323](https://github.com/dgenio/contextweaver/issues/323) |
+| Public API surfaces documented with stability levels. | In progress: [#324](https://github.com/dgenio/contextweaver/issues/324) |
+| Experimental CLI/runtime commands clearly marked. | Partially done |
+| API reference published and linked from docs. | Done |
+| At least one reference architecture maintained as a compatibility fixture. | Done |
+| Benchmark limits and reproducibility documented. | Done, expanded by [#323](https://github.com/dgenio/contextweaver/issues/323) |
+| Changelog and migration notes maintained under `## [Unreleased]`. | Done |
+
+Recommended Beta classifier change: move from
+`Development Status :: 3 - Alpha` to `Development Status :: 4 - Beta` only
+after the open blocker rows above are closed or intentionally deferred.
+
+## 1.0 Readiness Checklist
+
+1.0 means public APIs are frozen enough for normal semantic-versioning
+expectations.
+
+| Item | Required before 1.0 |
+|---|---|
+| Public import map reviewed | Decide which documented `contextweaver.*` imports are stable long-term. |
+| Experimental surfaces isolated | Keep experimental gateway/runtime features labeled or move them behind clear namespaces. |
+| Deprecation policy enforced | Deprecated public APIs warn before removal. |
+| Migration guide ready | Document any pre-1.0 breaking changes and replacements. |
+| Benchmark report stable | Make sure benchmark methodology, limits, and regeneration flow are current. |
+| Security-sensitive defaults reviewed | Re-check sensitivity and firewall defaults before declaring 1.0. |
+| Protocol compatibility reviewed | Re-check MCP, A2A, and weaver-spec adapter behavior against current upstream specs. |
+| Docs and examples pass cleanly | `make ci` and `make docs` should be clean on a release branch. |
+
+## Deprecation Policy
+
+Before 1.0:
+
+- Public APIs may still change when correctness or clarity requires it.
+- The project should prefer warnings, migration notes, and changelog entries
+  over surprise removals.
+- Experimental surfaces may change faster, but docs should say so.
+
+After 1.0:
+
+- Breaking changes to stable public APIs should wait for a major release.
+- Deprecated public APIs should be documented for at least one minor release
+  before removal.
+- Internal modules remain internal even after 1.0.
+
+## Import Guidance
+
+| Prefer | Avoid |
+|---|---|
+| Documented classes and functions linked from the API reference. | Modules or helpers whose names start with `_`. |
+| `contextweaver.context.manager.ContextManager` for builds. | Reaching into individual context pipeline internals unless extending the library. |
+| `contextweaver.routing.*` public classes for catalogs and routing. | Depending on private scorer or graph helper functions. |
+| Store protocols and concrete store classes documented in `store/`. | Mutating in-memory store internals directly. |
+
+If a public-looking path is not documented and you need it, open an issue. That
+is exactly the kind of API-boundary feedback that should be resolved before 1.0.
+
+## Release Messaging
+
+Use this public phrasing until the Beta checklist is complete:
+
+```text
+contextweaver is Alpha: the core context and routing engines are tested and
+usable today, while gateway/runtime and adapter edges are still being hardened
+before Beta and 1.0.
+```
+
+Avoid saying:
+
+- "production-ready for every agent stack"
+- "1.0-stable API"
+- "drop-in replacement for memory, RAG, or agent frameworks"
+- "guaranteed cost reduction"
+
+See the [Launch Kit](launch_kit.md) for reusable wording and claim guardrails.

--- a/examples/agno_adapter_demo.py
+++ b/examples/agno_adapter_demo.py
@@ -125,7 +125,7 @@ def main() -> None:
     # 1. Namespace inference.
     print("[1] Namespace inference:")
     for name in ("duckduckgo_search", "yfinance_get_company_info", "calculator_evaluate"):
-        print(f"    {name!r:35s} → namespace={infer_agno_namespace(name)!r}")
+        print(f"    {name!r:35s} -> namespace={infer_agno_namespace(name)!r}")
 
     # 2. Single conversion.
     print("\n[2] Single tool conversion:")

--- a/examples/architectures/mcp_context_gateway/main_multi.py
+++ b/examples/architectures/mcp_context_gateway/main_multi.py
@@ -92,7 +92,7 @@ TRANSCRIPT: list[tuple[str, str, str, dict[str, Any], dict[str, Any]]] = [
                 {
                     "type": "text",
                     "text": (
-                        "ticket TKT-742 — 'Self-serve downgrade for C-12345 (Growth → "
+                        "ticket TKT-742 — 'Self-serve downgrade for C-12345 (Growth -> "
                         "Starter)'\nstatus: closed\nowner: alice@example.com\n"
                         "closed_at: 2026-03-18T17:42Z\nlink: https://linear.app/ops/issue/TKT-742"
                     ),

--- a/examples/architectures/mcp_context_gateway/main_real.py
+++ b/examples/architectures/mcp_context_gateway/main_real.py
@@ -203,8 +203,8 @@ def main() -> None:
 
     _print_header("Real-catalog scenarios complete")
     print(
-        "All three real-catalog scenarios walked the same route → call → "
-        "interpret → answer cycle that the offline 60-tool architecture uses. "
+        "All three real-catalog scenarios walked the same route -> call -> "
+        "interpret -> answer cycle that the offline 60-tool architecture uses. "
         "No catalog modifications were needed — the existing routing engine, "
         "schema-hydration helper (#261), and context firewall handle the real "
         "wire shape verbatim."

--- a/examples/cookbook/byot_recipe.py
+++ b/examples/cookbook/byot_recipe.py
@@ -30,22 +30,22 @@ from contextweaver.types import ContextItem, ItemKind, Phase, SelectableItem
 
 def web_search(query: str) -> str:
     """Search the public web for *query* and return a short text summary."""
-    return f"web_search({query!r}) → 3 results: example.com, docs.example.com, blog.example.com"
+    return f"web_search({query!r}) -> 3 results: example.com, docs.example.com, blog.example.com"
 
 
 def db_query(sql: str) -> str:
     """Execute a read-only SQL query and return the result rows as JSON."""
-    return f"db_query({sql!r}) → 2 rows"
+    return f"db_query({sql!r}) -> 2 rows"
 
 
 def send_email(to: str, subject: str, body: str) -> str:
     """Send an email to *to* with *subject* and *body*."""
-    return f"send_email(to={to!r}, subject={subject!r}) → ok"
+    return f"send_email(to={to!r}, subject={subject!r}) -> ok"
 
 
 def schedule_meeting(participants: str, when: str) -> str:
     """Schedule a calendar meeting between *participants* at *when*."""
-    return f"schedule_meeting(participants={participants!r}, when={when!r}) → ok"
+    return f"schedule_meeting(participants={participants!r}, when={when!r}) -> ok"
 
 
 TOOLS: dict[str, Callable[..., str]] = {

--- a/examples/crewai_adapter_demo.py
+++ b/examples/crewai_adapter_demo.py
@@ -73,7 +73,7 @@ def main() -> None:
     # 1. Namespace inference picks the prefix before the first ``_`` / ``.``.
     print("[1] Namespace inference:")
     for name in ("github_search_repos", "slack_send_message", "calendar.create_event"):
-        print(f"    {name!r:30s} → namespace={infer_crewai_namespace(name)!r}")
+        print(f"    {name!r:30s} -> namespace={infer_crewai_namespace(name)!r}")
 
     # 2. Single conversion.
     print("\n[2] Single tool conversion:")

--- a/examples/fastmcp_adapter_demo.py
+++ b/examples/fastmcp_adapter_demo.py
@@ -75,7 +75,7 @@ def main() -> None:
     print("[1] Namespace inference:")
     for name in ["github_search_repos", "slack_send_message", "db_query", "search"]:
         ns = infer_fastmcp_namespace(name)
-        print(f"    {name!r:30s} → namespace={ns!r}")
+        print(f"    {name!r:30s} -> namespace={ns!r}")
 
     # 2. Single tool conversion
     print("\n[2] Single tool conversion:")

--- a/examples/mcp_proxy_demo.py
+++ b/examples/mcp_proxy_demo.py
@@ -95,7 +95,7 @@ async def main() -> int:
         {"name": "tool_execute", "arguments": {"tool_id": tool_id, "args": {}}},
     )
     bad_body = json.loads(bad["content"][0]["text"])
-    print(f"      missing path → error={bad_body['error']}, message={bad_body['message'][:50]}")
+    print(f"      missing path -> error={bad_body['error']}, message={bad_body['message'][:50]}")
 
     print("\n[4/4] tool_execute happy path:")
     ok = await dispatch_proxy_request(

--- a/examples/pydantic_ai_adapter_demo.py
+++ b/examples/pydantic_ai_adapter_demo.py
@@ -133,7 +133,7 @@ def main() -> None:
         "calendar.create_event",
         "weather_get_forecast",
     ):
-        print(f"    {name!r:30s} → namespace={infer_pydantic_ai_namespace(name)!r}")
+        print(f"    {name!r:30s} -> namespace={infer_pydantic_ai_namespace(name)!r}")
 
     # 2. Single conversion.
     print("\n[2] Single tool conversion:")

--- a/examples/smolagents_adapter_demo.py
+++ b/examples/smolagents_adapter_demo.py
@@ -112,7 +112,7 @@ def main() -> None:
     # 1. Namespace inference.
     print("[1] Namespace inference:")
     for name in ("web_search", "image_generator", "final_answer"):
-        print(f"    {name!r:25s} → namespace={infer_smolagents_namespace(name)!r}")
+        print(f"    {name!r:25s} -> namespace={infer_smolagents_namespace(name)!r}")
 
     # 2. Single conversion.
     print("\n[2] Single tool conversion:")

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -35,11 +35,24 @@
 [![Docs](https://img.shields.io/badge/docs-mkdocs--material-blue.svg)](https://dgenio.github.io/contextweaver)
 [![GitHub Discussions](https://img.shields.io/github/discussions/dgenio/contextweaver)](https://github.com/dgenio/contextweaver/discussions)
 
-> **Context firewall + tool router for tool-heavy AI agents.** Phase-specific,
-> budget-aware **context engineering** with a deterministic core — large tool
-> outputs stay out of the prompt, large catalogs collapse to a few
-> `ChoiceCard`s, and your token bill drops 42–75 % on the committed
-> benchmarks.
+> **Context firewall + tool router for MCP and tool-heavy agents.** Keep huge
+> tool catalogs, tool schemas, tool results, and long histories out of the
+> prompt without losing the context your agent needs. Phase-specific,
+> budget-aware **context engineering** with a deterministic core: large
+> catalogs collapse to a few `ChoiceCard`s, large outputs stay artifact-backed,
+> and prompt tokens drop 42-84 % on the committed benchmarks.
+
+| If your agent has... | contextweaver gives you... |
+|---|---|
+| Too many MCP / FastMCP / Python tools | A bounded `ChoiceCard` shortlist instead of dumping every schema into the route prompt. |
+| Huge JSON, logs, tables, or binary tool results | An artifact-backed context firewall: compact summary in the prompt, raw bytes out of band. |
+| Long tool-using conversations | Phase-specific context packs with budgeted selection and dependency closure. |
+
+| Use this when... | Do not use this when... |
+|---|---|
+| You already have an agent loop and need runtime context control. | You need an agent framework, LLM SDK, or tool executor. |
+| Your model-visible tool list or tool-result payloads are getting too large. | Your agent has a handful of tiny tools and no context-budget pressure. |
+| You want deterministic prompt budgeting and traceable drops. | You only need long-term memory, RAG, or observability by itself. |
 
 <p align="center">
   <img src="docs/assets/hero.svg" alt="contextweaver architecture: Context Engine plus Routing Engine, with the Context Firewall storing large tool outputs out of band and the Routing Engine narrowing a 100-tool catalog to 5 ChoiceCards."/>
@@ -60,7 +73,7 @@ python -m contextweaver demo     # 5-step end-to-end demo
   <img src="docs/assets/before_after.svg" alt="Before vs after token comparison from examples/before_after.py: 417 raw prompt tokens without contextweaver vs 126 final prompt tokens with contextweaver — a 70 percent reduction, 291 tokens saved, budget compliant."/>
 </p>
 
-[📖 Documentation](https://dgenio.github.io/contextweaver) · [🧭 Which pattern fits my use case?](docs/which_pattern.md) · [📊 Benchmark scorecard](benchmarks/scorecard.md) · [🎬 Replay demo (.cast)](docs/assets/demo.cast)
+[📖 Documentation](https://dgenio.github.io/contextweaver) · [🧭 Which pattern fits my use case?](docs/which_pattern.md) · [📊 Adopter benchmark report](docs/benchmark_report.md) · [🗺️ Ecosystem map](docs/ecosystem.md) · [🎬 Replay demo (.cast)](docs/assets/demo.cast)
 
 ---
 
@@ -101,12 +114,12 @@ Agent hallucinates tool calls, repeats questions, forgets context
 Route phase:  5 tool cards (≈500 tokens), no full schemas
 Answer phase: 3 relevant turns + dependency closure (≈2k tokens)
 Result:       2.5k tokens, complete context, deterministic
-Cost:         41.6%–74.5% fewer prompt tokens [^naive-baseline]  ·  Latency: sub-second  ·  Quality: relevant context only
+Cost:         41.6 %-84.3 % fewer prompt tokens [^naive-baseline]  ·  Latency: sub-second  ·  Quality: relevant context only
 ```
 
 [^naive-baseline]: Measured against the "concatenate all tool schemas + full
-    conversation history" baseline using `tiktoken.cl100k_base` on the four
-    committed benchmark scenarios. Range 41.6 %–74.5 %, average 55.8 %.
+    conversation history" baseline using `tiktoken.cl100k_base` on the six
+    committed benchmark scenarios. Range 41.6 %-84.3 %, average 64.3 %.
     Reproducible via `make benchmark-matrix && make scorecard` — see the
     *vs. naïve concat baseline* section of
     [`benchmarks/scorecard.md`](benchmarks/scorecard.md) and the
@@ -164,15 +177,16 @@ contextweaver provides two cooperating engines:
 pip install contextweaver
 ```
 
-`contextweaver` ships with a minimal, opinionated core: `tiktoken`,
-`PyYAML`, and `rank-bm25`. These power accurate token budgeting, YAML
-catalog/config files, and the default lexical retrieval backend.
+`contextweaver` ships with a small, opinionated core: `tiktoken`,
+`PyYAML`, `rank-bm25`, `mcp`, `jsonschema`, `typer`, and `rich`. These power
+accurate token budgeting, YAML catalog/config files, the default lexical
+retrieval backend, MCP gateway/proxy surfaces, schema validation, and the CLI.
 
 Optional capabilities are gated behind extras so the core install stays small:
 
 | Extra | What it adds |
 |---|---|
-| `contextweaver[cli]` | Rich-formatted CLI rendering (rich) |
+| `contextweaver[cli]` | Deprecated no-op alias; Typer/Rich now ship in core |
 | `contextweaver[retrieval]` | Fuzzy lexical matching backend (rapidfuzz) |
 | `contextweaver[otel]` | OpenTelemetry tracing + metrics export |
 | `contextweaver[ann]` | Approximate-nearest-neighbour backend (reserved) |
@@ -319,9 +333,10 @@ contextweaver is built for production use with comprehensive quality gates:
   produce identical outputs. Configurable retrieval backends (TF-IDF, BM25, fuzzy)
   preserve determinism within each mode.
 - **Public benchmark scorecard** — top-k recall, token savings, and routing latency at
-  catalog sizes 50 / 83 / 1000, plus context pipeline metrics across three reference
+  catalog sizes 50 / 83 / 1000, plus context pipeline metrics across six reference
   scenarios. See [`benchmarks/scorecard.md`](benchmarks/scorecard.md) (regenerate with
-  `make scorecard`).
+  `make scorecard`) and the adopter-facing
+  [`benchmark report`](docs/benchmark_report.md).
 
 Run the full suite yourself:
 
@@ -382,9 +397,9 @@ ChainWeaver, agent-kernel):
   (the source the gate fetches; the same documents are also published at
   `https://weaver-spec.dev/contracts/v0/`)
 
-> contextweaver is positioned to become the standard context management layer for AI agents.
-> Supporting MCP, A2A, and weaver-spec now means your codebase is future-proof as these
-> protocols mature and gain wider adoption.
+> contextweaver is designed as a protocol-friendly context management layer for
+> tool-using agents. Supporting MCP, A2A, and weaver-spec keeps the integration
+> boundary explicit as these protocols mature.
 
 - [MCP Integration](docs/integration_mcp.md)
 - [A2A Integration](docs/integration_a2a.md)
@@ -417,24 +432,24 @@ contextweaver works with any LLM provider and any agent framework:
 > You are not locked into a specific framework or LLM provider. contextweaver is a layer
 > *beneath* frameworks — context management as a composable primitive.
 
-### 5. Versioning & Compatibility
+### 5. Stability & Compatibility
 
-contextweaver follows [Semantic Versioning](https://semver.org/):
+contextweaver is currently **Alpha** in package metadata because the project is
+still clarifying its pre-1.0 stability boundary. The core context/routing APIs
+are intentionally deterministic and heavily tested; newer runtime surfaces such
+as gateway commands, adapters, and extras are called out as experimental where
+appropriate. See the detailed [stability and 1.0 readiness checklist](docs/stability.md).
 
-- **Breaking changes** to public APIs only in major versions
-- **Deprecation policy**: deprecated public APIs are warned for at least one minor version and removed only in a later major release
-- **API stability**: public APIs in `contextweaver.*` are stable; internal `_*` modules may change
-- **Python support**: 3.10+ (aligned with Python's active security support lifecycle)
-
-| Version | Status | Notes |
+| Surface | Current promise | Notes |
 |---|---|---|
-| **0.1.x** | ✅ Current | Foundation engines (context + routing), MCP/A2A adapters, CLI, sensitivity |
-| **0.2.0** | 🚧 In progress (Q2 2026) | Framework integration guides, benchmark suite, distributed stores |
-| **0.3.0** | 📋 Planned (Q3 2026) | DAG visualization, merge compression, LLM-assisted labeler |
-| **1.0.0** | 📋 Planned (Q4 2026) | API freeze, production benchmarks, enterprise features |
+| Documented public APIs | Change deliberately, with changelog/migration notes when behavior changes. | Dataclasses, stores, context/routing APIs, and documented adapters. |
+| Experimental runtime surfaces | May change before 1.0. | MCP gateway/proxy commands, newer optional extras, and reference architecture variants. |
+| Internal modules | No compatibility promise. | Modules beginning with `_` and test helpers are implementation details. |
+| Python support | Python 3.10+. | Aligned with the package metadata and CI matrix. |
 
-> Adopting a library is a long-term commitment. contextweaver's versioning policy ensures you
-> can upgrade safely, and the roadmap shows where it's headed.
+> Adopting a library is a long-term commitment. The stability page makes the
+> Alpha/Beta/1.0 line explicit so teams can decide which surfaces are ready for
+> their risk tolerance.
 
 #### Weaver Spec Compatibility
 
@@ -471,32 +486,17 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 
 ### 6. Roadmap & Community
 
-**v0.1 (✅ Complete)**
+Current package version: **0.10.0**.
 
-- Context Engine: 8-stage pipeline (candidates → closure → sensitivity → firewall → score → dedup → select → render)
-- Routing Engine: Catalog, DAG builder, beam-search router, choice cards
-- Protocol adapters: MCP (full content types, structured content, output schemas) and A2A
-- Stores: `EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore` with protocol-based interfaces
-- 1100+ passing tests, mypy strict, ruff clean, minimal core dependencies
+Recent milestones:
 
-**v0.2 (🚧 In Progress — Q2 2026)**
-
-- Framework integration guides: LlamaIndex, LangChain, LangGraph, OpenAI Agents SDK, Google ADK, Pipecat
-- Benchmark suite: token reduction, latency, and accuracy vs. naive concatenation
-- Distributed stores: Redis-backed `EventLog`, S3-backed `ArtifactStore`
-
-**v0.3 (📋 Planned — Q3 2026)**
-
-- DAG visualization: interactive routing graph inspector
-- Merge compression: deduplicate similar tool results across turns
-- LLM-based labeler: auto-generate namespace labels for tool catalogs
-- LLM-based extractor: structured fact extraction with prompt-based schema
-
-**v1.0 (📋 Planned — Q4 2026)**
-
-- API freeze: no breaking changes in 1.x releases
-- Production benchmarks: 1M+ turn deployments
-- Enterprise features: audit logging, compliance tags, PII redaction
+| Milestone | Status | Highlights |
+|---|---|---|
+| **v0.8** | ✅ complete | CrewAI adapter Phase 1, Mem0 external-memory backend, provider-SDK-leak tests |
+| **v0.9** | ✅ complete | Provider message adapters, cache-stable routing, launch polish |
+| **v0.10** | ✅ complete | `contextweaver mcp serve`, MCP Context Gateway architecture, gateway benchmark suite, route/context explanations |
+| **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
+| **v1.0** | 📋 planned | API freeze, documented deprecation policy, long-term compatibility window |
 
 **Community:**
 
@@ -504,8 +504,10 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 - [GitHub Issues](https://github.com/dgenio/contextweaver/issues) — report bugs, request features
 - [CHANGELOG](CHANGELOG.md) — track every release
 
-> contextweaver is under active development with a clear roadmap. v0.1 is feature-complete
-> for basic use cases; v0.2 adds production-ready integrations; v1.0 is the API stability milestone.
+> contextweaver is under active development with a clear roadmap. The core is
+> usable today; the project remains Alpha until the
+> [Beta readiness checklist](docs/stability.md#beta-readiness-checklist) is
+> complete or intentionally revised.
 
 ### Comparison
 
@@ -515,14 +517,14 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 
 | Approach | Tool routing | History compaction | Sensitivity firewall | Deterministic | MCP-native |
 |---|---|---|---|---|---|
-| **contextweaver** (this repo, [v0.9.0](https://pypi.org/project/contextweaver/0.9.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42–75 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
+| **contextweaver** (this repo, [v0.10.0](https://pypi.org/project/contextweaver/0.10.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42-84 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
 | **Naïve concat-everything** | ❌ No router · prompt carries every tool schema | ❌ No compaction · prompt grows with turn count | ❌ Raw outputs in the prompt | ⚠️ Only if the upstream LLM is | ⚠️ Compatible but no shaping |
 | **LangGraph memory** ([0.6.x](https://github.com/langchain-ai/langgraph/releases)) | ❌ Out of scope — LangGraph routes state, not tools | ⚠️ Optional via `ConversationSummaryMemory` (LLM-based, non-deterministic) [^lg-mem] | ❌ Not provided | ⚠️ Workflow yes; memory summarizer no | ⚠️ Possible via custom adapter, not first-class |
 | **LlamaIndex retrievers** ([0.11.x](https://github.com/run-llama/llama_index/releases)) | ⚠️ Tool retrieval via `ObjectIndex` is unranked similarity, no bounded routing | ⚠️ `ChatMemoryBuffer` token-bounded · no phase awareness [^li-mem] | ❌ Not provided · large outputs flow through verbatim | ⚠️ Retriever yes; summarizer no | ⚠️ Possible via custom tool wrapper |
 | **Raw MCP** ([modelcontextprotocol v0.1](https://modelcontextprotocol.io)) | ❌ Servers expose tools; routing across many servers is the client's problem | ❌ Out of scope for the protocol | ❌ Out of scope for the protocol | ✅ Wire protocol is deterministic | ✅ — _is_ the protocol |
 
 [^cw-route]: `contextweaver.routing.router.Router` ships a four-stage pipeline (`retrieve → rerank → navigate → pack`) with deterministic tie-break by `id`. Locked by `tests/test_cards.py::test_make_choice_cards_byte_identical_stable_order`.
-[^cw-bench]: Range from the committed scorecard ([`benchmarks/scorecard.md`](benchmarks/scorecard.md)) using `tiktoken.cl100k_base` against the naïve baseline ([`scripts/baseline_naive.py`](scripts/baseline_naive.py)). Average 55.8 %; min 41.6 % on the smallest scenario; max 74.5 % on `stress_conversation.jsonl`.
+[^cw-bench]: Range from the committed scorecard ([`benchmarks/scorecard.md`](benchmarks/scorecard.md)) using `tiktoken.cl100k_base` against the naïve baseline ([`scripts/baseline_naive.py`](scripts/baseline_naive.py)). Average 64.3 %; min 41.6 % on `long_conversation.jsonl`; max 84.3 % on `tiny_payload.jsonl`.
 [^cw-fire]: `contextweaver.context.firewall.apply_firewall` plus `ArtifactRef` drilldown selectors (`head` / `lines` / `json_keys` / `rows`). See [`docs/context_firewall.md`](docs/context_firewall.md) and the [`firewall_drilldown_recipe`](examples/cookbook/firewall_drilldown_recipe.py).
 [^cw-det]: Determinism is an invariant — see `docs/agent-context/invariants.md` and `make scorecard-check` in the CI gate.
 [^cw-mcp]: `src/contextweaver/adapters/mcp_proxy.py`, `mcp_gateway.py`, `mcp_proxy_server.py`, `mcp_gateway_server.py`. Bound by `docs/gateway_spec.md`.
@@ -639,8 +641,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions.
 | **v0.6 — Adopter surface** (2026-05-17) | ✅ complete | Typer + Rich CLI rewrite, OTel GenAI semconv, provider message adapters (OpenAI / Anthropic / Gemini), 5-line adoption snippet |
 | **v0.7 — Reference architectures + routing pipeline** (2026-05-18) | ✅ complete | Explicit routing pipeline, embedding backend, history-aware routing, code-review bot + voice agent architectures, FastMCP CodeMode hooks |
 | **v0.8 — CrewAI + Mem0** (2026-05-19) | ✅ complete | CrewAI adapter (Phase 1), Mem0 external-memory backend, provider-SDK-leak invariant tests |
-| **v0.9 — Launch polish + adapters** (2026-05) | 🚧 in progress | `contextweaver mcp serve` CLI, full MCP Context Gateway architecture, CrewAI/Pydantic AI/smolagents/Agno adapter Phase 2 |
-| **v1.0 — API stability** | 📋 planned | API freeze, semantic-versioning commitment, long-term support window |
+| **v0.9 — Launch polish + adapters** (2026-05) | ✅ complete | Provider message adapters, cache-stable routing, launch polish |
+| **v0.10 — MCP gateway runtime + audit surfaces** (2026-05) | ✅ complete | `contextweaver mcp serve`, full MCP Context Gateway architecture, gateway benchmark suite, route/context explanations |
+| **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
+| **v1.0 — API stability** | 📋 planned | API freeze, documented deprecation policy, long-term compatibility window |
 | **Future** | 📋 planned | DAG visualization, LLM-assisted labeler, distributed stores, multi-agent coordination |
 
 See [CHANGELOG.md](CHANGELOG.md) for the detailed release history.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -539,7 +539,7 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 
 ### 6. Roadmap & Community
 
-Current package version: **0.10.0**.
+Current package version: **0.11.0**.
 
 Recent milestones:
 
@@ -548,6 +548,7 @@ Recent milestones:
 | **v0.8** | ✅ complete | CrewAI adapter Phase 1, Mem0 external-memory backend, provider-SDK-leak tests |
 | **v0.9** | ✅ complete | Provider message adapters, cache-stable routing, launch polish |
 | **v0.10** | ✅ complete | `contextweaver mcp serve`, MCP Context Gateway architecture, gateway benchmark suite, route/context explanations |
+| **v0.11** | ✅ complete | Memory-source adapter interface, session-handoff context pack, "when not to use" guidance |
 | **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
 | **v1.0** | 📋 planned | API freeze, documented deprecation policy, long-term compatibility window |
 
@@ -708,7 +709,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions.
 | **v0.7 — Reference architectures + routing pipeline** (2026-05-18) | ✅ complete | Explicit routing pipeline, embedding backend, history-aware routing, code-review bot + voice agent architectures, FastMCP CodeMode hooks |
 | **v0.8 — CrewAI + Mem0** (2026-05-19) | ✅ complete | CrewAI adapter (Phase 1), Mem0 external-memory backend, provider-SDK-leak invariant tests |
 | **v0.9 — Launch polish + adapters** (2026-05-20) | ✅ complete | Budget checks, provider adapters, benchmark transparency suite, launch polish |
-| **v0.10 — MCP serve + gateway polish** (2026-05-22) | ✅ current | `contextweaver mcp serve`, schema hydration helpers, full MCP Context Gateway demos, context-build explanations |
+| **v0.10 — MCP serve + gateway polish** (2026-05-22) | ✅ complete | `contextweaver mcp serve`, schema hydration helpers, full MCP Context Gateway demos, context-build explanations |
+| **v0.11 — Memory source + session handoff** (2026-05-27) | ✅ current | `MemorySource` protocol + `JsonFixtureMemorySource`, session-handoff context pack, "when not to use" section |
 | **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
 | **v1.0 — API stability** | 📋 planned | API freeze, semantic-versioning commitment, long-term support window |
 | **Future** | 📋 planned | DAG visualization, LLM-assisted labeler, distributed stores, multi-agent coordination |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: contextweaver
 site_url: https://dgenio.github.io/contextweaver
 site_description: >-
-  Phase-specific, budget-aware context engineering for tool-using AI agents.
-  Minimal core dependencies. Python ≥ 3.10.
+  Context firewall + tool router for MCP and tool-heavy AI agents.
+  Phase-specific, budget-aware context engineering. Python ≥ 3.10.
 
 repo_url: https://github.com/dgenio/contextweaver
 repo_name: dgenio/contextweaver
@@ -64,6 +64,7 @@ nav:
   - Quickstart: quickstart.md
   - Showcase: showcase.md
   - Where it fits: comparison.md
+  - Ecosystem Map: ecosystem.md
   - FAQ: faq.md
   - Which pattern fits?: which_pattern.md
   - Context Firewall: context_firewall.md
@@ -91,6 +92,9 @@ nav:
       - External Memory: integration_memory.md
   - Architecture: architecture.md
   - Benchmarks: benchmarks.md
+  - Adopter Benchmark Report: benchmark_report.md
+  - Stability: stability.md
+  - Launch Kit: launch_kit.md
   - Contracts: contracts.md
   - Observability: integration_otel.md
   - Troubleshooting: troubleshooting.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "contextweaver"
 version = "0.10.0"
-description = "Dynamic context management for tool-using AI agents"
+description = "Context firewall + tool router for MCP and tool-heavy AI agents"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
@@ -18,7 +18,12 @@ keywords = [
     "llm",
     "tools",
     "tool-routing",
+    "tool-heavy-agents",
     "mcp",
+    "mcp-gateway",
+    "context-firewall",
+    "tool-result-firewall",
+    "choicecards",
     "prompt-budgeting",
     "agent-infrastructure",
     "routing",


### PR DESCRIPTION
## Summary

Sharpen the public adopter positioning around contextweaver as the context firewall + tool router for MCP and tool-heavy agents.

Fixes #321
Fixes #323
Fixes #324
Fixes #327
Fixes #328
Fixes #329

## Changes

- `README.md` — sharpened the first-screen category, added quick problem and use-fit tables, refreshed benchmark ranges, and aligned maturity/roadmap language with v0.10.
- `pyproject.toml`, `mkdocs.yml`, `docs/index.md`, `docs/assets/hero.svg` — aligned PyPI/site/docs/hero positioning language and discovery keywords.
- `docs/benchmark_report.md` — added adopter-facing cost, prompt-size, latency, routing-quality, failure-mode, and reproduction framing backed by committed scorecard data.
- `docs/ecosystem.md` — added an adopter-facing comparison and decision matrix for agent frameworks, MCP/FastMCP, memory, RAG, observability, and model SDKs.
- `docs/stability.md` — documented Alpha/Beta/1.0 readiness, stability levels, deprecation expectations, and release messaging guardrails.
- `docs/launch_kit.md`, `docs/faq.md`, `CONTRIBUTING.md` — added reusable public copy, asset links, responsible-claims checklist, and neutral naming-collision guidance.
- `docs/benchmarks.md`, `docs/comparison.md`, `CHANGELOG.md`, `llms-full.txt` — linked the new docs surfaces and refreshed generated machine-readable docs.
- `examples/*` — normalized a few runnable example output strings from Unicode arrows to ASCII arrows so the Makefile example suite runs on Windows cp1252 consoles.

## Checklist

- [x] Tests added or updated for every new/changed public function (N/A: docs/example-output-only; no public API changes)
- [x] `make ci` passes locally (Windows note: `make` is unavailable on PATH; ran the underlying Makefile commands individually, including lint, type, tests, schemas, examples, and demo)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docstrings added for all new public APIs (N/A: no public APIs)
- [x] Every modified module stays ≤ 300 lines (N/A: no source modules changed; example string-only edits)
- [x] Related issue linked in the summary above
- [x] Agent-facing docs updated if pipeline, API, or conventions changed (N/A: no pipeline/API/convention changes)

## Notes for reviewers

This intentionally keeps the package classifier at Alpha and documents the Beta gates instead of promoting maturity in the same PR. The benchmark cost math uses an illustrative bring-your-own-price formula rather than named provider pricing so it does not become stale.

## Reproducibility (scoring / context-pipeline changes)

N/A. This PR does not change routing, scoring, tokenisation, or the context pipeline. It packages existing benchmark data for adopters.

## What changed

- Added dedicated adopter docs for benchmarks, ecosystem positioning, stability/readiness, and launch copy.
- Updated first-screen README/docs/PyPI language to the canonical subtitle: context firewall + tool router for MCP and tool-heavy agents.
- Reused existing committed assets and scorecard data rather than adding fake launch visuals or new benchmark claims.
- Fixed Windows console-safe example output discovered while running the example gate.

## Why

The issue group asks for a clearer top-of-funnel story: who contextweaver is for, when it is unnecessary, what evidence supports the claims, and how it compares with adjacent ecosystem categories. The implementation keeps the existing honest framing: contextweaver does not replace MCP, agent frameworks, memory systems, RAG, observability, or model SDKs.

## How verified

- `git diff --check` — clean
- `.\.venv\Scripts\python.exe -m ruff format --check src/ tests/ examples/ scripts/` — 216 files already formatted
- `.\.venv\Scripts\python.exe -m ruff check src/ tests/ examples/ scripts/` — all checks passed
- `.\.venv\Scripts\python.exe -m mypy src/` — success, 93 source files
- `.\.venv\Scripts\python.exe -m pytest --cov=contextweaver --cov-report=term-missing -q` — 1531 passed, 35 skipped
- `.\.venv\Scripts\python.exe scripts\gen_schemas.py --check` — schemas up to date
- `.\.venv\Scripts\python.exe scripts\gen_llms.py --check` — llms files up to date
- `.\.venv\Scripts\python.exe -m mkdocs build --clean` — built successfully in 143.46s; only pre-existing docs link warnings remain
- Manual Makefile `example` equivalent — all listed example and architecture scripts completed successfully on Windows
- `.\.venv\Scripts\python.exe -m contextweaver demo` — demo complete
- `.\.venv\Scripts\python.exe -m pytest tests\test_architectures_mcp_context_gateway_multi.py tests\test_architectures_mcp_context_gateway_real.py -q` — 15 passed

## Tradeoffs / risks

- The PR is intentionally broad because the issues form one positioning cluster; the new detail lives in separate docs pages to keep README churn controlled.
- The stability page references live issue numbers, which is useful for release planning but will need maintenance as blockers close.
- The cost examples are illustrative input-token estimates, not provider-specific pricing or end-to-end production cost claims.

## Scope notes (Mode B)

Scope covers all six requested positioning/readiness/launch issues in one owner-mode PR. Adjacent memory-system deepening (#282) is not bundled; the new ecosystem page links to existing memory docs and #195 without taking over that contributor-scoped issue.