### PR TITLE
docs: code of conduct, contribution paths, skill-card interop, and safety-gate cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Community & interop docs** — `CODE_OF_CONDUCT.md` (Contributor Covenant
+  2.1) for the GitHub community-standards check (#249); a contributor landing
+  page `docs/contributing_paths.md` mapping time-boxed contribution paths to
+  files, commands, and labels (#325); a cookbook recipe documenting a
+  post-generation safety gate for agent-generated diffs, with no runtime
+  dependency (#332); and `docs/interop_skill_cards.md` mapping a reviewed skill
+  card onto a `ContextItem` with matching / non-matching examples (#333).
 - **Adopter positioning docs** — new adopter-facing benchmark report,
   ecosystem comparison map, stability / Beta / 1.0 readiness checklist, and
   launch kit for reusable public copy and asset links. Issues #323, #324,

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at diogofcul@hotmail.com (project maintainer). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,9 @@ instead.
 
 ## Where to start
 
+- **Not sure where to help?** [`docs/contributing_paths.md`](docs/contributing_paths.md)
+  maps concrete contribution paths (docs, adapters, benchmarks, examples,
+  good-first-issues, AI-assisted work) to the right files, commands, and labels.
 - **First time?** Look for issues labelled
   [`good first issue`](https://github.com/dgenio/contextweaver/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
   These are scoped, well-defined, and don't require deep architectural
@@ -255,3 +258,11 @@ Common labels you will see:
 
 If you want to claim a `good first issue`, comment on the issue first
 so it can be assigned to you — that avoids duplicate work.
+
+## Code of Conduct
+
+This project follows the
+[Contributor Covenant](https://www.contributor-covenant.org) v2.1. By
+participating you agree to uphold it — see
+[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) for the full text and how to report
+unacceptable behaviour.

--- a/README.md
+++ b/README.md
@@ -664,7 +664,10 @@ make demo     # run the built-in demo
 make ci       # all of the above
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, and
+[docs/contributing_paths.md](docs/contributing_paths.md) to pick a contribution
+path (docs, adapters, benchmarks, examples, good-first-issues) by how much time
+you have. All contributors agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ---
 

--- a/docs/contributing_paths.md
+++ b/docs/contributing_paths.md
@@ -54,7 +54,7 @@ or framework. The full checklist is in
 In short:
 
 1. Implement `src/contextweaver/adapters/<name>.py` using the
-   `from_<protocol>(...) -> ContextManager` / `to_<protocol>(pack) -> payload`
+   `from_<protocol>(..., into=...) -> list[ContextItem]` / `to_<protocol>(items) -> payload`
    convention.
 2. Re-export the public surface from `adapters/__init__.py`.
 3. Add `tests/test_adapters_<name>.py` covering both directions (round-trip

--- a/docs/contributing_paths.md
+++ b/docs/contributing_paths.md
@@ -1,0 +1,129 @@
+# Contribution Paths
+
+> Where can I help in 30 minutes, half a day, or one weekend?
+>
+> [`CONTRIBUTING.md`](https://github.com/dgenio/contextweaver/blob/main/CONTRIBUTING.md)
+> is the full setup-and-style reference. This page is the shortcut: pick the
+> kind of help you want to give and jump straight to the relevant section,
+> commands, and issue labels — without reading the whole repo first.
+
+Every path below runs the same validation gate. Confirm your environment is
+healthy before you start:
+
+```bash
+pip install -e ".[dev]"
+make ci        # fmt + lint + type + test + schemas-check + example + demo
+```
+
+## Pick your path
+
+| I want to… | Time | Start here | Issue labels |
+|---|---|---|---|
+| Improve docs | 30 min | [Docs](#i-want-to-improve-docs) | `documentation`, `good first issue` |
+| Add an adapter | 1 weekend | [Adapters](#i-want-to-add-an-adapter) | `enhancement`, `area/adapters` |
+| Add a benchmark scenario | half a day | [Benchmarks](#i-want-to-add-a-benchmark-scenario) | `area/eval` |
+| Improve adoption / growth | half a day | [Adoption](#i-want-to-improve-adoption-growth) | `documentation`, `enhancement` |
+| Grab a good first issue | 30 min–½ day | [Good first issue](#i-want-a-good-first-issue) | `good first issue` |
+| Drive it with an AI assistant | any | [AI assistant](#i-am-using-an-ai-coding-assistant) | `agent-friendly` |
+
+## I want to improve docs
+
+The lowest-friction way in. Docs live under [`docs/`](https://github.com/dgenio/contextweaver/tree/main/docs)
+and the site is built with `make docs` (preview with `make docs-serve` at
+<http://127.0.0.1:8000>).
+
+- **README clarity** — tighten [`README.md`](https://github.com/dgenio/contextweaver/blob/main/README.md);
+  the first screen is the category pitch.
+- **Recipes** — add a copy-paste pattern to the [Cookbook](cookbook.md). Each
+  recipe is runnable core-only code, so it does not bitrot.
+- **Integration pages** — `docs/integration_<framework>.md` explains wiring a
+  specific runtime. Use an existing page (e.g. [MCP](integration_mcp.md)) as a
+  template.
+- **Troubleshooting examples** — extend [`docs/troubleshooting.md`](troubleshooting.md)
+  with a concrete failure you hit and how you fixed it.
+
+New pages must be added to the `nav:` block in
+[`mkdocs.yml`](https://github.com/dgenio/contextweaver/blob/main/mkdocs.yml).
+Look for the `documentation` and `good first issue` labels.
+
+## I want to add an adapter
+
+Adapters convert between contextweaver's domain types and an external protocol
+or framework. The full checklist is in
+[CONTRIBUTING § Adding a new adapter](https://github.com/dgenio/contextweaver/blob/main/CONTRIBUTING.md#adding-a-new-adapter).
+In short:
+
+1. Implement `src/contextweaver/adapters/<name>.py` using the
+   `from_<protocol>(...) -> ContextManager` / `to_<protocol>(pack) -> payload`
+   convention.
+2. Re-export the public surface from `adapters/__init__.py`.
+3. Add `tests/test_adapters_<name>.py` covering both directions (round-trip
+   where applicable).
+4. Add a worked `examples/<name>_adapter_demo.py` and wire it into the
+   `example:` target in the `Makefile`.
+5. Add `docs/integration_<name>.md` and a row to the interop matrix in
+   [How contextweaver Fits](interop.md).
+6. **Never import the third-party SDK at module load** — use guarded imports
+   and put heavy dependencies under `[project.optional-dependencies]`.
+
+## I want to add a benchmark scenario
+
+The committed scorecard at `benchmarks/scorecard.md` is regenerated
+deterministically. Adding a scenario extends the gold dataset it reports on —
+see [CONTRIBUTING § Adding a new benchmark scenario](https://github.com/dgenio/contextweaver/blob/main/CONTRIBUTING.md#adding-a-new-benchmark-scenario)
+and [`docs/benchmarks.md`](benchmarks.md) "Known limits" for gaps worth
+measuring.
+
+1. Drop a JSONL file under `benchmarks/scenarios/` (one `ContextItem`-shaped
+   event per line).
+2. Target a **specific behaviour** the scorecard does not yet capture.
+3. Run `make benchmark-matrix && make scorecard` to regenerate, and commit both
+   `benchmarks/scorecard.md` and `benchmarks/results/latest.json`.
+
+## I want to improve adoption / growth
+
+Help adopters say "yes" faster.
+
+- **Examples** — add a deterministic, network-free script under `examples/`
+  (see [CONTRIBUTING § Adding a new example script](https://github.com/dgenio/contextweaver/blob/main/CONTRIBUTING.md#adding-a-new-example-script))
+  and a row to the *Examples* table in `README.md`.
+- **Demo assets** — the `contextweaver demo` scenarios power README and docs
+  hero content.
+- **Comparison pages** — sharpen [Where it fits](comparison.md) and the
+  [Ecosystem Map](ecosystem.md) so readers can place contextweaver in their
+  stack.
+- **Honest limitations** — the [Launch Kit](launch_kit.md) sets the
+  responsible-claims guardrails; keep new copy inside them.
+
+## I want a good first issue
+
+[`good first issue`](https://github.com/dgenio/contextweaver/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+items are scoped to roughly one file or one module, with explicit acceptance
+criteria and no deep architectural context required.
+
+**Comment on the issue first so it can be assigned to you** — that avoids
+duplicate work. A good first contribution in this repo:
+
+- touches a single module and keeps it ≤ 300 lines;
+- adds or updates a test for every changed public function;
+- updates `CHANGELOG.md` under `## [Unreleased]`;
+- passes `make ci` locally before the PR is opened.
+
+## I am using an AI coding assistant
+
+contextweaver is friendly to AI coding agents (Claude Code, GitHub Copilot
+Agent Mode, Codex, …). Load these first, in order:
+
+1. [`AGENTS.md`](https://github.com/dgenio/contextweaver/blob/main/AGENTS.md) —
+   module map, conventions, and pipeline summary (the single source of truth).
+2. [`.claude/CLAUDE.md`](https://github.com/dgenio/contextweaver/blob/main/.claude/CLAUDE.md)
+   and [`.github/copilot-instructions.md`](https://github.com/dgenio/contextweaver/blob/main/.github/copilot-instructions.md)
+   — assistant-specific operating overlays.
+3. [`llms.txt`](https://github.com/dgenio/contextweaver/blob/main/llms.txt) /
+   [`llms-full.txt`](https://github.com/dgenio/contextweaver/blob/main/llms-full.txt)
+   — machine-readable repo summary.
+
+Then follow the same rules everyone else does: no `print()` in library code,
+no business logic in `__init__.py`, every public function gets a test, and
+`make ci` is the gate. Tasks tagged `agent-friendly` are scoped for end-to-end
+agent work.

--- a/docs/contributing_paths.md
+++ b/docs/contributing_paths.md
@@ -34,8 +34,10 @@ and the site is built with `make docs` (preview with `make docs-serve` at
 
 - **README clarity** — tighten [`README.md`](https://github.com/dgenio/contextweaver/blob/main/README.md);
   the first screen is the category pitch.
-- **Recipes** — add a copy-paste pattern to the [Cookbook](cookbook.md). Each
-  recipe is runnable core-only code, so it does not bitrot.
+- **Recipes** — add a copy-paste pattern to the [Cookbook](cookbook.md). Most
+  recipes are runnable core-only code, so they don't bitrot; a few drive an
+  external CLI as a `subprocess` for illustration (e.g. Recipe 7's safety
+  gate) and document that they add no runtime dependency.
 - **Integration pages** — `docs/integration_<framework>.md` explains wiring a
   specific runtime. Use an existing page (e.g. [MCP](integration_mcp.md)) as a
   template.

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -12,6 +12,7 @@ The recipes:
 4. [Firewall + drilldown for large tool outputs](#4-firewall-drilldown-for-large-tool-outputs)
 5. [CrewAI routing — bounded tool shortlists for crews](#5-crewai-routing-bounded-tool-shortlists-for-crews)
 6. [External memory backend — Mem0 / Zep / LangMem](#6-external-memory-backend)
+7. [Post-generation safety gate for agent-generated diffs](#7-post-generation-safety-gate-for-agent-generated-diffs)
 
 If you are evaluating where contextweaver fits in your runtime, start with
 the [How contextweaver Fits](interop.md) page first; come back here for
@@ -316,6 +317,84 @@ ctx_mgr = ContextManager(stores=bundle)
 
 Full walkthrough, decision matrix, and the Zep / LangMem follow-up
 status: [External Memory Backends](integration_memory.md).
+
+---
+
+## 7. Post-generation safety gate for agent-generated diffs
+
+**Goal.** Pair contextweaver (which decides *what context the agent acts on*)
+with a deterministic safety gate (which checks *what the agent produced*) so an
+agent that edits files cannot quietly ship an unreviewed change.
+
+**Use this when:** your agent generates or edits code and you want a
+fail-closed check on the resulting diff before it reaches review or merge —
+without putting the scanner inside the LLM's context path.
+
+These are adjacent stages of the same loop, not competitors:
+
+1. contextweaver compiles phase-specific context (route → call → interpret →
+   answer) so the agent acts on the right, bounded information.
+2. The agent generates an artifact — a diff, a file edit, a patch.
+3. A deterministic gate inspects that artifact *outside* the model context.
+   This recipe uses [VibeGuard](https://github.com/dgenio/vibeguard) as the
+   gate, but any diff-aware checker works the same way.
+
+> **No runtime dependency.** contextweaver does not import or require the gate,
+> and contextweaver is **not** a security scanner. The gate is a separate
+> process you run after the agent step. Keep it that way — it is what makes the
+> check deterministic and auditable.
+
+### The loop
+
+```python
+import subprocess
+
+from contextweaver.context.manager import ContextManager
+from contextweaver.types import ContextItem, ItemKind, Phase
+
+mgr = ContextManager()
+mgr.ingest_sync(ContextItem(id="u1", kind=ItemKind.user_turn, text="fix the bug"))
+
+# 1. Compile the answer-phase prompt and let the agent produce a diff.
+pack = mgr.build_sync(phase=Phase.answer, query="fix the bug")
+# diff = your_llm(pack.prompt)  -> apply the edit to the working tree
+
+# 2. Run the gate as a plain subprocess, OUTSIDE the LLM context path.
+result = subprocess.run(
+    ["vibeguard", "gate", "--diff", "--fail-on", "high"],
+    capture_output=True,
+    text=True,
+)
+gate_passed = result.returncode == 0
+
+# 3. Record the gate verdict back into the event log as a tool_result, so a
+#    later interpret/answer turn can reason about *why* a change was blocked.
+mgr.ingest_tool_result_sync(
+    tool_call_id="gate-001",
+    raw_output=result.stdout,
+    tool_name="vibeguard_gate",
+)
+```
+
+The gate output flows back through the context firewall like any other tool
+result: a compact summary enters the prompt and the full report is stored
+out-of-band under `mgr.artifact_store`. The model never sees the raw scanner
+output unless it drills into the artifact.
+
+### As a CI step
+
+The same gate belongs in CI, where it is the merge-blocking check rather than an
+in-loop signal:
+
+```yaml
+# .github/workflows/safety-gate.yml (sketch)
+- name: Safety gate on the proposed diff
+  run: vibeguard gate --diff origin/main...HEAD --fail-on high
+```
+
+This keeps the boundary clean: contextweaver shapes what the agent reads, the
+agent writes, and a deterministic gate — local or in CI — has the final say on
+what merges.
 
 ---
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -376,10 +376,13 @@ mgr.ingest_tool_result_sync(
 )
 ```
 
-The gate output flows back through the context firewall like any other tool
-result: a compact summary enters the prompt and the full report is stored
-out-of-band under `mgr.artifact_store`. The model never sees the raw scanner
-output unless it drills into the artifact.
+Whether the gate output is firewalled depends on its size. `ingest_tool_result_sync`
+only intercepts output longer than `firewall_threshold` (default 2000 characters):
+above that threshold a compact summary enters the prompt and the full report is
+stored out-of-band under `mgr.artifact_store`, so the model only sees the raw
+scanner output if it drills into the artifact. Shorter output is kept inline as the
+item's `text` and stays eligible for the prompt — pass a lower `firewall_threshold`
+to `ingest_tool_result_sync` if you want gate output always summarised.
 
 ### As a CI step
 

--- a/docs/interop.md
+++ b/docs/interop.md
@@ -157,6 +157,8 @@ These are deliberate scope boundaries. Use your runtime for them.
 
 - [Cookbook](cookbook.md) — copy-paste recipes for FastMCP, A2A,
   bring-your-own-tools, and firewall + drilldown
+- [Skill Cards as Context Artifacts](interop_skill_cards.md) — how reviewed
+  guidance from another Weaver component maps onto a `ContextItem`
 - [MCP Integration](integration_mcp.md) ·
   [A2A Integration](integration_a2a.md)
 - [LlamaIndex](integration_llamaindex.md) ·

--- a/docs/interop_skill_cards.md
+++ b/docs/interop_skill_cards.md
@@ -1,0 +1,110 @@
+# Skill Cards as Context Artifacts
+
+> The Weaver projects need a clear boundary between *reusable guidance produced
+> by one component* and *context selected by another component*. A reviewed
+> **skill card** is guidance authored and approved elsewhere; contextweaver's
+> job is only to decide whether — and how — that guidance enters a given
+> phase's prompt.
+>
+> This page documents the mapping. It is documentation, not a new adapter:
+> everything below uses existing contextweaver APIs and adds no dependency.
+
+## What a skill card is
+
+A skill card is a small, reviewed unit of guidance — "when editing
+`sensitivity.py`, treat changes as security-grade", or "prefer `match`
+statements for protocol dispatch". Some other component (a reviewer, a curation
+pipeline) decides the card is worth keeping. contextweaver receives the card as
+data and scores it against the current query under the same budget pressure as
+every other event.
+
+## The mapping
+
+A skill card maps onto a single [`ContextItem`](https://github.com/dgenio/contextweaver/blob/main/src/contextweaver/types.py).
+There is no bespoke type — the existing fields carry everything a card needs:
+
+| Skill-card concept | `ContextItem` field | Notes |
+|---|---|---|
+| artifact id | `id` | Stable, unique. Reuse the card's own id so provenance round-trips. |
+| artifact text | `text` | The guidance itself — what the model should read. |
+| scope metadata | `metadata["scope"]` | Where the card applies (module, task type, phase hint). Free-form. |
+| sensitivity metadata | `sensitivity` | One of `Sensitivity.public` / `internal` / `confidential`. Drives the sensitivity floor. |
+| provenance metadata | `metadata["provenance"]` | Who reviewed it, when, source commit/URL. Audit trail, not scored. |
+| task-matching notes | `text` (+ `metadata`) | Matching is lexical against `text`; see below. |
+
+`kind` should be `ItemKind.doc_snippet` for reference guidance (or
+`ItemKind.policy` when the card is a hard rule the answer phase must always
+see). Both flow through the standard phase-filter → sensitivity → firewall →
+scoring → dedup → budget pipeline with no special-casing.
+
+### Constructing a card
+
+```python
+from contextweaver.types import ContextItem, ItemKind, Sensitivity
+
+card = ContextItem(
+    id="skill:sensitivity-is-security-grade",
+    kind=ItemKind.doc_snippet,
+    text=(
+        "When editing context/sensitivity.py, treat changes as security-grade: "
+        "never weaken the default sensitivity floor or default drop action."
+    ),
+    sensitivity=Sensitivity.internal,
+    metadata={
+        "scope": {"module": "context/sensitivity.py", "task": "edit"},
+        "provenance": {
+            "reviewed_by": "maintainers",
+            "source": "AGENTS.md#things-that-must-not-be-simplified",
+        },
+    },
+)
+```
+
+Ingest it like any other event:
+
+```python
+from contextweaver.context.manager import ContextManager
+
+mgr = ContextManager()
+mgr.ingest_sync(card)
+```
+
+## Task matching
+
+contextweaver does **not** run a separate skill-card matcher. The card competes
+in the normal scoring pass: its `text` is scored lexically against the current
+query (default `tfidf` / `bm25`), and the highest-scoring items that fit the
+phase budget are kept. Two consequences worth designing for:
+
+- **Matching quality is a function of the card's `text`.** Put the words a
+  query would use into the guidance itself; do not hide the trigger only in
+  `metadata`, which is not scored.
+- **`metadata["scope"]` is yours to enforce.** contextweaver preserves it but
+  does not filter on it. If you want a card to apply only to one module, read
+  `metadata["scope"]` in your own pre-ingest filter and skip cards that do not
+  apply before calling `ingest_sync`.
+
+### Matching example
+
+Query: *"I'm about to edit the sensitivity module — anything I should know?"*
+
+The card above scores highly: its `text` shares "edit", "sensitivity", and the
+module name with the query, so it survives scoring and lands in the compiled
+context. The model sees the security-grade warning before it proposes a change.
+
+### Non-matching example
+
+Query: *"How do I add a new CrewAI adapter?"*
+
+The same card scores near zero — no lexical overlap with adapter/CrewAI terms —
+so it is dropped under budget pressure in favour of adapter-relevant items. The
+card stays in the event log (nothing is deleted); it simply does not enter
+*this* prompt. That is the intended behaviour: guidance is available everywhere
+but only surfaces where it is relevant.
+
+## See also
+
+- [How contextweaver Fits](interop.md) — the overall policy-vs-execution boundary
+- [Concepts](concepts.md) — `ContextItem`, phases, and the scoring pipeline
+- [External Memory Backends](integration_memory.md) — the related pattern for
+  cross-session facts and episodes

--- a/docs/interop_skill_cards.md
+++ b/docs/interop_skill_cards.md
@@ -95,11 +95,15 @@ consequences worth designing for:
 
 ### Matching example
 
-Query: *"I'm about to edit the sensitivity module — anything I should know?"*
+Query: *"I'm editing context/sensitivity.py — anything I should know?"*
 
-The card above scores highly: its `text` shares "edit", "sensitivity", and the
-module name with the query, so it survives scoring and lands in the compiled
-context. The model sees the security-grade warning before it proposes a change.
+The card above scores well: its `text` shares the `editing`, `context`,
+`sensitivity.py`, `sensitivity`, and `context/sensitivity.py` tokens with the
+query (contextweaver's `tokenize()` helper lowercases input and splits
+compounds on `.`, `/`, and `-`, but does **not** stem — so write cards and
+queries with overlapping word forms). With little competition from other items
+on this query, the card survives scoring and lands in the compiled context.
+The model sees the security-grade warning before it proposes a change.
 
 ### Non-matching example
 

--- a/docs/interop_skill_cards.md
+++ b/docs/interop_skill_cards.md
@@ -28,14 +28,18 @@ There is no bespoke type — the existing fields carry everything a card needs:
 | artifact id | `id` | Stable, unique. Reuse the card's own id so provenance round-trips. |
 | artifact text | `text` | The guidance itself — what the model should read. |
 | scope metadata | `metadata["scope"]` | Where the card applies (module, task type, phase hint). Free-form. |
-| sensitivity metadata | `sensitivity` | One of `Sensitivity.public` / `internal` / `confidential`. Drives the sensitivity floor. |
+| sensitivity metadata | `sensitivity` | One of `Sensitivity.public` / `internal` / `confidential` / `restricted`. Drives the sensitivity floor. |
 | provenance metadata | `metadata["provenance"]` | Who reviewed it, when, source commit/URL. Audit trail, not scored. |
 | task-matching notes | `text` (+ `metadata`) | Matching is lexical against `text`; see below. |
 
 `kind` should be `ItemKind.doc_snippet` for reference guidance (or
-`ItemKind.policy` when the card is a hard rule the answer phase must always
-see). Both flow through the standard phase-filter → sensitivity → firewall →
-scoring → dedup → budget pipeline with no special-casing.
+`ItemKind.policy` for high-priority guidance — `policy` carries a higher kind
+priority in scoring, but inclusion is still subject to per-kind limits
+(`max_items_per_kind`) and the phase token budget, so it is not guaranteed to
+appear in any given prompt). If a rule must always be present, inject it via the
+pack's `header`/`footer` or size the phase budget to accommodate it. Both kinds
+flow through the standard phase-filter → sensitivity → firewall → scoring →
+dedup → budget pipeline with no special-casing.
 
 ### Constructing a card
 
@@ -72,13 +76,18 @@ mgr.ingest_sync(card)
 ## Task matching
 
 contextweaver does **not** run a separate skill-card matcher. The card competes
-in the normal scoring pass: its `text` is scored lexically against the current
-query (default `tfidf` / `bm25`), and the highest-scoring items that fit the
-phase budget are kept. Two consequences worth designing for:
+in the normal scoring pass: its `text` is scored against the current query with
+tokenized Jaccard overlap, combined with tag overlap (`metadata["tags"]`),
+recency, item-kind priority, and a token-cost penalty (see
+[`context/scoring.py`](https://github.com/dgenio/contextweaver/blob/main/src/contextweaver/context/scoring.py)).
+This is **not** TF-IDF or BM25 — those are *routing* backends, a separate
+subsystem. The highest-scoring items that fit the phase budget are kept. Two
+consequences worth designing for:
 
 - **Matching quality is a function of the card's `text`.** Put the words a
   query would use into the guidance itself; do not hide the trigger only in
-  `metadata`, which is not scored.
+  free-form `metadata` such as `scope`, which is not scored. (The one scored
+  metadata field is `metadata["tags"]`, which contributes tag overlap.)
 - **`metadata["scope"]` is yours to enforce.** contextweaver preserves it but
   does not filter on it. If you want a card to apply only to one module, read
   `metadata["scope"]` in your own pre-ingest filter and skip cards that do not

--- a/docs/interop_skill_cards.md
+++ b/docs/interop_skill_cards.md
@@ -36,8 +36,10 @@ There is no bespoke type — the existing fields carry everything a card needs:
 `ItemKind.policy` for high-priority guidance — `policy` carries a higher kind
 priority in scoring, but inclusion is still subject to per-kind limits
 (`max_items_per_kind`) and the phase token budget, so it is not guaranteed to
-appear in any given prompt). If a rule must always be present, inject it via the
-pack's `header`/`footer` or size the phase budget to accommodate it. Both kinds
+appear in any given prompt). If a rule must always be present, pass it as the
+`header` or `footer` keyword argument to `build_sync()` (its token cost is
+reserved up front — see `BuildStats.header_footer_tokens`) or size the phase
+budget to accommodate it. Both kinds
 flow through the standard phase-filter → sensitivity → firewall → scoring →
 dedup → budget pipeline with no special-casing.
 
@@ -76,9 +78,11 @@ mgr.ingest_sync(card)
 ## Task matching
 
 contextweaver does **not** run a separate skill-card matcher. The card competes
-in the normal scoring pass: its `text` is scored against the current query with
-tokenized Jaccard overlap, combined with tag overlap (`metadata["tags"]`),
-recency, item-kind priority, and a token-cost penalty (see
+in the normal scoring pass: when the query carries tags, the similarity term
+is tokenized Jaccard between the card's `metadata["tags"]` and the query
+tags; otherwise it falls back to tokenized Jaccard between the card's `text`
+and the query text. That similarity term is then combined with recency,
+item-kind priority, and a token-cost penalty (see
 [`context/scoring.py`](https://github.com/dgenio/contextweaver/blob/main/src/contextweaver/context/scoring.py)).
 This is **not** TF-IDF or BM25 — those are *routing* backends, a separate
 subsystem. The highest-scoring items that fit the phase budget are kept. Two

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
   - Tool Router: tool_router.md
   - Concepts: concepts.md
   - How contextweaver Fits (deeper): interop.md
+  - Skill Cards (interop): interop_skill_cards.md
   - Cookbook: cookbook.md
   - Architectures:
       - Overview: architectures/index.md
@@ -105,6 +106,7 @@ nav:
   - Contracts: contracts.md
   - Observability: integration_otel.md
   - Troubleshooting: troubleshooting.md
+  - Contribution Paths: contributing_paths.md
   - API Reference: reference/
 
 exclude_docs: |


### PR DESCRIPTION
## Summary

Bundles four community/interop **documentation** issues into one docs-only PR.
All changes are Markdown (plus the mkdocs nav); no source files are touched.

Closes #249
Closes #325
Closes #332
Closes #333

## Changes

- **#249 — `CODE_OF_CONDUCT.md`** (new): Contributor Covenant 2.1 verbatim, so the
  GitHub community-standards check goes green. Enforcement contact wired to the
  `pyproject.toml` author email. Linked from the bottom of `CONTRIBUTING.md` and
  from `README.md`.
- **#325 — `docs/contributing_paths.md`** (new): a contributor landing page that
  answers "where can I help in 30 minutes, half a day, or one weekend?", mapping
  paths (docs / adapters / benchmarks / examples / good-first-issue / AI agents)
  to the real `make` targets, files, and issue labels. Linked from `README.md`
  and `CONTRIBUTING.md`; added to the mkdocs nav.
- **#332 — cookbook recipe** (`docs/cookbook.md`): new "Recipe 7 — post-generation
  safety gate for agent-generated diffs", showing contextweaver shaping context
  while a deterministic gate (VibeGuard) checks the produced diff *outside* the
  LLM context path, both in-loop and as a CI step. No runtime dependency added.
- **#333 — `docs/interop_skill_cards.md`** (new): documents how a reviewed skill
  card maps onto a `ContextItem` (`id` / `text` / `metadata["scope"]` /
  `sensitivity` / `metadata["provenance"]`), plus task-matching notes and one
  matching / one non-matching example. Cross-linked from `interop.md`; added to nav.
- `CHANGELOG.md`: one `[Unreleased] / Added` bullet covering all four.

## Why

These are the "documentation & community surface" cluster from issue triage:
single shared implementation path (Markdown + nav + cross-links), no `src/`
changes, near-zero regression risk, and aligned with the current launch-readiness
direction. They are mutually reinforcing — the contributor landing page links to
the new Code of Conduct, cookbook recipe, and skill-card interop page.

## How verified

- `mkdocs build --clean` → exit 0; **no warnings on the new pages**. Fixed one
  heading-anchor slug (`adoption / growth` → single-hyphen) caught by the build.
- `git diff --stat` confirms only docs/markdown + `mkdocs.yml` changed (9 files,
  no `src/`), so lint / type / pytest / example / demo are unaffected; CI runs the
  full `make ci` gate regardless.

## Checklist

- [x] Tests added or updated for every new/changed public function — *N/A, docs-only, no public functions changed*
- [x] `make ci` passes locally — *docs-only; verified `mkdocs build --clean` (exit 0). No `src/` changes, so the rest of the gate is unaffected; CI confirms.*
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docstrings added for all new public APIs (Google-style) — *N/A, no code*
- [x] Every modified module stays ≤ 300 lines — *N/A, no modules changed*
- [x] Related issue linked in the summary above
- [x] Agent-facing docs updated if pipeline, API, or conventions changed — *N/A, no pipeline/API/convention change*

## Notes for reviewers

- **Mode-B delta on #332:** the issue text proposed a new `docs/cookbook/` directory;
  this PR instead adds a recipe to the existing single-page `docs/cookbook.md`, which
  is what the mkdocs nav wires up ("Cookbook: cookbook.md"). Creating a new directory
  would have orphaned the existing page or required a nav restructure. Flagging in case
  a directory layout is preferred.
- **#282 deliberately excluded** from this group: it is a `good first issue` already
  assigned to community contributor `@Monish102006`, so it is left for them rather than
  folded in here.
- The cookbook recipe references `vibeguard` as the example gate per the issue; it is
  documentation only and adds no dependency.

## Reproducibility (scoring / context-pipeline changes)

N/A — no routing, scoring, tokenisation, or context-pipeline code changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_0167rpmVuWha7nLKMtt4Cvtr)_