### PR TITLE
Add adoption examples: catalog showcase, killer demo, LangGraph loop, eval-artifact profile (#330, #322, #326, #335)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,7 +193,9 @@ These are strongly recommended. Engineering judgment applies — deviate with go
 - **≤ 300 lines per module** — exempt: `types.py`, `envelope.py`, `__main__.py`,
   `_mcp_cli.py` (experimental Typer sub-app; size is dominated by Typer
   parameter declarations + docstrings and is expected to shrink once
-  `mcp serve` graduates from `[experimental]` to stable).
+  `mcp serve` graduates from `[experimental]` to stable), and `_demos.py`
+  (CLI demo-output module — print-heavy walkthrough scripts backing the
+  `demo` subcommand, same rationale as `__main__.py`).
 - **Core runtime dependencies.** The core install pulls `tiktoken`, `PyYAML`, `rank-bm25`, plus `mcp` and `jsonschema` (added when the proxy / gateway runtimes landed — both are load-bearing for `docs/gateway_spec.md` §4.4 schema validation and the MCP transport binding).  Adding *another* core dependency requires explicit justification: broad ecosystem use, small wheel, and a default the library would otherwise have to approximate.  Heavy or runtime-specific packages (CLI, OpenTelemetry, fuzzy retrieval, ANN, NetworkX, FastMCP, LangChain) live under `[project.optional-dependencies]` and are loaded via guarded imports.
 
 ## Testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Catalog showcase reference architecture** — a start-here, deterministic
+  example (`examples/architectures/catalog_showcase/`) that narrows a
+  65-tool catalog to a 5-card shortlist, hydrates only the selected tool's
+  schema, and firewalls a large result; wired into `make architectures` and
+  documented at `docs/architectures/catalog_showcase.md`. (#330)
+- **`contextweaver demo --scenario killer`** — the 60-second failure mode:
+  100 tools + a long history + a huge tool result, contrasting a naive loop
+  against contextweaver in character terms (92–99% reductions). New README
+  "The 60-second failure mode" section and `docs/killer_demo.md`. (#322)
+- **LangGraph agent-loop reference architecture** — contextweaver running
+  *inside* a LangGraph `StateGraph`
+  (`examples/architectures/langgraph_agent_loop/`): LangGraph owns control
+  flow, contextweaver owns route/firewall/answer. Guarded import with a
+  hand-rolled fallback so it runs without the framework; new `[langgraph]`
+  extra (also in `[dev]` so CI exercises the real path).
+  `docs/architectures/langgraph_agent_loop.md`. (#326)
+- **Agent-safe evaluation-artifact context profile** — a context-shaping
+  profile (`examples/architectures/eval_artifact_profile/`) with `ok` /
+  `caution` / `high_risk` fixtures that never surfaces `V_hat` without
+  support diagnostics and foregrounds caveats for high-risk artifacts, with
+  runtime-asserted invariants. `docs/architectures/eval_artifact_profile.md`. (#335)
+
 ### Fixed
 
 - **Docs accuracy follow-up to #337** — aligned the VibeGuard `--diff` shape

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ example:
 	$(MAKE) architectures
 
 architectures:
+	python examples/architectures/catalog_showcase/main.py
 	python examples/architectures/mcp_context_gateway/main.py
 	python examples/architectures/mcp_context_gateway/main_live.py
 	python examples/architectures/mcp_context_gateway/main_multi.py
@@ -41,6 +42,8 @@ architectures:
 	python examples/architectures/slack_ops_bot/main.py
 	python examples/architectures/code_review_bot/main.py
 	python examples/architectures/voice_agent/main.py
+	python examples/architectures/langgraph_agent_loop/main.py
+	python examples/architectures/eval_artifact_profile/main.py
 
 demo:
 	python -m contextweaver demo

--- a/README.md
+++ b/README.md
@@ -49,6 +49,32 @@ python -m contextweaver demo     # 5-step end-to-end demo
 
 ---
 
+## The 60-second failure mode
+
+See why a naive tool-using agent loop breaks down — and what contextweaver
+does about it — in one command (no API keys, no network):
+
+```bash
+contextweaver demo --scenario killer
+```
+
+An internal ops agent with **100 tools** and a running conversation is asked
+to *"find unpaid invoices, check the account notes, and draft a reminder."*
+A naive loop pays for all 100 tool descriptions, the full history, and a
+huge raw tool result at once:
+
+| | Naive | contextweaver | Reduction |
+|---|---|---|---|
+| Tools in the route prompt | all 100 (6,326 chars) | 5 ChoiceCards (491 chars) | **92.2%** |
+| The huge tool result | raw (14,430 chars) | firewalled summary (60 chars) | **99.6%** |
+| The full answer prompt | everything raw (21,332 chars) | compiled (823 chars) | **96.1%** |
+
+Full walkthrough: [The 60-second failure mode](docs/killer_demo.md). For the
+same story as a runnable, inspectable script, see the
+[catalog showcase architecture](docs/architectures/catalog_showcase.md).
+
+---
+
 ## The Problem
 
 Even with 200K-token context windows, dumping everything into the prompt is expensive,
@@ -569,6 +595,7 @@ contextweaver ships with a CLI for quick experimentation:
 
 ```bash
 contextweaver demo                                    # end-to-end demonstration
+contextweaver demo --scenario killer                  # the 60-second failure mode (100 tools + huge output)
 contextweaver init                                    # scaffold config + sample catalog
 contextweaver build --catalog c.json --out g.json    # build routing graph
 contextweaver route --graph g.json --catalog c.json --query "send email"
@@ -595,6 +622,9 @@ contextweaver replay --session session.json --phase answer
 | `langchain_memory_demo.py` | LangChain memory replacement: `InMemoryChatMessageHistory` vs contextweaver |
 | `cookbook/byot_recipe.py` | Bring-your-own-tools cookbook recipe — wrap plain Python callables and route |
 | `cookbook/firewall_drilldown_recipe.py` | Cookbook recipe: firewall a large tool result, then drill into the artifact |
+| `architectures/catalog_showcase/` | **Start-here** reference architecture — 65-tool catalog → 5-card shortlist, single-tool schema hydration, firewall on a ~3 KB result, final `BuildStats` ([guide](docs/architectures/catalog_showcase.md)) |
+| `architectures/langgraph_agent_loop/` | contextweaver **inside** a LangGraph `StateGraph` (route → execute → answer), firewall on a ~21 KB log dump, cross-turn retention; optional framework with a hand-rolled fallback ([guide](docs/architectures/langgraph_agent_loop.md)) |
+| `architectures/eval_artifact_profile/` | Agent-safe context shaping for offline-evaluation reports — never surfaces `V_hat` without support diagnostics ([guide](docs/architectures/eval_artifact_profile.md)) |
 | `architectures/mcp_context_gateway/` | Launch reference architecture — 60-tool MCP-style gateway end-to-end: ChoiceCards, lazy schema hydration, context firewall on a 16 KB result, artifact-backed answer prompt ([guide](docs/architectures/mcp_context_gateway.md)) |
 | `architectures/mcp_context_gateway/main_real.py` | Same flow, run against verbatim `tools/list` snapshots of MIT-licensed reference MCP servers (`server-time`, `server-filesystem`, `server-everything`) committed under `real_catalogs/` |
 | `recipes/serve_gateway.py` | Minimal stdio launcher used by the [Claude Desktop](docs/recipes/claude_desktop.md) and [GitHub Copilot](docs/recipes/github_copilot.md) recipes |

--- a/docs/agent-context/invariants.md
+++ b/docs/agent-context/invariants.md
@@ -88,7 +88,8 @@ Adapters MUST emit `tool_id` values that round-trip through the canonical `parse
 
 ## Cross-Cutting Rules
 
-- **Module size ≤ 300 lines** — exempt: `types.py`, `envelope.py`, `__main__.py`.
+- **Module size ≤ 300 lines** — exempt: `types.py`, `envelope.py`, `__main__.py`,
+  `_mcp_cli.py` (experimental Typer sub-app), `_demos.py` (CLI demo-output module).
 - **`from __future__ import annotations`** — every source file.
 - **Google-style docstrings** — every public class and function.
 - **Type hints** — every public function and method.

--- a/docs/architectures/catalog_showcase.md
+++ b/docs/architectures/catalog_showcase.md
@@ -1,0 +1,64 @@
+# Catalog showcase
+
+> The smallest end-to-end demonstration of why contextweaver exists. A
+> **65-tool** catalog is narrowed to a **5-card shortlist** for one user
+> request, only the selected tool's schema is hydrated, and a large tool
+> result is firewalled — so the prompt stays bounded no matter how big the
+> catalog or the result. **Start here** before the other architectures.
+
+## TL;DR
+
+| What | Where |
+|---|---|
+| The script | [`examples/architectures/catalog_showcase/main.py`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/catalog_showcase/main.py) |
+| Captured output | [`examples/architectures/catalog_showcase/OUTPUT.md`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/catalog_showcase/OUTPUT.md) |
+| Local README | [`examples/architectures/catalog_showcase/README.md`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/catalog_showcase/README.md) |
+
+Run it:
+
+```bash
+python examples/architectures/catalog_showcase/main.py
+```
+
+(Or `make architectures` / `make example`.)
+
+## The four steps
+
+1. **Route → shortlist.** `Router.route(request)` narrows 65 tools to a
+   5-card shortlist. The model only ever sees compact
+   [`ChoiceCard`](../tool_router.md)s — never the full catalog, never any
+   argument schema.
+2. **Expand only the selected tool.** `Catalog.hydrate(chosen)` resolves the
+   full `args_schema` for the one selected tool (653 chars). The other 64
+   tools cost zero schema bytes.
+3. **Firewall a large result.** A ~3 KB product-search payload is ingested;
+   the [context firewall](../context_firewall.md) replaces it with a
+   ~500-char summary (an 84% prompt-side reduction) and keeps the raw bytes
+   addressable in the artifact store.
+4. **Final answer pack.** `build_sync(phase=Phase.answer, ...)` assembles the
+   budget-aware prompt; `BuildStats` shows exactly what was kept.
+
+## What's load-bearing
+
+| Feature | What it does here |
+|---|---|
+| `Router.route(query)` | Narrows 65 tools → top-5 shortlist (`top_k=5`) |
+| `ChoiceCard` rendering | The model sees 5 compact cards with **no** schemas |
+| `Catalog.hydrate(tool_id)` | Lazily resolves the full schema for the **one** selected tool |
+| Context firewall | Compacts the ~3 KB result to a ~500-char summary |
+| Artifact store | Raw bytes stay addressable for drilldown |
+
+## Determinism
+
+The bulk of the catalog is generated from a fixed seed
+(`generate_sample_catalog(n=62, seed=7)`), the three schema-rich hero tools
+are defined inline, the tool result is canned, and no model or network call
+happens. Per-section token counts depend on the active tokeniser; every
+other number is character- or count-based and stable across environments.
+
+## Read next
+
+- The [60-second killer demo](../killer_demo.md) makes the same point as a
+  before/after token comparison.
+- The [code-review bot](code_review_bot.md) and [Slack ops bot](slack_ops_bot.md)
+  layer multi-turn state on top of these same primitives.

--- a/docs/architectures/eval_artifact_profile.md
+++ b/docs/architectures/eval_artifact_profile.md
@@ -1,0 +1,63 @@
+# Agent-safe evaluation-artifact profile
+
+> Offline policy-evaluation reports are large and easy to misread. An agent
+> that sees only a headline score such as `V_hat` can draw a confident,
+> wrong conclusion. This profile compiles an evaluation artifact into
+> **phase-aware, agent-safe** context that foregrounds support health,
+> uncertainty, and caveats — and only then the headline estimate.
+
+## TL;DR
+
+| What | Where |
+|---|---|
+| The script | [`examples/architectures/eval_artifact_profile/main.py`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/eval_artifact_profile/main.py) |
+| The fixtures | [`examples/architectures/eval_artifact_profile/fixtures/`](https://github.com/dgenio/contextweaver/tree/main/examples/architectures/eval_artifact_profile/fixtures) |
+| Captured output | [`examples/architectures/eval_artifact_profile/OUTPUT.md`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/eval_artifact_profile/OUTPUT.md) |
+| Local README | [`examples/architectures/eval_artifact_profile/README.md`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/eval_artifact_profile/README.md) |
+
+Run it:
+
+```bash
+python examples/architectures/eval_artifact_profile/main.py
+```
+
+(Or `make architectures` / `make example`.)
+
+## What it is (and isn't)
+
+A **context-shaping profile**, not a statistics library. It does no
+estimation — that belongs to the artifact producer (for example
+`skdr-eval`). The profile, `compile_eval_context(artifact, phase)`, decides
+*what to show an agent, in what order, at each phase*. Three fixtures
+(`ok` / `caution` / `high_risk`) exercise it.
+
+## Behaviour by phase
+
+- **Route** — summary metadata only: artifact type, available diagnostics,
+  whether it needs interpretation or policy gating. No metrics, no estimate.
+- **Interpret** — the full diagnostic view: support health → warnings →
+  (limitations, for high-risk) → assumptions → delta with uncertainty →
+  decision stability → limitations → headline estimate → full-artifact handle.
+- **Answer** — a compact human-safe summary: what was evaluated, whether the
+  evidence is usable, the decision it supports, and the blocking caveats. The
+  estimate leads the summary **only** for an `ok` artifact.
+
+## The safety invariants
+
+Enforced by the profile and verified by `check_invariants()` and the test
+suite:
+
+1. **Never present `V_hat` without support diagnostics.** Any phase whose
+   output contains the value estimate also contains a support-health item
+   *earlier* in the list; the route phase never exposes it.
+2. **High-risk artifacts foreground caveats before estimates.**
+
+`main()` asserts these at runtime, so a regression breaks `make example`
+rather than silently shipping unsafe context shaping.
+
+## Read next
+
+- The [Concepts](../concepts.md) guide covers `ContextItem`, `Phase`, and
+  the prompt renderer used here.
+- The [context firewall](../context_firewall.md) is the complementary tool
+  for keeping the *raw* artifact bytes out of the prompt.

--- a/docs/architectures/index.md
+++ b/docs/architectures/index.md
@@ -14,10 +14,13 @@ for a production agent, you are in the right place.
 
 | Architecture | What it shows | Size |
 |---|---|---|
+| [Catalog showcase](catalog_showcase.md) | **Start here.** 65-tool catalog → 5-card shortlist, single-tool schema hydration, firewall on a ~3 KB result — the core value in one linear read | ~250 lines |
 | [MCP Context Gateway](mcp_context_gateway.md) | 60-tool MCP-style gateway, 5 `ChoiceCards`, lazy schema hydration, firewall on a 16 KB upstream result, artifact-backed answer-phase prompt | ~240 lines + YAML catalog |
 | [Slack ops bot](slack_ops_bot.md) | ~48 internal tools, multi-turn investigations, firewall on log/grep outputs, persistent fact memory across conversations | ~280 lines + YAML catalog |
 | [Code-review bot](code_review_bot.md) | ~24 analysis tools, firewall on diff / grep outputs as the load-bearing pattern, tight per-phase budgets for a latency-sensitive review | ~300 lines + YAML catalog |
 | [Voice agent](voice_agent.md) | ~18 customer-service tools, `asyncio.to_thread(mgr.build_sync, …)` async pattern, tight budgets for sub-300 ms TTS — canonical worked example for the [Pipecat guide](../integration_pipecat.md) | ~270 lines + YAML catalog |
+| [LangGraph agent loop](langgraph_agent_loop.md) | contextweaver **inside** a LangGraph `StateGraph` (route → execute → answer), 36 tools, firewall on a ~21 KB log dump, cross-turn retention — optional framework with a hand-rolled fallback | ~330 lines |
+| [Evaluation-artifact profile](eval_artifact_profile.md) | Agent-safe context shaping for offline-evaluation reports — never surfaces `V_hat` without support diagnostics; foregrounds caveats for high-risk artifacts | ~280 lines + JSON fixtures |
 
 ## How each architecture is structured
 
@@ -25,8 +28,11 @@ Every architecture under `examples/architectures/<name>/` contains:
 
 - `main.py` — the runnable script. Mocked tool implementations, deterministic
   transcript, prints rendered prompts and `BuildStats` to stdout.
-- `catalog.yaml` — the tool catalog as a YAML file (loaded via
-  `routing.catalog.load_catalog_yaml`).
+- a tool catalog — usually a `catalog.yaml` loaded via
+  `routing.catalog.load_catalog_yaml`, though some (the catalog showcase and
+  LangGraph agent loop) generate it deterministically with
+  `generate_sample_catalog(...)` plus a few schema-rich inline tools, and the
+  evaluation-artifact profile ships JSON fixtures instead.
 - `README.md` — explains the setup, lists which contextweaver features are
   load-bearing for this architecture and which are not.
 - `OUTPUT.md` — captured output from a known seed so you can read the

--- a/docs/architectures/langgraph_agent_loop.md
+++ b/docs/architectures/langgraph_agent_loop.md
@@ -1,0 +1,61 @@
+# LangGraph agent loop
+
+> contextweaver running **inside** a LangGraph agent loop, not as a
+> replacement for one. LangGraph owns control flow; contextweaver owns
+> phase-aware context compilation (route → firewall → answer); tool
+> execution stays outside contextweaver.
+
+## TL;DR
+
+| What | Where |
+|---|---|
+| The script | [`examples/architectures/langgraph_agent_loop/main.py`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/langgraph_agent_loop/main.py) |
+| Captured output | [`examples/architectures/langgraph_agent_loop/OUTPUT.md`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/langgraph_agent_loop/OUTPUT.md) |
+| Local README | [`examples/architectures/langgraph_agent_loop/README.md`](https://github.com/dgenio/contextweaver/blob/main/examples/architectures/langgraph_agent_loop/README.md) |
+
+Run it:
+
+```bash
+python examples/architectures/langgraph_agent_loop/main.py
+```
+
+(Or `make architectures` / `make example`. Install the framework path with
+`pip install 'contextweaver[langgraph]'`.)
+
+## The boundary
+
+| Concern | Owner |
+|---|---|
+| Control flow (`route -> execute -> answer`, the per-turn loop) | **LangGraph** `StateGraph` |
+| Tool selection bounding (catalog → ChoiceCard shortlist) | **contextweaver** route phase |
+| Large tool-result firewalling | **contextweaver** interpret phase |
+| Budget-aware prompt + dependency-chain preservation | **contextweaver** answer phase |
+| Executing a tool | The app / a tool runtime (here: mocked) |
+
+## LangGraph is optional
+
+The import is guarded. With LangGraph installed the real `StateGraph` drives
+the loop; otherwise an equivalent hand-rolled loop calls the same node
+functions in the same order. The output is identical apart from one
+`agent loop engine:` banner line, so the example runs under a bare
+`pip install contextweaver`. See the
+[LangChain + LangGraph guide](../integration_langchain.md) for the broader
+integration story.
+
+## The scenario
+
+A two-turn ops session; the "model" decision at each node is a deterministic
+intent map standing in for an LLM holding the rendered ChoiceCards (no API
+key, no network):
+
+1. *"pull the recent error logs for the payments service"* → `infra.logs_search`
+   returns a ~21 KB dump that the firewall compacts to a short summary.
+2. *"summarize the root cause and draft an incident note"* → `incident.draft_note`;
+   the answer build carries turn 1's firewalled result forward.
+
+## Read next
+
+- The [comparison page](../comparison.md) explains why contextweaver
+  complements rather than replaces agent frameworks.
+- The [catalog showcase](catalog_showcase.md) is the framework-free version
+  of the same route → firewall → answer flow.

--- a/docs/killer_demo.md
+++ b/docs/killer_demo.md
@@ -1,0 +1,57 @@
+# The 60-second failure mode
+
+> The fastest way to see why a naive tool-using agent loop breaks down — and
+> what contextweaver does about it — in one command, with no API keys and no
+> network.
+
+```bash
+contextweaver demo --scenario killer
+```
+
+(Also available as `python -m contextweaver demo --scenario killer`.)
+
+## The scenario
+
+An internal ops agent with **100 tools** and a running conversation. The
+user asks:
+
+> "Find unpaid invoices, check the account notes, and draft a reminder."
+
+A naive loop pays for three things at once:
+
+1. **The tool catalog** — all 100 tool descriptions injected into the route
+   prompt.
+2. **The conversation history** — every prior turn included raw.
+3. **A huge tool result** — the invoice/account dump pasted straight back
+   into the answer prompt.
+
+contextweaver narrows each one:
+
+| | Naive | contextweaver | Reduction |
+|---|---|---|---|
+| Tools in the route prompt | all 100 descriptions (6,326 chars) | 5 ChoiceCards (491 chars) | **92.2%** |
+| The huge tool result | raw (14,430 chars) | firewalled summary (60 chars) | **99.6%** |
+| The full answer prompt | everything raw (21,332 chars) | compiled (823 chars) | **96.1%** |
+
+Sizes are reported in **characters** (deterministic everywhere). The demo
+also prints a token estimate using the active tokeniser.
+
+## What you are seeing
+
+- **Route narrows the catalog.** `Router.route(query)` turns 100 tools into a
+  5-card shortlist — the [Tool Router](tool_router.md) at work. The model
+  never sees 100 schemas.
+- **The firewall externalises the big result.** The ~14 KB invoice dump is
+  stored out-of-band as an artifact and replaced with a short summary — the
+  [Context Firewall](context_firewall.md). The raw bytes stay addressable.
+- **The answer prompt is compiled, not concatenated.** A budget-aware build
+  keeps the relevant history plus the summary, instead of dumping everything.
+
+## Where to go next
+
+- The [catalog showcase architecture](architectures/catalog_showcase.md) is
+  the same story as a runnable, inspectable script with `BuildStats`.
+- The [Showcase](showcase.md) walks the other `demo --scenario` flows
+  (`large-catalog`, `huge-tool-output`, `mcp-gateway-full`).
+- The [Quickstart](quickstart.md) shows the direct-API version you would
+  embed in your own agent loop.

--- a/examples/architectures/catalog_showcase/OUTPUT.md
+++ b/examples/architectures/catalog_showcase/OUTPUT.md
@@ -1,0 +1,95 @@
+# Catalog showcase — captured run
+
+Output of `python examples/architectures/catalog_showcase/main.py` from a
+clean checkout. Deterministic: the catalog is seed-generated, the tool
+result is canned, and the firewall is hash-based on artifact content.
+Per-section token counts depend on the active tokeniser (tiktoken when
+available, otherwise a chars/4 fallback) and may differ slightly across
+environments; every other number is character- or count-based and stable.
+
+```
+
+============================================================================
+contextweaver -- Catalog showcase reference architecture
+============================================================================
+Loaded catalog: 65 tools across 9 namespaces
+
+============================================================================
+1. Route -> compact shortlist
+============================================================================
+request:  search the product catalog for 4k monitors under 400 dollars and show the top matches
+shortlist: 5 of 65 tools -> ['commerce.product_search', 'commerce.product_details', 'commerce.inventory_check', 'search.internal.search', 'search.web.summarize']
+
+ChoiceCards the model sees (NO argument schemas):
+[1/5] commerce.product_search (tool) — Search the product catalog by keyword, price range, and category; returns the top ranked matching products with price and rating [catalog, price, products, search] score=2.30
+[2/5] commerce.product_details (tool) — Fetch the full product detail record for a single catalog item by id [catalog, detail, products] score=1.97
+[3/5] commerce.inventory_check (tool) — Check warehouse stock levels for a product across regions [inventory, products, stock] score=1.65
+[4/5] search.internal.search (tool) — Search internal knowledge base [internal, search] score=0.83
+[5/5] search.web.summarize (tool) — Summarize a web page [search, web] score=0.83
+
+============================================================================
+2. Expand only the selected tool
+============================================================================
+chosen:   commerce.product_search  (intent='commerce.product_search', in shortlist)
+hydrated schema for 'commerce.product_search': 653 chars
+hydrated schema for the other 64 tools: 0 chars (never paid for)
+
+============================================================================
+3. Firewall a large tool result
+============================================================================
+firewall: 3,128 chars -> 501-char summary (artifact artifact:result:tc1)
+prompt-side reduction: 84.0%
+artifacts kept (addressable for drilldown): 1
+
+============================================================================
+4. Final answer-phase prompt
+============================================================================
+[USER]
+search the product catalog for 4k monitors under 400 dollars and show the top matches
+
+[TOOL RESULT [artifact:artifact:result:tc1]]
+{
+  "query": "4k monitors",
+  "max_price": 400,
+  "total_matches": 15,
+  "results": [
+    {
+      "product_id": "SKU-1000",
+      "name": "Acer 27\" 4K UHD Monitor",
+      "price_usd": 219,
+      "rating": 3.5,
+      "in_stock": false,
+      "panel": "IPS",
+      "refresh_hz": 60
+    },
+    {
+      "product_id": "SKU-1001",
+      "name": "Dell 28\" 4K UHD Monitor",
+      "price_usd": 226,
+      "rating": 4.8,
+      "in_stock": true,
+      "panel": "VA",
+      "refresh_hz": 75
+    },
+    {
+      …
+
+[TOOL CALL]
+commerce.product_search(...)
+
+--- BuildStats ---
+total_candidates:    3
+included_count:      3
+dropped_count:       0
+dedup_removed:       0
+dependency_closures: 0
+tokens_per_section:  {'user_turn': 21, 'tool_result': 125, 'tool_call': 7}
+
+============================================================================
+Adoption scoreboard
+============================================================================
+catalog size:           65 tools
+shown to model (route): 5 ChoiceCards, 0 schemas
+schemas hydrated:       1 (only the selected tool)
+large result inlined:   0 bytes (firewalled to a 501-char summary)
+```

--- a/examples/architectures/catalog_showcase/README.md
+++ b/examples/architectures/catalog_showcase/README.md
@@ -1,0 +1,76 @@
+# Catalog showcase — reference architecture
+
+> The smallest end-to-end demonstration of why contextweaver exists. A
+> **65-tool** catalog is narrowed to a **5-card shortlist** for one user
+> request, only the selected tool's schema is hydrated, and a large tool
+> result is firewalled to a compact summary — so the prompt stays bounded
+> no matter how big the catalog or the result.
+
+## Run it
+
+```bash
+python examples/architectures/catalog_showcase/main.py
+```
+
+(Or `make architectures` / `make example`.)
+
+A captured run of the script lives in [`OUTPUT.md`](OUTPUT.md).
+
+## What this is (and isn't)
+
+This is the **first architecture to read**. It is deliberately linear —
+one request, four steps — so a new adopter sees the core value before
+learning every concept. The other architectures (code-review bot, Slack
+ops bot, voice agent) layer multi-turn state and richer transcripts on
+top of the same primitives.
+
+It is **deterministic and offline**: the bulk of the catalog is generated
+from a fixed seed (`generate_sample_catalog(n=62, seed=7)`), the three
+schema-rich "hero" tools are defined inline in [`main.py`](main.py), the
+tool result is canned, and no language model or network call happens.
+
+## The four steps
+
+1. **Route → shortlist.** `Router.route(request)` narrows 65 tools to a
+   5-card shortlist. The model only ever sees compact `ChoiceCard`s —
+   never the full catalog and never any argument schema.
+2. **Expand only the selected tool.** After the shortlist is chosen,
+   `Catalog.hydrate(chosen)` resolves the full `args_schema` for the one
+   selected tool (653 chars). The other 64 tools cost zero schema bytes.
+3. **Firewall a large result.** A ~3 KB product-search payload is ingested
+   via `ingest_tool_result_sync(...)`; the firewall replaces it with a
+   ~500-char summary (an 84% prompt-side reduction) and keeps the raw
+   bytes addressable in the artifact store.
+4. **Final answer pack.** `build_sync(phase=Phase.answer, ...)` assembles
+   the budget-aware prompt; `BuildStats` shows exactly what was kept.
+
+## What's load-bearing
+
+| contextweaver feature | Used | What it does here |
+|---|---|---|
+| `Router.route(query)` | ✅ | Narrows 65 tools → top-5 shortlist (`top_k=5`) |
+| `ChoiceCard` rendering | ✅ | The model sees 5 compact cards with **no** argument schemas |
+| `Catalog.hydrate(tool_id)` | ✅ | Lazily resolves the full schema for the **one** selected tool |
+| **Context firewall** | ✅✅ | Compacts the ~3 KB search payload to a ~500-char summary before it touches the prompt |
+| Artifact store | ✅ | Raw bytes stay addressable for drilldown; only the summary lands in the prompt |
+| `ContextBudget` | ✅ | `ContextBudget(route=1500, call=2500, interpret=2500, answer=3000)` keeps every phase bounded |
+
+## What's intentionally not here
+
+- **Real tool execution.** The product-search result is canned to keep the
+  example deterministic. A real deployment would call a backend or an MCP
+  server and pipe the response through the same firewall.
+- **Multi-turn state.** This is a single request. See the
+  [code-review bot](../code_review_bot/README.md) and
+  [Slack ops bot](../slack_ops_bot/README.md) for persistent facts and
+  multi-step transcripts.
+
+## Read next
+
+- The [60-second killer demo](../../../docs/quickstart.md) (`contextweaver
+  demo --scenario killer`) makes the same point as a before/after token
+  comparison.
+- The [cookbook](../../../docs/cookbook.md) covers the individual
+  primitives — routing, firewall, drilldown — used here.
+- [`docs/architectures/catalog_showcase.md`](../../../docs/architectures/catalog_showcase.md)
+  is the public-docs version of this README.

--- a/examples/architectures/catalog_showcase/__init__.py
+++ b/examples/architectures/catalog_showcase/__init__.py
@@ -1,0 +1,1 @@
+"""Catalog showcase reference architecture (issue #330)."""

--- a/examples/architectures/catalog_showcase/main.py
+++ b/examples/architectures/catalog_showcase/main.py
@@ -1,0 +1,277 @@
+"""Catalog showcase — large-catalog adoption story (#330).
+
+The smallest end-to-end demonstration of the contextweaver value
+proposition for a tool-heavy agent:
+
+1. Load a **large** synthetic tool catalog (65 tools).
+2. Build a **compact shortlist** for a single realistic user request — the
+   model only ever sees a handful of :class:`ChoiceCard` objects, never the
+   full catalog and never any argument schema.
+3. **Expand only the selected tool** after the shortlist is chosen — its
+   full ``args_schema`` is hydrated on demand; the other 64 tools cost
+   zero schema bytes.
+4. Ingest a **large** (checked-in, synthetic) tool result and let the
+   context firewall represent it compactly while the raw bytes stay
+   addressable in the artifact store.
+5. Print the final answer-phase context pack and :class:`BuildStats`.
+
+Everything is deterministic — the catalog is generated from a fixed seed,
+the tool result is canned, and no language model or network call happens.
+The point is to show, in one read, why a naive "dump every tool schema and
+every raw result into the prompt" loop falls over at catalog scale and how
+contextweaver keeps the prompt bounded instead.
+
+Run standalone::
+
+    python examples/architectures/catalog_showcase/main.py
+
+Or via ``make example`` (the ``architectures`` umbrella target).
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+
+from contextweaver.config import ContextBudget
+from contextweaver.context.manager import ContextManager
+from contextweaver.routing.cards import make_choice_cards, render_cards_text
+from contextweaver.routing.catalog import Catalog, generate_sample_catalog
+from contextweaver.routing.router import Router
+from contextweaver.routing.tree import TreeBuilder
+from contextweaver.types import ContextItem, ItemKind, Phase, SelectableItem
+
+# A single realistic request for a commerce ops agent. The interesting tool
+# (``commerce.product_search``) carries a real argument schema so the
+# "expand only the selected tool" step has something concrete to hydrate.
+USER_REQUEST = (
+    "search the product catalog for 4k monitors under 400 dollars and show the top matches"
+)
+INTENT = "commerce.product_search"
+
+# Hand-crafted "hero" tools with populated ``args_schema``. The bulk of the
+# catalog is generated synthetically (see ``_build_catalog``) to create
+# realistic routing pressure; these few carry full schemas so hydration
+# shows a non-trivial payload that the route phase never had to pay for.
+_HERO_TOOLS: list[SelectableItem] = [
+    SelectableItem(
+        id="commerce.product_search",
+        kind="tool",
+        name="product_search",
+        description=(
+            "Search the product catalog by keyword, price range, and category; "
+            "returns the top ranked matching products with price and rating"
+        ),
+        tags=["search", "catalog", "products", "price"],
+        namespace="commerce",
+        args_schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Free-text product query"},
+                "max_price": {"type": "number", "description": "Maximum unit price filter"},
+                "category": {"type": "string", "description": "Optional category slug"},
+                "sort": {
+                    "type": "string",
+                    "enum": ["relevance", "price_asc", "price_desc", "rating"],
+                    "default": "relevance",
+                },
+                "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 20},
+            },
+            "required": ["query"],
+        },
+        side_effects=False,
+        cost_hint=0.15,
+    ),
+    SelectableItem(
+        id="commerce.product_details",
+        kind="tool",
+        name="product_details",
+        description="Fetch the full product detail record for a single catalog item by id",
+        tags=["catalog", "products", "detail"],
+        namespace="commerce",
+        args_schema={
+            "type": "object",
+            "properties": {"product_id": {"type": "string"}},
+            "required": ["product_id"],
+        },
+        cost_hint=0.10,
+    ),
+    SelectableItem(
+        id="commerce.inventory_check",
+        kind="tool",
+        name="inventory_check",
+        description="Check warehouse stock levels for a product across regions",
+        tags=["inventory", "stock", "products"],
+        namespace="commerce",
+        cost_hint=0.10,
+    ),
+]
+
+
+@functools.cache
+def _large_search_result() -> str:
+    """Return a ~6 KB synthetic product-search payload (> firewall threshold)."""
+    products = [
+        {
+            "product_id": f"SKU-{1000 + i}",
+            "name": f'{brand} {size}" 4K UHD Monitor',
+            "price_usd": 219 + (i * 7) % 180,
+            "rating": round(3.5 + ((i * 13) % 15) / 10, 1),
+            "in_stock": i % 4 != 0,
+            "panel": ["IPS", "VA", "OLED"][i % 3],
+            "refresh_hz": [60, 75, 120, 144][i % 4],
+        }
+        for i, (brand, size) in enumerate(
+            [
+                ("Acer", 27),
+                ("Dell", 28),
+                ("LG", 27),
+                ("Samsung", 32),
+                ("ASUS", 28),
+                ("BenQ", 27),
+                ("HP", 27),
+                ("ViewSonic", 32),
+                ("MSI", 27),
+                ("Gigabyte", 28),
+                ("Philips", 27),
+                ("AOC", 27),
+                ("Lenovo", 28),
+                ("Sony", 27),
+                ("Apple", 27),
+            ]
+        )
+    ]
+    return json.dumps(
+        {
+            "query": "4k monitors",
+            "max_price": 400,
+            "total_matches": len(products),
+            "results": products,
+        },
+        indent=2,
+    )
+
+
+def _build_catalog() -> Catalog:
+    """Generate a 65-tool catalog: synthetic bulk + a few schema-rich hero tools."""
+    catalog = Catalog()
+    for raw in generate_sample_catalog(n=62, seed=7):
+        catalog.register(SelectableItem.from_dict(raw))
+    for hero in _HERO_TOOLS:
+        catalog.register(hero)
+    return catalog
+
+
+def _print_header(title: str) -> None:
+    """Print a section banner consistent with the other architecture scripts."""
+    print()
+    print("=" * 76)
+    print(title)
+    print("=" * 76)
+
+
+def _select_from_shortlist(shortlist: list[str], intent: str) -> str:
+    """Pick *intent* if it is in *shortlist*, else fall back to ``shortlist[0]``.
+
+    The Router bounds the choice to a handful of cards; a real bot (or an LLM
+    holding the shortlist in its prompt) makes the final pick. The intent map
+    keeps this example deterministic without an LLM.
+    """
+    if intent in shortlist:
+        return intent
+    return shortlist[0]
+
+
+def main() -> None:
+    """Run the catalog showcase end-to-end."""
+    _print_header("contextweaver -- Catalog showcase reference architecture")
+
+    catalog = _build_catalog()
+    items = catalog.all()
+    ns_count = len({it.namespace for it in items})
+    print(f"Loaded catalog: {len(items)} tools across {ns_count} namespaces")
+
+    # ------------------------------------------------------------------
+    # 1. Route the request to a compact shortlist (never the full catalog).
+    # ------------------------------------------------------------------
+    _print_header("1. Route -> compact shortlist")
+    graph = TreeBuilder(max_children=12).build(items)
+    router = Router(graph, items=items, beam_width=3, top_k=5)
+    result = router.route(USER_REQUEST)
+    shortlist = result.candidate_ids
+    print(f"request:  {USER_REQUEST}")
+    print(f"shortlist: {len(shortlist)} of {len(items)} tools -> {shortlist}")
+    cards = make_choice_cards(
+        result.candidate_items,
+        scores=dict(zip(result.candidate_ids, result.scores, strict=False)),
+    )
+    print("\nChoiceCards the model sees (NO argument schemas):")
+    print(render_cards_text(cards))
+
+    # ------------------------------------------------------------------
+    # 2. Expand ONLY the selected tool — hydrate its schema on demand.
+    # ------------------------------------------------------------------
+    _print_header("2. Expand only the selected tool")
+    chosen = _select_from_shortlist(shortlist, INTENT)
+    intent_in_shortlist = INTENT in shortlist
+    print(
+        f"chosen:   {chosen}  "
+        f"(intent={INTENT!r}, {'in shortlist' if intent_in_shortlist else 'NOT in shortlist'})"
+    )
+    hydrated = catalog.hydrate(chosen)
+    schema_json = json.dumps(hydrated.args_schema, indent=2, sort_keys=True)
+    print(f"hydrated schema for {chosen!r}: {len(schema_json)} chars")
+    print(f"hydrated schema for the other {len(items) - 1} tools: 0 chars (never paid for)")
+
+    # ------------------------------------------------------------------
+    # 3. Ingest a large tool result; the firewall keeps the prompt compact.
+    # ------------------------------------------------------------------
+    _print_header("3. Firewall a large tool result")
+    budget = ContextBudget(route=1500, call=2500, interpret=2500, answer=3000)
+    mgr = ContextManager(budget=budget)
+    mgr.ingest_sync(ContextItem(id="u1", kind=ItemKind.user_turn, text=USER_REQUEST))
+    mgr.ingest_sync(
+        ContextItem(id="tc1", kind=ItemKind.tool_call, text=f"{chosen}(...)", parent_id="u1")
+    )
+    raw_output = _large_search_result()
+    item, _envelope = mgr.ingest_tool_result_sync(
+        tool_call_id="tc1",
+        raw_output=raw_output,
+        tool_name=chosen,
+        firewall_threshold=2000,
+    )
+    handle = item.artifact_ref.handle if item.artifact_ref else "<none>"
+    saving = 100.0 * (1.0 - len(item.text) / max(len(raw_output), 1))
+    print(
+        f"firewall: {len(raw_output):,} chars -> {len(item.text):,}-char summary "
+        f"(artifact {handle})"
+    )
+    print(f"prompt-side reduction: {saving:.1f}%")
+    print(
+        f"artifacts kept (addressable for drilldown): {len(list(mgr.artifact_store.list_refs()))}"
+    )
+
+    # ------------------------------------------------------------------
+    # 4. Final answer-phase context pack + BuildStats.
+    # ------------------------------------------------------------------
+    _print_header("4. Final answer-phase prompt")
+    final = mgr.build_sync(phase=Phase.answer, query=USER_REQUEST)
+    print(final.prompt)
+    print()
+    print("--- BuildStats ---")
+    print(f"total_candidates:    {final.stats.total_candidates}")
+    print(f"included_count:      {final.stats.included_count}")
+    print(f"dropped_count:       {final.stats.dropped_count}")
+    print(f"dedup_removed:       {final.stats.dedup_removed}")
+    print(f"dependency_closures: {final.stats.dependency_closures}")
+    print(f"tokens_per_section:  {final.stats.tokens_per_section}")
+
+    _print_header("Adoption scoreboard")
+    print(f"catalog size:           {len(items)} tools")
+    print(f"shown to model (route): {len(shortlist)} ChoiceCards, 0 schemas")
+    print("schemas hydrated:       1 (only the selected tool)")
+    print(f"large result inlined:   0 bytes (firewalled to a {len(item.text):,}-char summary)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/architectures/eval_artifact_profile/OUTPUT.md
+++ b/examples/architectures/eval_artifact_profile/OUTPUT.md
@@ -1,0 +1,197 @@
+# Agent-safe evaluation-artifact context profile — captured run
+
+Output of `python examples/architectures/eval_artifact_profile/main.py`
+from a clean checkout. Deterministic and offline: the three artifact
+fixtures are checked in under `fixtures/`, and the profile does no
+statistical computation — it only shapes the artifact into phase-aware,
+agent-safe context. The trailing `[PASS]` lines are the runtime safety
+invariant checks.
+
+```
+
+============================================================================
+contextweaver -- Agent-safe evaluation-artifact context profile
+============================================================================
+Reliability floor (effective sample size): 500
+
+============================================================================
+Artifact: ok  —  candidate ranking policy v2 vs production baseline v1
+============================================================================
+
+--- route phase (1 items) ---
+[DOCUMENT]
+evaluation artifact (offline_policy_evaluation): status=ok; diagnostics=[support, uncertainty, sensitivity, overlap]; needs_interpretation=True; policy_gating=False
+
+--- interpret phase (8 items) ---
+[FACT]
+support health: healthy: effective sample size 18,432; action overlap good; no extrapolation needed
+
+[POLICY]
+assumption: logged propensities are correct
+
+[POLICY]
+assumption: no unobserved confounding in the logging policy
+
+[FACT]
+delta (candidate - baseline): +0.035 (95% CI [0.011, 0.059]); baseline=0.412, candidate=0.447
+
+[FACT]
+decision stability: stable across sensitivity sweeps (sign of delta unchanged)
+
+[POLICY]
+limitation: evaluation window covers 14 days of traffic only
+
+[FACT]
+headline estimate V_hat=0.447 (95% CI [0.421, 0.473]) — read only alongside the support and uncertainty above
+
+[DOCUMENT]
+full artifact: artifact:ope:ope-2026-05-20-abc
+
+--- answer phase (5 items) ---
+[DOCUMENT]
+evaluated: candidate ranking policy v2 vs production baseline v1
+
+[FACT]
+evidence usable? yes — the evidence is usable (healthy: effective sample size 18,432; action overlap good; no extrapolation needed)
+
+[POLICY]
+caveats: none beyond the stated limitations
+
+[DOCUMENT]
+decision supported: adopt the candidate (delta is positive and stable)
+
+[FACT]
+headline V_hat=0.447 (95% CI [0.421, 0.473])
+
+--- safety invariants ---
+  [PASS] route phase exposes no headline estimate
+  [PASS] interpret phase: support health precedes the estimate
+  [PASS] answer phase: support health precedes the estimate
+
+============================================================================
+Artifact: caution  —  candidate pricing policy v5 vs production baseline v4
+============================================================================
+
+--- route phase (1 items) ---
+[DOCUMENT]
+evaluation artifact (offline_policy_evaluation): status=caution; diagnostics=[support, uncertainty, sensitivity, overlap]; needs_interpretation=True; policy_gating=True
+
+--- interpret phase (11 items) ---
+[FACT]
+support health: moderate: effective sample size 2,140; partial action overlap on high-value segment
+
+[POLICY]
+warning: confidence interval for the delta crosses zero
+
+[POLICY]
+warning: high-value customer segment is thinly supported
+
+[POLICY]
+assumption: logged propensities are correct
+
+[POLICY]
+assumption: segment membership is stable over the window
+
+[FACT]
+delta (candidate - baseline): +0.021 (95% CI [-0.006, 0.048]); baseline=0.318, candidate=0.339
+
+[FACT]
+decision stability: unstable: sign of delta flips under the pessimistic sensitivity sweep
+
+[POLICY]
+limitation: evaluation window covers 7 days only
+
+[POLICY]
+limitation: no holiday traffic represented
+
+[FACT]
+headline estimate V_hat=0.339 (95% CI [0.291, 0.387]) — read only alongside the support and uncertainty above
+
+[DOCUMENT]
+full artifact: artifact:ope:ope-2026-05-22-def
+
+--- answer phase (4 items) ---
+[DOCUMENT]
+evaluated: candidate pricing policy v5 vs production baseline v4
+
+[FACT]
+evidence usable? only with caution — the evidence is weak (moderate: effective sample size 2,140; partial action overlap on high-value segment)
+
+[POLICY]
+caveats: confidence interval for the delta crosses zero; high-value customer segment is thinly supported
+
+[DOCUMENT]
+decision supported: do not adopt yet — gather more support before deciding
+
+--- safety invariants ---
+  [PASS] route phase exposes no headline estimate
+  [PASS] interpret phase: support health precedes the estimate
+  [PASS] answer phase: estimate withheld (safe for this status)
+
+============================================================================
+Artifact: high_risk  —  candidate aggressive-retention policy v9 vs production baseline v8
+============================================================================
+
+--- route phase (1 items) ---
+[DOCUMENT]
+evaluation artifact (offline_policy_evaluation): status=high_risk; diagnostics=[support, uncertainty, overlap]; needs_interpretation=True; policy_gating=True
+
+--- interpret phase (13 items) ---
+[FACT]
+support health: poor: effective sample size 184; severe action mismatch; heavy extrapolation
+
+[POLICY]
+warning: estimate relies on heavy extrapolation outside the logged action distribution
+
+[POLICY]
+warning: effective sample size is below the reliability floor (184 < 500)
+
+[POLICY]
+warning: importance weights are extreme (max weight 1,920)
+
+[POLICY]
+limitation: evaluation window covers 3 days only
+
+[POLICY]
+limitation: no sensitivity sweep available for this run
+
+[POLICY]
+limitation: candidate policy visits actions never taken by the logging policy
+
+[POLICY]
+assumption: logged propensities are correct
+
+[POLICY]
+assumption: the model extrapolates correctly to unsupported actions (UNVERIFIED)
+
+[FACT]
+delta (candidate - baseline): +0.283 (95% CI [-0.14, 0.706]); baseline=0.205, candidate=0.488
+
+[FACT]
+decision stability: not assessable: insufficient support to run a meaningful sensitivity sweep
+
+[FACT]
+headline estimate V_hat=0.488 (95% CI [0.061, 0.915]) — read only alongside the support and uncertainty above
+
+[DOCUMENT]
+full artifact: artifact:ope:ope-2026-05-25-ghi
+
+--- answer phase (4 items) ---
+[DOCUMENT]
+evaluated: candidate aggressive-retention policy v9 vs production baseline v8
+
+[FACT]
+evidence usable? no — the evidence is not usable for a decision (poor: effective sample size 184; severe action mismatch; heavy extrapolation)
+
+[POLICY]
+caveats: estimate relies on heavy extrapolation outside the logged action distribution; effective sample size is below the reliability floor (184 < 500); importance weights are extreme (max weight 1,920)
+
+[DOCUMENT]
+decision supported: do not act on this estimate — treat the run as inconclusive
+
+--- safety invariants ---
+  [PASS] route phase exposes no headline estimate
+  [PASS] interpret phase: support health precedes the estimate
+  [PASS] answer phase: estimate withheld (safe for this status)
+  [PASS] high_risk: caveats are foregrounded before the estimate
+```

--- a/examples/architectures/eval_artifact_profile/README.md
+++ b/examples/architectures/eval_artifact_profile/README.md
@@ -1,0 +1,79 @@
+# Agent-safe evaluation-artifact context profile — reference architecture
+
+> Offline policy-evaluation reports are large and easy to misread. An agent
+> that sees only a headline score such as `V_hat` can draw a confident,
+> wrong conclusion. This profile compiles an evaluation artifact into
+> **phase-aware, agent-safe** context that foregrounds support health,
+> uncertainty, and caveats — and only then the headline estimate.
+
+## Run it
+
+```bash
+python examples/architectures/eval_artifact_profile/main.py
+```
+
+(Or `make architectures` / `make example`.)
+
+A captured run of the script lives in [`OUTPUT.md`](OUTPUT.md).
+
+## What this is (and isn't)
+
+This is a **context-shaping profile**, not a statistics library. It does no
+estimation — that belongs to the artifact producer (for example
+[`skdr-eval`](https://github.com/dgenio/skdr-eval)). It takes a decoded
+evaluation artifact and decides *what to show an agent, in what order, at
+each phase*, so the agent never reasons from a bare estimate.
+
+The profile is the function `compile_eval_context(artifact, phase)` in
+[`main.py`](main.py). Three fixtures under [`fixtures/`](fixtures/) exercise
+it at every risk level:
+
+| Fixture | Decision status | Support |
+|---|---|---|
+| [`artifact_ok.json`](fixtures/artifact_ok.json) | `ok` | healthy (n≈18k, good overlap) |
+| [`artifact_caution.json`](fixtures/artifact_caution.json) | `caution` | moderate (delta CI crosses zero) |
+| [`artifact_high_risk.json`](fixtures/artifact_high_risk.json) | `high_risk` | poor (n=184, heavy extrapolation) |
+
+## Behaviour by phase
+
+- **Route** — summary metadata only: artifact type, available diagnostics,
+  whether it needs interpretation or policy gating. No metrics, no estimate.
+- **Interpret** — the full diagnostic view, ordered: support health →
+  warnings → (limitations, for high-risk) → assumptions → delta with
+  uncertainty → decision stability → limitations → headline estimate →
+  full-artifact handle.
+- **Answer** — a compact human-safe summary: what was evaluated, whether the
+  evidence is usable, the decision it supports, and the caveats that block a
+  stronger conclusion. The headline estimate leads the summary **only** for
+  an `ok` artifact.
+
+## The safety invariants
+
+The profile enforces — and `check_invariants(artifact)` (plus the test
+suite) verifies — two rules for every artifact:
+
+1. **Never present `V_hat` without support diagnostics.** Any phase whose
+   output contains the value estimate also contains a support-health item
+   *earlier* in the list. The route phase never exposes the estimate.
+2. **High-risk artifacts foreground caveats before estimates.** For a
+   `high_risk` artifact, warnings and limitations are emitted before the
+   value estimate in the interpret view, and the answer view withholds the
+   estimate entirely.
+
+`main()` asserts these invariants at runtime, so a regression breaks
+`make example` rather than silently shipping unsafe context shaping.
+
+## What's intentionally not here
+
+- **Statistical computation.** No estimator, no confidence-interval math —
+  the artifact already carries those numbers.
+- **A hard dependency on a producer.** The profile reads a plain dict; it
+  aligns with a `weaver-spec` `EvaluationArtifact` shape when one is
+  available but does not require it.
+
+## Read next
+
+- [`docs/architectures/eval_artifact_profile.md`](../../../docs/architectures/eval_artifact_profile.md)
+  is the public-docs version of this README.
+- The [concepts guide](../../../docs/concepts.md) covers `ContextItem`,
+  `Phase`, and the prompt renderer used here.

--- a/examples/architectures/eval_artifact_profile/__init__.py
+++ b/examples/architectures/eval_artifact_profile/__init__.py
@@ -1,0 +1,1 @@
+"""Agent-safe evaluation-artifact context profile (issue #335)."""

--- a/examples/architectures/eval_artifact_profile/fixtures/artifact_caution.json
+++ b/examples/architectures/eval_artifact_profile/fixtures/artifact_caution.json
@@ -1,0 +1,31 @@
+{
+  "artifact_type": "offline_policy_evaluation",
+  "evaluated": "candidate pricing policy v5 vs production baseline v4",
+  "decision_status": "caution",
+  "support_health": "moderate: effective sample size 2,140; partial action overlap on high-value segment",
+  "available_diagnostics": ["support", "uncertainty", "sensitivity", "overlap"],
+  "needs_interpretation": true,
+  "policy_gating": true,
+  "warnings": [
+    "confidence interval for the delta crosses zero",
+    "high-value customer segment is thinly supported"
+  ],
+  "assumptions": [
+    "logged propensities are correct",
+    "segment membership is stable over the window"
+  ],
+  "limitations": [
+    "evaluation window covers 7 days only",
+    "no holiday traffic represented"
+  ],
+  "key_metrics": {
+    "baseline_value": 0.318,
+    "candidate_value": 0.339,
+    "delta": 0.021,
+    "delta_ci95": [-0.006, 0.048]
+  },
+  "decision_stability": "unstable: sign of delta flips under the pessimistic sensitivity sweep",
+  "value_estimate": {"name": "V_hat", "candidate": 0.339, "ci95": [0.291, 0.387]},
+  "provenance": {"producer": "skdr-eval", "run_id": "ope-2026-05-22-def", "method": "doubly_robust"},
+  "full_artifact_handle": "artifact:ope:ope-2026-05-22-def"
+}

--- a/examples/architectures/eval_artifact_profile/fixtures/artifact_high_risk.json
+++ b/examples/architectures/eval_artifact_profile/fixtures/artifact_high_risk.json
@@ -1,0 +1,33 @@
+{
+  "artifact_type": "offline_policy_evaluation",
+  "evaluated": "candidate aggressive-retention policy v9 vs production baseline v8",
+  "decision_status": "high_risk",
+  "support_health": "poor: effective sample size 184; severe action mismatch; heavy extrapolation",
+  "available_diagnostics": ["support", "uncertainty", "overlap"],
+  "needs_interpretation": true,
+  "policy_gating": true,
+  "warnings": [
+    "estimate relies on heavy extrapolation outside the logged action distribution",
+    "effective sample size is below the reliability floor (184 < 500)",
+    "importance weights are extreme (max weight 1,920)"
+  ],
+  "assumptions": [
+    "logged propensities are correct",
+    "the model extrapolates correctly to unsupported actions (UNVERIFIED)"
+  ],
+  "limitations": [
+    "evaluation window covers 3 days only",
+    "no sensitivity sweep available for this run",
+    "candidate policy visits actions never taken by the logging policy"
+  ],
+  "key_metrics": {
+    "baseline_value": 0.205,
+    "candidate_value": 0.488,
+    "delta": 0.283,
+    "delta_ci95": [-0.140, 0.706]
+  },
+  "decision_stability": "not assessable: insufficient support to run a meaningful sensitivity sweep",
+  "value_estimate": {"name": "V_hat", "candidate": 0.488, "ci95": [0.061, 0.915]},
+  "provenance": {"producer": "skdr-eval", "run_id": "ope-2026-05-25-ghi", "method": "ips"},
+  "full_artifact_handle": "artifact:ope:ope-2026-05-25-ghi"
+}

--- a/examples/architectures/eval_artifact_profile/fixtures/artifact_ok.json
+++ b/examples/architectures/eval_artifact_profile/fixtures/artifact_ok.json
@@ -1,0 +1,27 @@
+{
+  "artifact_type": "offline_policy_evaluation",
+  "evaluated": "candidate ranking policy v2 vs production baseline v1",
+  "decision_status": "ok",
+  "support_health": "healthy: effective sample size 18,432; action overlap good; no extrapolation needed",
+  "available_diagnostics": ["support", "uncertainty", "sensitivity", "overlap"],
+  "needs_interpretation": true,
+  "policy_gating": false,
+  "warnings": [],
+  "assumptions": [
+    "logged propensities are correct",
+    "no unobserved confounding in the logging policy"
+  ],
+  "limitations": [
+    "evaluation window covers 14 days of traffic only"
+  ],
+  "key_metrics": {
+    "baseline_value": 0.412,
+    "candidate_value": 0.447,
+    "delta": 0.035,
+    "delta_ci95": [0.011, 0.059]
+  },
+  "decision_stability": "stable across sensitivity sweeps (sign of delta unchanged)",
+  "value_estimate": {"name": "V_hat", "candidate": 0.447, "ci95": [0.421, 0.473]},
+  "provenance": {"producer": "skdr-eval", "run_id": "ope-2026-05-20-abc", "method": "doubly_robust"},
+  "full_artifact_handle": "artifact:ope:ope-2026-05-20-abc"
+}

--- a/examples/architectures/eval_artifact_profile/main.py
+++ b/examples/architectures/eval_artifact_profile/main.py
@@ -1,0 +1,278 @@
+"""Agent-safe context profile for statistical evaluation artifacts (#335).
+
+Offline policy-evaluation reports are large and easy to misread. An agent
+that sees only a headline score such as ``V_hat`` can draw a confident,
+wrong conclusion. This profile compiles an evaluation artifact into
+**phase-aware, agent-safe** context that foregrounds support health,
+uncertainty, and caveats, and only then the headline estimate.
+
+The profile is the function :func:`compile_eval_context`. It enforces two
+safety invariants for every artifact:
+
+1. **Never present ``V_hat`` without support diagnostics.** Any phase whose
+   output contains the value estimate also contains a support-health item
+   *earlier* in the list. The route phase never exposes the estimate at all.
+2. **High-risk artifacts foreground caveats before estimates.** For a
+   ``high_risk`` artifact, warnings and limitations are emitted before the
+   value estimate.
+
+Three fixtures (``ok`` / ``caution`` / ``high_risk``) under ``fixtures/``
+exercise the profile. Everything is deterministic and offline — no model,
+no network, no statistical computation (that belongs to the artifact
+producer, e.g. ``skdr-eval``; this example only *shapes* its output).
+
+Run standalone::
+
+    python examples/architectures/eval_artifact_profile/main.py
+
+Or via ``make example`` (the ``architectures`` umbrella target).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from contextweaver.context.prompt import render_context
+from contextweaver.types import ContextItem, ItemKind, Phase
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+# Roles stamped on each compiled item so the safety invariants can be
+# checked structurally (rather than by string-matching the rendered text).
+ROLE_SUPPORT = "support_health"
+ROLE_VALUE = "value_estimate"
+ROLE_CAVEAT = "caveat"
+
+# Below this effective sample size an offline estimate is treated as
+# unreliable; surfaced here only to document the producer's convention.
+RELIABILITY_FLOOR = 500
+
+_USABILITY = {
+    "ok": "yes — the evidence is usable",
+    "caution": "only with caution — the evidence is weak",
+    "high_risk": "no — the evidence is not usable for a decision",
+}
+_DECISION = {
+    "ok": "adopt the candidate (delta is positive and stable)",
+    "caution": "do not adopt yet — gather more support before deciding",
+    "high_risk": "do not act on this estimate — treat the run as inconclusive",
+}
+
+
+def _item(seq: int, kind: ItemKind, text: str, role: str) -> ContextItem:
+    """Build a compiled context item tagged with its safety *role*."""
+    return ContextItem(id=f"eval-{role}-{seq}", kind=kind, text=text, metadata={"role": role})
+
+
+def compile_eval_context(artifact: dict[str, Any], phase: Phase) -> list[ContextItem]:
+    """Compile an evaluation *artifact* into agent-safe context for *phase*.
+
+    Args:
+        artifact: A decoded evaluation-artifact dict (see ``fixtures/``).
+        phase: The pipeline phase the context is being built for.
+
+    Returns:
+        An ordered list of :class:`~contextweaver.types.ContextItem`. The
+        ordering encodes the safety invariants documented in the module
+        docstring.
+    """
+    status = str(artifact["decision_status"])
+    items: list[ContextItem] = []
+    seq = 0
+
+    if phase is Phase.route:
+        # Route: summary metadata only — no metrics, no estimate.
+        diagnostics = ", ".join(artifact.get("available_diagnostics", []))
+        items.append(
+            _item(
+                seq,
+                ItemKind.doc_snippet,
+                f"evaluation artifact ({artifact['artifact_type']}): status={status}; "
+                f"diagnostics=[{diagnostics}]; needs_interpretation="
+                f"{artifact['needs_interpretation']}; policy_gating={artifact['policy_gating']}",
+                "summary_metadata",
+            )
+        )
+        return items
+
+    if phase is Phase.interpret:
+        # 1. Support health is ALWAYS first — it gates how every later
+        #    number should be read.
+        items.append(
+            _item(
+                seq,
+                ItemKind.memory_fact,
+                f"support health: {artifact['support_health']}",
+                ROLE_SUPPORT,
+            )
+        )
+        seq += 1
+        # 2. Warnings (caveats) come next.
+        for warning in artifact.get("warnings", []):
+            items.append(_item(seq, ItemKind.policy, f"warning: {warning}", ROLE_CAVEAT))
+            seq += 1
+        # 3. For high-risk artifacts, surface limitations BEFORE any estimate.
+        if status == "high_risk":
+            for limitation in artifact.get("limitations", []):
+                items.append(_item(seq, ItemKind.policy, f"limitation: {limitation}", ROLE_CAVEAT))
+                seq += 1
+        # 4. Assumptions the estimate rests on.
+        for assumption in artifact.get("assumptions", []):
+            items.append(_item(seq, ItemKind.policy, f"assumption: {assumption}", "assumption"))
+            seq += 1
+        # 5. Effect size with uncertainty.
+        metrics = artifact["key_metrics"]
+        items.append(
+            _item(
+                seq,
+                ItemKind.memory_fact,
+                f"delta (candidate - baseline): {metrics['delta']:+.3f} "
+                f"(95% CI {metrics['delta_ci95']}); baseline={metrics['baseline_value']}, "
+                f"candidate={metrics['candidate_value']}",
+                "metrics",
+            )
+        )
+        seq += 1
+        # 6. Sensitivity / decision stability.
+        items.append(
+            _item(
+                seq,
+                ItemKind.memory_fact,
+                f"decision stability: {artifact['decision_stability']}",
+                "stability",
+            )
+        )
+        seq += 1
+        # 7. Limitations (for non-high-risk; high-risk already surfaced them).
+        if status != "high_risk":
+            for limitation in artifact.get("limitations", []):
+                items.append(_item(seq, ItemKind.policy, f"limitation: {limitation}", ROLE_CAVEAT))
+                seq += 1
+        # 8. Headline estimate LAST — never before its support diagnostics.
+        estimate = artifact["value_estimate"]
+        items.append(
+            _item(
+                seq,
+                ItemKind.memory_fact,
+                f"headline estimate {estimate['name']}={estimate['candidate']} "
+                f"(95% CI {estimate['ci95']}) — read only alongside the support and "
+                "uncertainty above",
+                ROLE_VALUE,
+            )
+        )
+        seq += 1
+        # 9. Handle to the full artifact for drilldown.
+        items.append(
+            _item(
+                seq,
+                ItemKind.doc_snippet,
+                f"full artifact: {artifact['full_artifact_handle']}",
+                "handle",
+            )
+        )
+        return items
+
+    # Phase.answer (and any other phase): a compact human-safe summary.
+    items.append(_item(seq, ItemKind.doc_snippet, f"evaluated: {artifact['evaluated']}", "summary"))
+    seq += 1
+    items.append(
+        _item(
+            seq,
+            ItemKind.memory_fact,
+            f"evidence usable? {_USABILITY[status]} ({artifact['support_health']})",
+            ROLE_SUPPORT,
+        )
+    )
+    seq += 1
+    caveats = list(artifact.get("warnings", [])) or ["none beyond the stated limitations"]
+    items.append(_item(seq, ItemKind.policy, "caveats: " + "; ".join(caveats), ROLE_CAVEAT))
+    seq += 1
+    items.append(
+        _item(seq, ItemKind.doc_snippet, f"decision supported: {_DECISION[status]}", "decision")
+    )
+    seq += 1
+    # Only an OK artifact leads the human-facing summary with the estimate,
+    # and only after the usability statement above.
+    if status == "ok":
+        estimate = artifact["value_estimate"]
+        items.append(
+            _item(
+                seq,
+                ItemKind.memory_fact,
+                f"headline {estimate['name']}={estimate['candidate']} (95% CI {estimate['ci95']})",
+                ROLE_VALUE,
+            )
+        )
+    return items
+
+
+def check_invariants(artifact: dict[str, Any]) -> list[str]:
+    """Return human-readable PASS/FAIL lines for the profile's safety rules.
+
+    Raises:
+        AssertionError: if any safety invariant is violated, so a
+            regression breaks ``make example`` rather than shipping unsafe
+            context shaping silently.
+    """
+    lines: list[str] = []
+
+    def _roles(items: list[ContextItem]) -> list[str]:
+        return [str(it.metadata.get("role", "")) for it in items]
+
+    route_roles = _roles(compile_eval_context(artifact, Phase.route))
+    assert ROLE_VALUE not in route_roles, "route phase must not expose the value estimate"
+    lines.append("  [PASS] route phase exposes no headline estimate")
+
+    for phase in (Phase.interpret, Phase.answer):
+        roles = _roles(compile_eval_context(artifact, phase))
+        if ROLE_VALUE in roles:
+            assert ROLE_SUPPORT in roles, f"{phase.value}: estimate shown without support health"
+            assert roles.index(ROLE_SUPPORT) < roles.index(ROLE_VALUE), (
+                f"{phase.value}: support health must precede the estimate"
+            )
+            lines.append(f"  [PASS] {phase.value} phase: support health precedes the estimate")
+        else:
+            lines.append(f"  [PASS] {phase.value} phase: estimate withheld (safe for this status)")
+
+    if artifact["decision_status"] == "high_risk":
+        roles = _roles(compile_eval_context(artifact, Phase.interpret))
+        assert ROLE_VALUE in roles and ROLE_CAVEAT in roles
+        assert roles.index(ROLE_CAVEAT) < roles.index(ROLE_VALUE), (
+            "high_risk: caveats must be foregrounded before the estimate"
+        )
+        lines.append("  [PASS] high_risk: caveats are foregrounded before the estimate")
+
+    return lines
+
+
+def _print_header(title: str) -> None:
+    """Print a section banner consistent with the other architecture scripts."""
+    print()
+    print("=" * 76)
+    print(title)
+    print("=" * 76)
+
+
+def main() -> None:
+    """Compile and validate all three artifact fixtures through every phase."""
+    _print_header("contextweaver -- Agent-safe evaluation-artifact context profile")
+    print(f"Reliability floor (effective sample size): {RELIABILITY_FLOOR}")
+
+    for status in ("ok", "caution", "high_risk"):
+        artifact = json.loads((_FIXTURES / f"artifact_{status}.json").read_text(encoding="utf-8"))
+        _print_header(f"Artifact: {status}  —  {artifact['evaluated']}")
+
+        for phase in (Phase.route, Phase.interpret, Phase.answer):
+            items = compile_eval_context(artifact, phase)
+            print(f"\n--- {phase.value} phase ({len(items)} items) ---")
+            print(render_context(items))
+
+        print("\n--- safety invariants ---")
+        for line in check_invariants(artifact):
+            print(line)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/architectures/eval_artifact_profile/main.py
+++ b/examples/architectures/eval_artifact_profile/main.py
@@ -211,10 +211,14 @@ def compile_eval_context(artifact: dict[str, Any], phase: Phase) -> list[Context
 def check_invariants(artifact: dict[str, Any]) -> list[str]:
     """Return human-readable PASS/FAIL lines for the profile's safety rules.
 
+    The asserts below are a best-effort in-demo guard so an obvious
+    regression trips ``make example``; they are not a hardened runtime gate
+    (Python's ``-O`` strips ``assert``). The authoritative regression gate
+    is ``tests/test_architectures_eval_artifact_profile.py``.
+
     Raises:
-        AssertionError: if any safety invariant is violated, so a
-            regression breaks ``make example`` rather than shipping unsafe
-            context shaping silently.
+        AssertionError: if any safety invariant is violated (when run
+            without ``-O``).
     """
     lines: list[str] = []
 

--- a/examples/architectures/langgraph_agent_loop/OUTPUT.md
+++ b/examples/architectures/langgraph_agent_loop/OUTPUT.md
@@ -1,0 +1,46 @@
+# LangGraph agent loop — captured run
+
+Output of `python examples/architectures/langgraph_agent_loop/main.py`
+from a clean checkout with LangGraph installed. Deterministic: routing is
+seed-stable, tool responses are canned, and the firewall is hash-based on
+artifact content. Without LangGraph installed the only difference is the
+`agent loop engine:` line — the hand-rolled fallback produces identical
+output otherwise.
+
+```
+
+============================================================================
+contextweaver -- LangGraph agent-loop reference architecture
+============================================================================
+agent loop engine: langgraph
+catalog: 36 tools across 9 namespaces
+
+============================================================================
+Turn t1
+============================================================================
+user: Our checkout API is throwing 500s — pull the recent error logs for the payments service
+routed shortlist: ['infra.logs_search', 'infra.logs.tail', 'infra.deployments.list', 'admin.audit.export', 'admin.roles.create']
+chosen: infra.logs_search  (intent='infra.logs_search', in shortlist)
+route prompt:  naive all-tools 2,364 chars  ->  ChoiceCards 526 chars
+firewall: 21,705 chars -> 49-char summary (artifact artifact:result:t1-tc)
+answer prompt: 228 chars  (included=3, dependency_closures=0)
+
+============================================================================
+Turn t2
+============================================================================
+user: Summarize the likely root cause from those logs and draft an incident note
+routed shortlist: ['incident.draft_note', 'incident.page_oncall', 'admin.audit.export', 'admin.roles.create', 'admin.roles.list']
+chosen: incident.draft_note  (intent='incident.draft_note', in shortlist)
+route prompt:  naive all-tools 2,364 chars  ->  ChoiceCards 561 chars
+answer prompt: 538 chars  (included=6, dependency_closures=0)
+
+============================================================================
+What this showed
+============================================================================
+- LangGraph owned the route -> execute -> answer control flow.
+- contextweaver bounded the catalog to a 5-card shortlist each turn.
+- the large log result was firewalled to a summary on turn t1.
+- turn t2's answer carried turn t1's firewalled result forward
+  (cross-turn retention); the dependency_closure stage keeps every
+  tool result paired with its originating tool call.
+```

--- a/examples/architectures/langgraph_agent_loop/README.md
+++ b/examples/architectures/langgraph_agent_loop/README.md
@@ -1,0 +1,92 @@
+# LangGraph agent loop — reference architecture
+
+> contextweaver running **inside** a LangGraph agent loop, not as a
+> replacement for one. LangGraph owns control flow; contextweaver owns
+> phase-aware context compilation (route → firewall → answer); tool
+> execution stays outside contextweaver.
+
+## Run it
+
+```bash
+python examples/architectures/langgraph_agent_loop/main.py
+```
+
+(Or `make architectures` / `make example`.)
+
+A captured run of the script lives in [`OUTPUT.md`](OUTPUT.md).
+
+## The boundary (the whole point)
+
+| Concern | Owner |
+|---|---|
+| Control flow (`route -> execute -> answer`, the per-turn loop) | **LangGraph** `StateGraph` |
+| Tool selection bounding (catalog → ChoiceCard shortlist) | **contextweaver** route phase |
+| Large tool-result firewalling | **contextweaver** interpret phase |
+| Budget-aware prompt with dependency-chain preservation | **contextweaver** answer phase |
+| Actually executing a tool | The app / a tool runtime (here: mocked) |
+
+contextweaver never executes a tool and never calls a model — it prepares
+context and routes tools. The graph nodes do the orchestration.
+
+## LangGraph is optional
+
+The import is guarded:
+
+```python
+try:
+    from langgraph.graph import END, START, StateGraph
+    _HAS_LANGGRAPH = True
+except ImportError:
+    _HAS_LANGGRAPH = False
+```
+
+When LangGraph is installed (`pip install 'contextweaver[langgraph]'`) the
+real `StateGraph` drives the loop. Otherwise an equivalent hand-rolled loop
+calls the *same* node functions in the same order. The output is identical
+either way — the test suite asserts the two paths agree apart from the
+one `agent loop engine:` banner line — so the example runs under a bare
+`pip install contextweaver`.
+
+## The scenario
+
+A two-turn ops session. The "model" decision at each node is a deterministic
+intent map standing in for an LLM holding the rendered ChoiceCards in its
+prompt (the comments mark exactly where a real LLM call would go), so the
+run needs no API key and no network.
+
+1. *"Our checkout API is throwing 500s — pull the recent error logs for the
+   payments service"* → routes to `infra.logs_search`. The tool returns a
+   ~21 KB log dump, which the firewall compacts to a short summary while the
+   raw bytes stay in the artifact store.
+2. *"Summarize the likely root cause from those logs and draft an incident
+   note"* → routes to `incident.draft_note`. The answer build carries turn 1's
+   firewalled result forward (cross-turn retention); the `dependency_closure`
+   stage keeps every tool result paired with its originating tool call.
+
+## What's load-bearing
+
+| contextweaver feature | Used | What it does here |
+|---|---|---|
+| `Router.route(query)` | ✅ | Narrows 36 tools → top-5 shortlist each turn |
+| `ChoiceCard` rendering | ✅ | The shortlist an LLM node would choose from |
+| **Context firewall** | ✅✅ | Compacts the ~21 KB log dump before it touches the prompt |
+| Artifact store | ✅ | Raw log bytes stay addressable for drilldown |
+| Cross-turn `ContextManager` | ✅ | Turn 2 sees turn 1's (firewalled) result |
+| `ContextBudget` | ✅ | Keeps every phase prompt bounded |
+
+## What's intentionally not here
+
+- **A real LLM.** The intent map is the stand-in; swap in a model call at
+  the marked spot in `route_node`.
+- **Real observability tools.** `infra.logs_search` returns a canned dump to
+  keep the run deterministic; wire it to your logging backend or an MCP
+  server in production.
+- **LangGraph persistence/checkpointing.** Cross-turn state lives in the
+  `ContextManager`, which is the boundary this example illustrates.
+
+## Read next
+
+- [`docs/architectures/langgraph_agent_loop.md`](../../../docs/architectures/langgraph_agent_loop.md)
+  is the public-docs version of this README.
+- The [comparison page](../../../docs/comparison.md) explains why
+  contextweaver complements (rather than replaces) agent frameworks.

--- a/examples/architectures/langgraph_agent_loop/__init__.py
+++ b/examples/architectures/langgraph_agent_loop/__init__.py
@@ -1,0 +1,1 @@
+"""LangGraph agent-loop reference architecture (issue #326)."""

--- a/examples/architectures/langgraph_agent_loop/main.py
+++ b/examples/architectures/langgraph_agent_loop/main.py
@@ -1,0 +1,357 @@
+"""contextweaver inside a LangGraph agent loop (#326).
+
+A support/ops agent fronting ~36 tools, driven by a **LangGraph**
+``StateGraph``. The boundary is the point of this example:
+
+- **LangGraph owns control flow** — the route -> execute -> answer graph,
+  and the per-turn invocation loop.
+- **contextweaver owns context compilation** — it narrows the catalog to a
+  ChoiceCard shortlist (route), firewalls large tool results (interpret),
+  and assembles a budget-aware answer prompt with dependency-chain
+  preservation (answer).
+- **Tool execution stays outside contextweaver** — the nodes call mocked
+  backends; contextweaver never executes a tool.
+
+The scenario is two turns, the second a follow-up that depends on the first
+turn's (firewalled) tool result, so the answer build has to pull the prior
+result back in via dependency closure.
+
+This runs with **no API keys and no network**: the "model" decision at each
+node is a deterministic intent map standing in for an LLM holding the
+ChoiceCard shortlist in its prompt. The comments mark exactly where a real
+LLM call would go.
+
+LangGraph is optional. When it is installed the real ``StateGraph`` drives
+the loop; otherwise an equivalent hand-rolled loop calls the same node
+functions in the same order, so the output is identical either way and the
+example still runs under a bare ``pip install contextweaver``. Install the
+framework with ``pip install 'contextweaver[langgraph]'``.
+
+Run standalone::
+
+    python examples/architectures/langgraph_agent_loop/main.py
+
+Or via ``make example`` (the ``architectures`` umbrella target).
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any, TypedDict
+
+from contextweaver.config import ContextBudget
+from contextweaver.context.manager import ContextManager
+from contextweaver.routing.cards import make_choice_cards, render_cards_text
+from contextweaver.routing.catalog import Catalog, generate_sample_catalog
+from contextweaver.routing.router import Router
+from contextweaver.routing.tree import TreeBuilder
+from contextweaver.types import ContextItem, ItemKind, Phase, SelectableItem
+
+try:  # Optional framework — see module docstring.
+    from langgraph.graph import END, START, StateGraph
+
+    _HAS_LANGGRAPH = True
+except ImportError:  # pragma: no cover - exercised only without the extra
+    _HAS_LANGGRAPH = False
+
+
+class TurnState(TypedDict, total=False):
+    """Per-turn LangGraph state. Each key is a channel that persists across
+    nodes; nodes return only the fields they update. The heavy context
+    (ContextManager, routing graph) lives in :class:`_Session`, not here."""
+
+    turn_id: str
+    query: str
+    intent: str
+    shortlist: list[str]
+    chosen: str
+    cards_text: str
+    raw_chars: int
+    firewall_note: str
+    answer_prompt: str
+    answer_chars: int
+    closures: int
+    included: int
+
+
+# Hero tools with strong, query-aligned vocabulary so routing is
+# deterministic; the rest of the catalog is generated for realistic
+# routing pressure (see ``_build_catalog``).
+_HERO_TOOLS: list[SelectableItem] = [
+    SelectableItem(
+        id="infra.logs_search",
+        kind="tool",
+        name="logs_search",
+        description="Search recent service error logs and stack traces by service and time window",
+        tags=["logs", "errors", "incident", "infra", "observability"],
+        namespace="infra",
+        cost_hint=0.3,
+    ),
+    SelectableItem(
+        id="infra.metrics_query",
+        kind="tool",
+        name="metrics_query",
+        description="Query service metrics (latency, error rate, saturation) over a time range",
+        tags=["metrics", "latency", "infra", "observability"],
+        namespace="infra",
+        cost_hint=0.2,
+    ),
+    SelectableItem(
+        id="incident.draft_note",
+        kind="tool",
+        name="draft_note",
+        description="Draft an incident summary note describing root cause, impact, and next steps",
+        tags=["incident", "summary", "note", "write"],
+        namespace="incident",
+        side_effects=True,
+        cost_hint=0.1,
+    ),
+    SelectableItem(
+        id="incident.page_oncall",
+        kind="tool",
+        name="page_oncall",
+        description="Page the on-call engineer for a service with an incident severity",
+        tags=["incident", "page", "oncall", "write"],
+        namespace="incident",
+        side_effects=True,
+        cost_hint=0.1,
+    ),
+]
+
+# A two-turn ops session. Each entry is ``(turn_id, user_text, intent)``
+# where ``intent`` is the tool an LLM would pick *given the routed
+# shortlist*. The second turn depends on the first turn's tool result.
+TRANSCRIPT: list[tuple[str, str, str]] = [
+    (
+        "t1",
+        "Our checkout API is throwing 500s — pull the recent error logs for the payments service",
+        "infra.logs_search",
+    ),
+    (
+        "t2",
+        "Summarize the likely root cause from those logs and draft an incident note",
+        "incident.draft_note",
+    ),
+]
+
+
+@functools.cache
+def _large_log_dump() -> str:
+    """Return a ~8 KB synthetic error-log payload (> firewall threshold)."""
+    lines = [
+        "service: payments  window: last 15m  level>=ERROR",
+        "",
+    ]
+    for i in range(110):
+        ts = f"2026-05-28T09:{i % 60:02d}:{(i * 7) % 60:02d}Z"
+        lines.append(
+            f"{ts} ERROR [payments] HTTP 500 POST /charge "
+            f"trace_id=tr-{4000 + i} err=ConnectionResetError "
+            f"upstream=ledger-db pool_wait_ms={(i * 13) % 900} "
+            f"msg='connection reset by peer while acquiring ledger lock'"
+        )
+    return "\n".join(lines) + "\n"
+
+
+_TOOL_RESPONSES: dict[str, str] = {
+    "infra.logs_search": _large_log_dump(),
+    "incident.draft_note": (
+        "incident note drafted: 'Payments 500s caused by ledger-db connection "
+        "resets under lock contention; mitigation: raise pool size + add retry.'"
+    ),
+}
+
+
+def _build_catalog() -> Catalog:
+    """Generate a ~36-tool catalog: synthetic bulk + query-aligned hero tools."""
+    catalog = Catalog()
+    for raw in generate_sample_catalog(n=32, seed=11):
+        catalog.register(SelectableItem.from_dict(raw))
+    for hero in _HERO_TOOLS:
+        catalog.register(hero)
+    return catalog
+
+
+def _select_from_shortlist(shortlist: list[str], intent: str) -> str:
+    """Pick *intent* if routed into the shortlist, else fall back to the top card.
+
+    This is the stand-in for the LLM decision: a real agent would put the
+    rendered ChoiceCards into its prompt and let the model choose. The
+    intent map keeps the example deterministic and key-free.
+    """
+    return intent if intent in shortlist else shortlist[0]
+
+
+class _Session:
+    """Holds the cross-turn agent state shared by the graph nodes.
+
+    The :class:`ContextManager` (and the routing graph) live here, *outside*
+    the LangGraph state, because they are not serialisable and because this
+    is exactly the boundary the example illustrates: the framework threads
+    lightweight per-turn state; contextweaver owns the heavy context.
+    """
+
+    def __init__(self) -> None:
+        self.catalog = _build_catalog()
+        items = self.catalog.all()
+        self.items = items
+        graph = TreeBuilder(max_children=10).build(items)
+        self.router = Router(graph, items=items, beam_width=3, top_k=5)
+        budget = ContextBudget(route=1200, call=2000, interpret=2000, answer=2600)
+        self.mgr = ContextManager(budget=budget)
+        self.step = 0
+
+    def render_all_tool_descriptions(self) -> str:
+        """The naive baseline: every tool description dumped into the prompt."""
+        return "\n".join(f"- {it.id} ({it.namespace}): {it.description}" for it in self.items)
+
+
+def _make_nodes(session: _Session) -> dict[str, Any]:
+    """Build the three graph node callables bound to *session*.
+
+    Each node takes the per-turn state dict and returns the fields it
+    updated — the signature LangGraph expects, and equally usable by the
+    hand-rolled fallback loop.
+    """
+
+    def route_node(state: dict[str, Any]) -> dict[str, Any]:
+        """contextweaver route phase: narrow the catalog to a shortlist."""
+        query = state["query"]
+        session.mgr.ingest_sync(
+            ContextItem(id=state["turn_id"] + "-u", kind=ItemKind.user_turn, text=query)
+        )
+        result = session.router.route(query)
+        shortlist = result.candidate_ids
+        # --- where a real LLM call would go -------------------------------
+        # The agent would receive these ChoiceCards in its prompt and pick a
+        # tool. We substitute a deterministic intent map instead.
+        cards = make_choice_cards(
+            result.candidate_items,
+            scores=dict(zip(result.candidate_ids, result.scores, strict=False)),
+        )
+        chosen = _select_from_shortlist(shortlist, state["intent"])
+        return {"shortlist": shortlist, "chosen": chosen, "cards_text": render_cards_text(cards)}
+
+    def execute_node(state: dict[str, Any]) -> dict[str, Any]:
+        """Tool execution (outside contextweaver) + interpret-phase firewall."""
+        chosen = state["chosen"]
+        tc_id = state["turn_id"] + "-tc"
+        session.mgr.ingest_sync(
+            ContextItem(
+                id=tc_id,
+                kind=ItemKind.tool_call,
+                text=f"{chosen}(...)",
+                parent_id=state["turn_id"] + "-u",
+            )
+        )
+        # The framework (or a real tool runtime) executes the tool. Here it
+        # is mocked; contextweaver only sees the *result*.
+        raw_output = _TOOL_RESPONSES.get(chosen, f"{chosen} returned ok")
+        item, _envelope = session.mgr.ingest_tool_result_sync(
+            tool_call_id=tc_id,
+            raw_output=raw_output,
+            tool_name=chosen,
+            firewall_threshold=2000,
+        )
+        fired = item.artifact_ref is not None and len(raw_output) > 2000
+        note = ""
+        if fired and item.artifact_ref is not None:
+            note = (
+                f"{len(raw_output):,} chars -> {len(item.text):,}-char summary "
+                f"(artifact {item.artifact_ref.handle})"
+            )
+        return {"raw_chars": len(raw_output), "firewall_note": note}
+
+    def answer_node(state: dict[str, Any]) -> dict[str, Any]:
+        """contextweaver answer phase: budget-aware prompt with closures."""
+        pack = session.mgr.build_sync(phase=Phase.answer, query=state["query"])
+        return {
+            "answer_prompt": pack.prompt,
+            "answer_chars": len(pack.prompt),
+            "closures": pack.stats.dependency_closures,
+            "included": pack.stats.included_count,
+        }
+
+    return {"route": route_node, "execute": execute_node, "answer": answer_node}
+
+
+def _run_turn_langgraph(session: _Session, nodes: dict[str, Any], turn: dict[str, Any]) -> dict:
+    """Drive one turn through a real LangGraph ``StateGraph``."""
+    builder = StateGraph(TurnState)
+    builder.add_node("route", nodes["route"])
+    builder.add_node("execute", nodes["execute"])
+    builder.add_node("answer", nodes["answer"])
+    builder.add_edge(START, "route")
+    builder.add_edge("route", "execute")
+    builder.add_edge("execute", "answer")
+    builder.add_edge("answer", END)
+    graph = builder.compile()
+    return dict(graph.invoke(turn))
+
+
+def _run_turn_fallback(session: _Session, nodes: dict[str, Any], turn: dict[str, Any]) -> dict:
+    """Drive one turn through an equivalent hand-rolled loop (no LangGraph)."""
+    state = dict(turn)
+    for name in ("route", "execute", "answer"):
+        state.update(nodes[name](state))
+    return state
+
+
+def _print_header(title: str) -> None:
+    """Print a section banner consistent with the other architecture scripts."""
+    print()
+    print("=" * 76)
+    print(title)
+    print("=" * 76)
+
+
+def main() -> None:
+    """Run the LangGraph agent loop end-to-end."""
+    _print_header("contextweaver -- LangGraph agent-loop reference architecture")
+    engine = "langgraph" if _HAS_LANGGRAPH else "fallback (langgraph not installed)"
+    session = _Session()
+    nodes = _make_nodes(session)
+    print(f"agent loop engine: {engine}")
+    n_namespaces = len({i.namespace for i in session.items})
+    print(f"catalog: {len(session.items)} tools across {n_namespaces} namespaces")
+
+    run_turn = _run_turn_langgraph if _HAS_LANGGRAPH else _run_turn_fallback
+
+    for turn_id, user_text, intent in TRANSCRIPT:
+        _print_header(f"Turn {turn_id}")
+        print(f"user: {user_text}")
+
+        # Naive baseline for this turn: dump every tool description (route)
+        # plus, on the answer side, the raw tool result the firewall would
+        # otherwise externalise.
+        naive_tools = session.render_all_tool_descriptions()
+
+        state = run_turn(session, nodes, {"turn_id": turn_id, "query": user_text, "intent": intent})
+
+        print(f"routed shortlist: {state['shortlist']}")
+        print(
+            f"chosen: {state['chosen']}  "
+            f"(intent={intent!r}, {'in shortlist' if intent in state['shortlist'] else 'fallback'})"
+        )
+        print(
+            f"route prompt:  naive all-tools {len(naive_tools):,} chars  ->  "
+            f"ChoiceCards {len(state['cards_text']):,} chars"
+        )
+        if state.get("firewall_note"):
+            print(f"firewall: {state['firewall_note']}")
+        print(
+            f"answer prompt: {state['answer_chars']:,} chars  "
+            f"(included={state['included']}, dependency_closures={state['closures']})"
+        )
+
+    _print_header("What this showed")
+    print("- LangGraph owned the route -> execute -> answer control flow.")
+    print("- contextweaver bounded the catalog to a 5-card shortlist each turn.")
+    print("- the large log result was firewalled to a summary on turn t1.")
+    print("- turn t2's answer carried turn t1's firewalled result forward")
+    print("  (cross-turn retention); the dependency_closure stage keeps every")
+    print("  tool result paired with its originating tool call.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
   - Home: index.md
   - Quickstart: quickstart.md
   - Showcase: showcase.md
+  - 60-second demo: killer_demo.md
   - Where it fits: comparison.md
   - Ecosystem Map: ecosystem.md
   - FAQ: faq.md
@@ -75,10 +76,13 @@ nav:
   - Cookbook: cookbook.md
   - Architectures:
       - Overview: architectures/index.md
+      - Catalog showcase: architectures/catalog_showcase.md
       - MCP Context Gateway: architectures/mcp_context_gateway.md
       - Slack ops bot: architectures/slack_ops_bot.md
       - Code-review bot: architectures/code_review_bot.md
       - Voice agent: architectures/voice_agent.md
+      - LangGraph agent loop: architectures/langgraph_agent_loop.md
+      - Evaluation-artifact profile: architectures/eval_artifact_profile.md
   - Recipes:
       - Overview: recipes/index.md
       - Claude Desktop: recipes/claude_desktop.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,13 @@ dev = [
     # ``[fastmcp]`` runtime extra below stays for end users who don't want
     # the dev toolchain.
     "fastmcp>=2.0",
+    # LangGraph is pulled into [dev] so the LangGraph agent-loop reference
+    # architecture (``examples/architectures/langgraph_agent_loop``, issue
+    # #326) exercises the *real* ``StateGraph`` under ``make example`` in CI.
+    # The example also ships a hand-rolled fallback so it still runs without
+    # this dependency; the ``[langgraph]`` runtime extra below is for end
+    # users who want the framework without the dev toolchain.
+    "langgraph>=0.2",
 ]
 # weaver-spec contract adapter (https://github.com/dgenio/weaver-spec).
 # Runtime extra for end users who want to interoperate with the canonical
@@ -143,6 +150,14 @@ agno = [
 # LangChain integration examples.
 langchain = [
     "langchain-core>=0.3",
+]
+# LangGraph agent-loop reference architecture (issue #326).  Pulls the
+# LangGraph runtime so ``examples/architectures/langgraph_agent_loop`` can
+# drive its route -> execute -> answer loop through a real ``StateGraph``.
+# The example ships a hand-rolled fallback, so it runs without this extra;
+# install it to exercise the framework path.
+langgraph = [
+    "langgraph>=0.2",
 ]
 # Real-time voice agents: Pipecat frame processors composed with the
 # contextweaver context engine.  Optional because pipecat-ai pulls heavy
@@ -236,6 +251,7 @@ all = [
     "contextweaver[graph]",
     "contextweaver[weaver-spec]",
     "contextweaver[voice]",
+    "contextweaver[langgraph]",
     "contextweaver[e2e-eval]",
 ]
 

--- a/src/contextweaver/__main__.py
+++ b/src/contextweaver/__main__.py
@@ -85,6 +85,7 @@ class _DemoScenario(str, Enum):
     huge_tool_output = "huge-tool-output"
     mcp_gateway = "mcp-gateway"
     mcp_gateway_full = "mcp-gateway-full"
+    killer = "killer"
 
 
 # ---------------------------------------------------------------------------
@@ -197,7 +198,9 @@ def demo(
                 "large-catalog = 1,000 tools shortlisted to compact ChoiceCards; "
                 "huge-tool-output = context firewall on a ~10 KB tool result; "
                 "mcp-gateway = MCP gateway meta-tools end-to-end (3 stub tools, no network); "
-                "mcp-gateway-full = full 60-tool MCP Context Gateway architecture (issue #264)."
+                "mcp-gateway-full = full 60-tool MCP Context Gateway architecture (issue #264); "
+                "killer = the 60-second failure mode: 100 tools + huge output, naive vs "
+                "contextweaver (issue #322)."
             ),
         ),
     ] = _DemoScenario.default,
@@ -211,6 +214,7 @@ def demo(
         _DemoScenario.huge_tool_output: _demos.run_huge_tool_output,
         _DemoScenario.mcp_gateway: _demos.run_mcp_gateway,
         _DemoScenario.mcp_gateway_full: _demos.run_mcp_gateway_full,
+        _DemoScenario.killer: _demos.run_killer,
     }
     dispatch[scenario]()
 

--- a/src/contextweaver/_demos.py
+++ b/src/contextweaver/_demos.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from contextweaver.context.firewall import apply_firewall
 from contextweaver.context.manager import ContextManager
-from contextweaver.routing.cards import make_choice_cards, render_cards_text
+from contextweaver.routing.cards import count_tokens, make_choice_cards, render_cards_text
 from contextweaver.routing.catalog import Catalog, generate_sample_catalog
 from contextweaver.routing.router import Router
 from contextweaver.routing.tree import TreeBuilder
@@ -235,6 +235,122 @@ def run_huge_tool_output() -> None:
 
     saving = 100.0 * (1.0 - len(processed.text) / max(len(raw_text), 1))
     print(f"\nToken savings vs raw: {saving:.1f}%")
+    _footer()
+
+
+def _pct_reduction(before: str, after: str) -> str:
+    """Return a ``NN.N%`` character-reduction string for *before* → *after*."""
+    saving = 100.0 * (1.0 - len(after) / max(len(before), 1))
+    return f"{saving:.1f}%"
+
+
+def _killer_history() -> list[ContextItem]:
+    """Build a long prior conversation (the kind that floods a naive prompt)."""
+    turns: list[ContextItem] = []
+    chatter = [
+        ("u", "Morning — can you help me chase some overdue accounts today?"),
+        ("a", "Of course. I can search billing, read CRM notes, and draft comms."),
+        ("u", "Great. Last week we talked about the enterprise tier renewals."),
+        ("a", "Right — three accounts were flagged for manual follow-up."),
+        ("u", "One of them, Northwind, disputed an invoice. Did that resolve?"),
+        ("a", "The dispute was closed; the invoice is valid and still unpaid."),
+        ("u", "Also remember the finance team wants reminders to stay polite."),
+        ("a", "Noted — I keep a friendly, non-threatening tone on all reminders."),
+    ]
+    for idx, (who, text) in enumerate(chatter, start=1):
+        kind = ItemKind.user_turn if who == "u" else ItemKind.agent_msg
+        turns.append(ContextItem(id=f"h{idx}", kind=kind, text=text))
+    return turns
+
+
+def _killer_big_result() -> str:
+    """Return a ~12 KB invoice/account-notes dump (floods a naive answer prompt)."""
+    rows = [
+        f'{{"invoice_id":"INV-{2000 + i}","account":"ACME-{i % 40:03d}",'
+        f'"amount_usd":{(i * 317) % 9000 + 100},"days_overdue":{(i * 7) % 95},'
+        f'"status":"unpaid","last_note":"left voicemail; awaiting AP confirmation #{i}"}}'
+        for i in range(90)
+    ]
+    return (
+        "status: ok\n"
+        f"rows_returned: {len(rows)}\n"
+        "source: billing.invoices.search\n\n" + "\n".join(rows) + "\n"
+    )
+
+
+def run_killer() -> None:
+    """The 60-second failure mode: 100 tools + long history + a huge result (#322).
+
+    A single deterministic, network-free scenario that makes the pain of a
+    naive agent loop obvious in under a minute: a 100-tool catalog bloats
+    the route prompt, a long conversation competes for budget, and a huge
+    tool result floods the answer prompt.  contextweaver narrows the
+    catalog to a handful of :class:`ChoiceCard` objects and firewalls the
+    big result out-of-band, so the prompt stays bounded.
+
+    Sizes are reported in **characters** (deterministic everywhere); the
+    closing token estimate uses the active tokeniser and is informational.
+    """
+    _banner("killer scenario (100 tools + huge output)")
+
+    catalog = Catalog()
+    for item in _synth_catalog(100, seed=42):
+        catalog.register(item)
+    items = catalog.all()
+    query = "Find unpaid invoices, check the account notes, and draft a reminder."
+    print(f"\nCatalog: {len(items)} tools across {len({i.namespace for i in items})} namespaces")
+    print(f"User:    {query!r}")
+
+    # ---- 1. Tool catalog: naive dump vs ChoiceCard shortlist --------------
+    naive_tools = "\n".join(f"- {it.id} ({it.namespace}): {it.description}" for it in items)
+    graph = TreeBuilder(max_children=20).build(items)
+    router = Router(graph, items=items, beam_width=3, top_k=5)
+    result = router.route(query)
+    cards = make_choice_cards(
+        result.candidate_items,
+        scores=dict(zip(result.candidate_ids, result.scores, strict=False)),
+    )
+    cw_tools = render_cards_text(cards)
+    chosen = result.candidate_ids[0]
+    print("\n[1/3] Tools in the route prompt")
+    print(f"      naive (all {len(items)} tools):        {len(naive_tools):,} chars")
+    print(f"      contextweaver ({len(cards)} ChoiceCards):    {len(cw_tools):,} chars")
+    print(f"      reduction: {_pct_reduction(naive_tools, cw_tools)}")
+    print(f"      shortlist: {result.candidate_ids}")
+
+    # ---- 2. Huge tool output: raw vs firewalled ---------------------------
+    mgr = ContextManager()
+    for turn in _killer_history():
+        mgr.ingest_sync(turn)
+    mgr.ingest_sync(ContextItem(id="u-now", kind=ItemKind.user_turn, text=query))
+    mgr.ingest_sync(
+        ContextItem(
+            id="tc1", kind=ItemKind.tool_call, text=f"{chosen}(status='unpaid')", parent_id="u-now"
+        )
+    )
+    big = _killer_big_result()
+    result_item, _envelope = mgr.ingest_tool_result_sync(
+        tool_call_id="tc1", raw_output=big, tool_name=chosen, firewall_threshold=2000
+    )
+    handle = result_item.artifact_ref.handle if result_item.artifact_ref else "<none>"
+    print("\n[2/3] The huge tool result")
+    print(f"      naive (raw):             {len(big):,} chars")
+    print(f"      contextweaver (summary):  {len(result_item.text):,} chars  (artifact {handle})")
+    print(f"      reduction: {_pct_reduction(big, result_item.text)}")
+
+    # ---- 3. The whole answer prompt: everything raw vs compiled -----------
+    raw_history = "\n".join(t.text for t in _killer_history())
+    naive_prompt = f"{naive_tools}\n\n{raw_history}\n\n{query}\n\n{big}"
+    pack = mgr.build_sync(phase=Phase.answer, query=query)
+    print("\n[3/3] The full answer prompt")
+    print(f"      naive (everything raw):   {len(naive_prompt):,} chars")
+    print(f"      contextweaver (compiled):  {len(pack.prompt):,} chars")
+    print(f"      reduction: {_pct_reduction(naive_prompt, pack.prompt)}")
+
+    print(
+        f"\nToken estimate: naive ~{count_tokens(naive_prompt):,} tokens "
+        f"-> contextweaver ~{count_tokens(pack.prompt):,} tokens"
+    )
     _footer()
 
 

--- a/src/contextweaver/_demos.py
+++ b/src/contextweaver/_demos.py
@@ -264,7 +264,7 @@ def _killer_history() -> list[ContextItem]:
 
 
 def _killer_big_result() -> str:
-    """Return a ~12 KB invoice/account-notes dump (floods a naive answer prompt)."""
+    """Return a large invoice/account-notes dump (floods a naive answer prompt)."""
     rows = [
         f'{{"invoice_id":"INV-{2000 + i}","account":"ACME-{i % 40:03d}",'
         f'"amount_usd":{(i * 317) % 9000 + 100},"days_overdue":{(i * 7) % 95},'

--- a/tests/test_architectures_catalog_showcase.py
+++ b/tests/test_architectures_catalog_showcase.py
@@ -1,0 +1,98 @@
+"""Smoke test for the catalog showcase reference architecture (#330).
+
+The showcase is exercised by ``make example`` via the ``architectures``
+umbrella target. This unit test pins the deterministic invariants of the
+adoption story — catalog size, shortlist contents, single-tool hydration,
+firewall reduction, artifact persistence — so regressions surface here
+rather than in a CI ``make example`` failure.
+
+Token counts are intentionally **not** asserted: the tokeniser falls back
+to a chars/4 estimate when the tiktoken encoding cannot be downloaded, so
+per-section token numbers differ between environments. Everything asserted
+below is character- or count-based and therefore environment-independent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_MAIN_PATH = _REPO_ROOT / "examples" / "architectures" / "catalog_showcase" / "main.py"
+_spec = importlib.util.spec_from_file_location("catalog_showcase_main", _MAIN_PATH)
+assert _spec is not None and _spec.loader is not None
+catalog_showcase = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(catalog_showcase)
+
+
+@pytest.fixture
+def showcase_output() -> str:
+    """Run ``main()`` once and capture stdout for assertions."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        catalog_showcase.main()
+    return buf.getvalue()
+
+
+def test_catalog_loads_at_scale(showcase_output: str) -> None:
+    """The synthetic catalog ships 65 tools across 9 namespaces."""
+    assert "Loaded catalog: 65 tools across 9 namespaces" in showcase_output
+
+
+def test_request_routes_to_a_five_tool_shortlist(showcase_output: str) -> None:
+    """The route phase narrows 65 tools to a 5-card shortlist."""
+    assert "shortlist: 5 of 65 tools" in showcase_output
+
+
+def test_intent_tool_tops_the_shortlist(showcase_output: str) -> None:
+    """``commerce.product_search`` is the intended tool and lands in the shortlist."""
+    assert (
+        "chosen:   commerce.product_search  (intent='commerce.product_search', in shortlist)"
+        in (showcase_output)
+    )
+    assert "NOT in shortlist" not in showcase_output
+
+
+def test_only_the_selected_tool_is_hydrated(showcase_output: str) -> None:
+    """Exactly one tool's schema is hydrated; the other 64 cost zero schema bytes."""
+    assert "hydrated schema for 'commerce.product_search': 653 chars" in showcase_output
+    assert "hydrated schema for the other 64 tools: 0 chars (never paid for)" in showcase_output
+
+
+def test_firewall_compacts_the_large_result(showcase_output: str) -> None:
+    """The ~3 KB search payload is firewalled to a 501-char summary (84% reduction)."""
+    assert "firewall: 3,128 chars -> 501-char summary" in showcase_output
+    assert "prompt-side reduction: 84.0%" in showcase_output
+    assert "artifact artifact:result:tc1" in showcase_output
+
+
+def test_raw_bytes_stay_addressable(showcase_output: str) -> None:
+    """Every tool result is persisted in the artifact store for drilldown."""
+    assert "artifacts kept (addressable for drilldown): 1" in showcase_output
+
+
+def test_final_prompt_has_expected_sections(showcase_output: str) -> None:
+    """The answer-phase prompt renders the user turn, the tool result, and the call."""
+    final_section = showcase_output.split("Final answer-phase prompt", 1)[1]
+    assert "[USER]" in final_section
+    assert "[TOOL RESULT" in final_section
+    assert "[TOOL CALL]" in final_section
+
+
+def test_buildstats_includes_three_items(showcase_output: str) -> None:
+    """The answer build keeps the user turn, the firewalled result, and the call."""
+    assert "included_count:      3" in showcase_output
+
+
+def test_select_from_shortlist_prefers_intent_when_present() -> None:
+    """The intent-map helper picks the intent if it is in the shortlist."""
+    assert catalog_showcase._select_from_shortlist(["a.x", "b.y", "c.z"], "b.y") == "b.y"
+
+
+def test_select_from_shortlist_falls_back_to_top_when_missing() -> None:
+    """The helper falls back to the top-1 candidate when the intent is absent."""
+    assert catalog_showcase._select_from_shortlist(["a.x", "b.y", "c.z"], "absent") == "a.x"

--- a/tests/test_architectures_eval_artifact_profile.py
+++ b/tests/test_architectures_eval_artifact_profile.py
@@ -1,0 +1,122 @@
+"""Tests for the agent-safe evaluation-artifact context profile (#335).
+
+Covers the three risk levels (``ok`` / ``caution`` / ``high_risk``) and the
+two safety invariants the profile guarantees:
+
+1. ``V_hat`` is never presented without a support-health item earlier in the
+   same compiled list, and never at all in the route phase.
+2. High-risk artifacts foreground caveats before the estimate.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+from contextweaver.types import Phase
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_ARCH_DIR = _REPO_ROOT / "examples" / "architectures" / "eval_artifact_profile"
+_MAIN_PATH = _ARCH_DIR / "main.py"
+_spec = importlib.util.spec_from_file_location("eval_artifact_profile_main", _MAIN_PATH)
+assert _spec is not None and _spec.loader is not None
+profile = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(profile)
+
+_STATUSES = ["ok", "caution", "high_risk"]
+
+
+def _load(status: str) -> dict:
+    return json.loads((_ARCH_DIR / "fixtures" / f"artifact_{status}.json").read_text("utf-8"))
+
+
+def _roles(items: list) -> list[str]:
+    return [str(it.metadata.get("role", "")) for it in items]
+
+
+@pytest.mark.parametrize("status", _STATUSES)
+def test_route_phase_never_exposes_the_estimate(status: str) -> None:
+    """The route phase must only carry summary metadata, never ``V_hat``."""
+    items = profile.compile_eval_context(_load(status), Phase.route)
+    assert profile.ROLE_VALUE not in _roles(items)
+    rendered = " ".join(it.text for it in items)
+    assert "V_hat" not in rendered
+
+
+@pytest.mark.parametrize("status", _STATUSES)
+def test_estimate_never_appears_without_support_diagnostics(status: str) -> None:
+    """In any phase, a value estimate must be preceded by support health."""
+    for phase in (Phase.route, Phase.interpret, Phase.answer):
+        roles = _roles(profile.compile_eval_context(_load(status), phase))
+        if profile.ROLE_VALUE in roles:
+            assert profile.ROLE_SUPPORT in roles
+            assert roles.index(profile.ROLE_SUPPORT) < roles.index(profile.ROLE_VALUE)
+
+
+def test_interpret_phase_surfaces_the_estimate_for_every_status() -> None:
+    """Interpret is the full diagnostic view — the estimate is present there."""
+    for status in _STATUSES:
+        roles = _roles(profile.compile_eval_context(_load(status), Phase.interpret))
+        assert profile.ROLE_VALUE in roles
+        assert roles[0] == profile.ROLE_SUPPORT  # support health is always first
+
+
+def test_ok_answer_includes_estimate_but_risky_answers_withhold_it() -> None:
+    """The human-facing answer leads with the estimate only when it is safe."""
+    ok_roles = _roles(profile.compile_eval_context(_load("ok"), Phase.answer))
+    assert profile.ROLE_VALUE in ok_roles
+    for status in ("caution", "high_risk"):
+        roles = _roles(profile.compile_eval_context(_load(status), Phase.answer))
+        assert profile.ROLE_VALUE not in roles
+
+
+def test_high_risk_foregrounds_caveats_before_the_estimate() -> None:
+    """A high-risk interpret build must place caveats before ``V_hat``."""
+    roles = _roles(profile.compile_eval_context(_load("high_risk"), Phase.interpret))
+    assert profile.ROLE_CAVEAT in roles and profile.ROLE_VALUE in roles
+    assert roles.index(profile.ROLE_CAVEAT) < roles.index(profile.ROLE_VALUE)
+
+
+@pytest.mark.parametrize("status", _STATUSES)
+def test_check_invariants_passes_for_every_fixture(status: str) -> None:
+    """``check_invariants`` returns only PASS lines and never raises."""
+    lines = profile.check_invariants(_load(status))
+    assert lines
+    assert all(line.strip().startswith("[PASS]") for line in lines)
+
+
+def test_check_invariants_raises_when_estimate_precedes_support() -> None:
+    """A tampered profile (estimate before support) must trip the assertion."""
+    bad = _load("ok")
+    # Drop support health entirely -> interpret would surface V_hat with no
+    # support diagnostic, which the invariant must reject.
+    bad["support_health"] = ""
+    original = profile.compile_eval_context
+
+    def _broken(artifact: dict, phase: Phase) -> list:
+        items = original(artifact, phase)
+        # Strip the support-health item to simulate a regression.
+        return [it for it in items if it.metadata.get("role") != profile.ROLE_SUPPORT]
+
+    profile.compile_eval_context = _broken  # type: ignore[assignment]
+    try:
+        with pytest.raises(AssertionError):
+            profile.check_invariants(bad)
+    finally:
+        profile.compile_eval_context = original  # type: ignore[assignment]
+
+
+def test_main_runs_and_reports_all_pass() -> None:
+    """End-to-end: ``main()`` runs offline and every invariant line is PASS."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        profile.main()
+    out = buf.getvalue()
+    assert "[FAIL]" not in out
+    assert out.count("[PASS]") >= 9  # 3 statuses x >=3 checks
+    assert "high_risk: caveats are foregrounded before the estimate" in out

--- a/tests/test_architectures_langgraph_agent_loop.py
+++ b/tests/test_architectures_langgraph_agent_loop.py
@@ -1,0 +1,96 @@
+"""Smoke test for the LangGraph agent-loop reference architecture (#326).
+
+The architecture runs with or without LangGraph installed (guarded import +
+hand-rolled fallback). These tests pin the deterministic invariants that
+hold on *both* paths, plus the guarantee that the two paths produce
+identical output apart from the one ``engine:`` banner line.
+
+Token counts are not asserted (tokeniser-dependent); every asserted number
+is character- or count-based.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_MAIN_PATH = _REPO_ROOT / "examples" / "architectures" / "langgraph_agent_loop" / "main.py"
+
+
+def _load_module(name: str) -> object:
+    spec = importlib.util.spec_from_file_location(name, _MAIN_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+langgraph_agent_loop = _load_module("langgraph_agent_loop_main")
+
+
+def _run(module: object) -> str:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        module.main()  # type: ignore[attr-defined]
+    return buf.getvalue()
+
+
+@pytest.fixture
+def run_output() -> str:
+    return _run(langgraph_agent_loop)
+
+
+def test_catalog_loads_with_hero_tools(run_output: str) -> None:
+    """The generated catalog plus the four hero tools total 36 tools."""
+    assert "catalog: 36 tools across 9 namespaces" in run_output
+
+
+def test_engine_line_is_one_of_two_known_values(run_output: str) -> None:
+    assert ("agent loop engine: langgraph" in run_output) or (
+        "agent loop engine: fallback (langgraph not installed)" in run_output
+    )
+
+
+def test_turn_one_routes_to_logs_search_and_fires_firewall(run_output: str) -> None:
+    """Turn t1 picks the log tool and firewalls the ~21 KB dump to a summary."""
+    t1 = run_output.split("Turn t1", 1)[1].split("Turn t2", 1)[0]
+    assert "chosen: infra.logs_search  (intent='infra.logs_search', in shortlist)" in t1
+    assert "firewall: 21,705 chars -> 49-char summary" in t1
+    assert "route prompt:  naive all-tools 2,364 chars  ->  ChoiceCards 526 chars" in t1
+
+
+def test_turn_two_routes_to_incident_and_retains_prior_context(run_output: str) -> None:
+    """Turn t2 picks the incident tool; its answer carries all 6 events forward."""
+    t2 = run_output.split("Turn t2", 1)[1]
+    assert "chosen: incident.draft_note  (intent='incident.draft_note', in shortlist)" in t2
+    # 3 events from t1 + 3 from t2 = cross-turn retention.
+    assert "included=6" in t2
+
+
+def test_closing_summary_present(run_output: str) -> None:
+    assert "LangGraph owned the route -> execute -> answer control flow." in run_output
+
+
+def test_langgraph_and_fallback_paths_agree(run_output: str) -> None:
+    """The two execution paths must produce identical output bar the engine line."""
+    real = _load_module("lg_real_path")
+    fb = _load_module("lg_fallback_path")
+    fb._HAS_LANGGRAPH = False  # type: ignore[attr-defined]
+
+    def _strip_engine(text: str) -> str:
+        return "\n".join(ln for ln in text.splitlines() if not ln.startswith("agent loop engine:"))
+
+    assert _strip_engine(_run(real)) == _strip_engine(_run(fb))
+
+
+def test_select_from_shortlist_prefers_intent_when_present() -> None:
+    assert langgraph_agent_loop._select_from_shortlist(["a", "b"], "b") == "b"  # type: ignore[attr-defined]
+
+
+def test_select_from_shortlist_falls_back_to_top_when_missing() -> None:
+    assert langgraph_agent_loop._select_from_shortlist(["a", "b"], "z") == "a"  # type: ignore[attr-defined]

--- a/tests/test_demos_killer.py
+++ b/tests/test_demos_killer.py
@@ -1,0 +1,88 @@
+"""Test the `killer` CLI scenario — the 60-second failure mode (issue #322).
+
+The scenario contrasts a naive agent loop (100 tool descriptions + a long
+history + a huge raw tool result, all inlined) against contextweaver
+(ChoiceCard shortlist + firewalled result + compiled prompt). All asserted
+numbers are **character**-based and therefore deterministic across
+environments; the closing token estimate depends on the active tokeniser
+and is not asserted.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+from contextlib import redirect_stdout
+
+from contextweaver import _demos
+from contextweaver.__main__ import _DemoScenario
+
+
+def _run() -> str:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _demos.run_killer()
+    return buf.getvalue()
+
+
+def test_scenario_enum_includes_killer() -> None:
+    """The CLI scenario flag must accept the new value."""
+    assert _DemoScenario.killer.value == "killer"
+
+
+def test_dispatch_wires_killer_handler() -> None:
+    """Every enum value needs a handler; ``killer`` maps to ``run_killer``."""
+    assert callable(_demos.run_killer)
+
+
+def test_banner_and_footer_present() -> None:
+    out = _run()
+    assert "killer scenario (100 tools + huge output)" in out
+    assert "Demo complete." in out
+
+
+def test_catalog_is_one_hundred_tools() -> None:
+    out = _run()
+    assert "Catalog: 100 tools across 8 namespaces" in out
+
+
+def test_tool_prompt_shrinks_to_a_five_card_shortlist() -> None:
+    """100 raw tool descriptions (6,326 chars) collapse to 5 ChoiceCards (491 chars)."""
+    out = _run()
+    assert "naive (all 100 tools):        6,326 chars" in out
+    assert "contextweaver (5 ChoiceCards):    491 chars" in out
+    assert "reduction: 92.2%" in out
+    assert "billing.invoices.search" in out
+
+
+def test_huge_result_is_firewalled() -> None:
+    """The ~14 KB invoice dump is firewalled to a 60-char summary (99.6% reduction)."""
+    out = _run()
+    assert "naive (raw):             14,430 chars" in out
+    assert "contextweaver (summary):  60 chars" in out
+    assert "reduction: 99.6%" in out
+    assert "artifact artifact:result:tc1" in out
+
+
+def test_full_answer_prompt_reduction() -> None:
+    """The whole naive answer prompt (21,332 chars) compiles down to 823 chars."""
+    out = _run()
+    assert "naive (everything raw):   21,332 chars" in out
+    assert "contextweaver (compiled):  823 chars" in out
+    assert "reduction: 96.1%" in out
+
+
+def test_token_estimate_line_present() -> None:
+    """A token estimate is shown (value not asserted — tokeniser-dependent)."""
+    out = _run()
+    assert re.search(r"Token estimate: naive ~[\d,]+ tokens -> contextweaver ~[\d,]+ tokens", out)
+
+
+def test_pct_reduction_helper() -> None:
+    assert _demos._pct_reduction("x" * 1000, "x" * 250) == "75.0%"
+    assert _demos._pct_reduction("x" * 100, "x" * 100) == "0.0%"
+
+
+def test_big_result_exceeds_firewall_threshold() -> None:
+    """The canned result must be large enough to actually trip the firewall."""
+    assert len(_demos._killer_big_result()) > 2000


### PR DESCRIPTION
## Summary

Implements the recommended combined-PR group from the open-issue triage — four adoption-focused, deterministic, offline deliverables, all wired into `make example` / `make demo`.

Fixes #330
Fixes #322
Fixes #326
Fixes #335

## Changes

- **#330 — `examples/architectures/catalog_showcase/`** — start-here reference architecture: a 65-tool catalog narrowed to a 5-card shortlist, single-tool schema hydration (`Catalog.hydrate`), firewall on a ~3 KB result, final `BuildStats`. Smoke test, docs page, README/Makefile/mkdocs wiring.
- **#322 — `contextweaver demo --scenario killer`** — the 60-second failure mode (100 tools + long history + a huge tool result), naive vs contextweaver in **character** terms: 92.2% / 99.6% / 96.1% reductions. New `_demos.run_killer`, CLI enum/dispatch/help, README "The 60-second failure mode" section, `docs/killer_demo.md`, `tests/test_demos_killer.py`.
- **#326 — `examples/architectures/langgraph_agent_loop/`** — contextweaver **inside** a LangGraph `StateGraph` (framework owns control flow; contextweaver owns route → firewall → answer; tool execution stays outside). Guarded import with a hand-rolled fallback that produces byte-identical output bar one banner line, so it runs under a bare `pip install contextweaver`. New `[langgraph]` extra, also added to `[dev]` so CI exercises the real `StateGraph` path.
- **#335 — `examples/architectures/eval_artifact_profile/`** — agent-safe context-shaping profile for offline-evaluation reports with `ok` / `caution` / `high_risk` fixtures. Enforces two invariants (verified at runtime and in tests): never present `V_hat` without support diagnostics; foreground caveats before estimates for high-risk artifacts.

Plus docs: 3 architecture pages + `docs/killer_demo.md`, `mkdocs.yml` nav, `docs/architectures/index.md` table, README rows, and a `CHANGELOG.md` entry.

## Why

These were the coherent "adoption showcase" cluster from triage: all share the `examples/architectures/` + docs + README surface and the same route → firewall → answer narrative. They demonstrate the core value to new adopters without touching the pipeline, public API, or scoring math.

## How verified

`make ci` (fmt + lint + type + test + schemas-check + example + demo) passes locally:

- `ruff format --check` — 247 files already formatted
- `ruff check` — All checks passed
- `mypy src/` — Success: no issues found in 102 source files
- `pytest` — **1766 passed, 12 skipped**
- `python scripts/gen_schemas.py --check` — schemas up to date
- `make example` (incl. the 3 new architectures) and `make demo` — exit 0

Token counts are intentionally not asserted in tests (tiktoken vs chars/4 fallback differs by environment); every asserted number is character- or count-based and stable.

## Tradeoffs / risks

- Adds `langgraph` to `[dev]` so CI exercises the real framework path; the example falls back cleanly if it is ever unavailable.
- `docs/` build is non-PR-gating here (the Docs workflow runs on push to `main`); nav and links were added/verified for that build.

## Checklist

- [x] Tests added or updated for every new/changed public function
- [x] `make ci` passes locally (fmt + lint + type + test + example + demo)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docstrings added for all new public APIs (Google-style)
- [x] Every modified module stays ≤ 300 lines (or a decomposition issue is linked above) — `_demos.py` is CLI demo code (exempt class) and the rest are examples
- [x] Related issues linked in the summary above
- [x] Agent-facing docs updated if pipeline, API, or conventions changed — new CLI scenario + architectures documented

## Notes for reviewers

- The `[TOOL RESULT [artifact:artifact:...]]` doubled prefix visible in some captured outputs is the pre-existing cosmetic bug tracked in #313, deliberately left untouched (out of scope).
- The LangGraph and fallback paths are asserted to produce identical output apart from the `agent loop engine:` line.

https://claude.ai/code/session_01EpVrEdoQF3ii2uzC1hkZGD

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpVrEdoQF3ii2uzC1hkZGD)_