### PR TITLE
feat: Weaver routing contracts + ChainWeaver flow interop (#318, #334, #353, #320)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ It prepares context and routes tools but never calls models or executes tools.
 | `envelope.py` | Result types: `ResultEnvelope`, `BuildStats`, `ContextPack`, `ChoiceCard`, `HydrationResult`, `RoutingDecision` |
 | `config.py` | Configuration: `ContextBudget`, `ContextPolicy`, `ScoringConfig` |
 | `profiles.py` | Routing and profile config: `Mode`, `RoutingConfig`, `ProfileConfig`, named presets |
-| `protocols.py` | Protocol interfaces: `TokenEstimator`, `EventHook`, `Summarizer`, `Extractor`, `RedactionHook`, `MemorySource`, `Labeler`, `Retriever`, `Reranker`, `ClusteringEngine` (store protocols re-exported from `store/protocols.py`) |
+| `protocols.py` | Protocol interfaces: `TokenEstimator`, `EventHook`, `Summarizer`, `Extractor`, `RedactionHook`, `MemorySource`, `Labeler`, `Retriever`, `Reranker`, `ClusteringEngine`, `RoutingScoreProvider` (store protocols re-exported from `store/protocols.py`) |
 | `store/protocols.py` | Store-layer protocols: `EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore` |
 | `exceptions.py` | Custom exception hierarchy (all errors inherit `ContextWeaverError`) |
 | `_utils.py` | Text similarity primitives: `tokenize()`, `jaccard()`, `TfIdfScorer` |
@@ -54,6 +54,7 @@ It prepares context and routes tools but never calls models or executes tools.
 | `routing/navigator.py` | `BeamSearchNavigator` (lifted from `router.py`) + `rank_collected` (issue #56) |
 | `routing/packer.py` | `DefaultCardPacker` wrapping `make_choice_cards` for the pipeline pack stage (issue #56) |
 | `routing/history.py` | `RouteHistory` dataclass + `adjust_scores` (history-aware re-routing, issue #27) |
+| `routing/feedback.py` | Optional feedback-aware routing scores (issue #318): `ExecutionFeedback` (contextweaver-native, **not** a weaver-spec type), `DeterministicScoreProvider` (default no-op), `FeedbackAwareScoreProvider`, `aggregate_feedback`. Plugs into `Router(score_provider=...)`; default `None` keeps routing deterministic. |
 | `extras/embeddings.py` | `SentenceTransformerBackend` + `HybridEmbeddingRetriever` + `HashingEmbeddingBackend` (re-exported) behind the `[embeddings]` extra (issue #8) |
 | `extras/embeddings_hashing.py` | `HashingEmbeddingBackend` — stdlib-only deterministic `EmbeddingBackend` using blake2b hashing trick; no extras required (issue #266) |
 | `_schema_gen.py` | Dataclass → JSON Schema (Draft 2020-12) generator + `make schemas-check` engine (issue #225) |
@@ -61,6 +62,7 @@ It prepares context and routes tools but never calls models or executes tools.
 | `routing/path.py` | `tool_browse` path-navigation grammar (`parse_path` / `resolve_path`) per `docs/gateway_spec.md` §3 |
 | `routing/hydration.py` | Public schema-hydration helpers — `SchemaSource` (from raw dict / JSON file / MCP tools-list), `hydrate_with_schema`, `lazy_schema_resolver`. Reference architectures use these to resolve a tool's full input schema from a sidecar source rather than hand-rolling a `_FULL_SCHEMAS` dict. Inline `args_schema` on the catalog item wins; sidecar only fills empties. Issue #261. |
 | `adapters/` | MCP, FastMCP, A2A, weaver-spec, CrewAI, Pydantic AI, smolagents, Agno protocol adapters + MCP proxy / gateway runtime + provider-message ingestion helpers for OpenAI / Anthropic / Gemini chat histories (issues #13, #28, #29, #34, #193, #194, #219, #222, #272, #274, #275) |
+| `adapters/chainweaver.py` | ChainWeaver flow-export → `SelectableItem(kind="flow")` import (`chainweaver_flow_to_selectable`, `chainweaver_flows_to_catalog`, `load_chainweaver_export`, issue #334). Pure data; no ChainWeaver dependency. Preserves name/description/input+output schemas; stamps `metadata["runtime"]="chainweaver"` + flow id/version. |
 | `adapters/crewai.py` | CrewAI `BaseTool` (or equivalent plain-dict shape) ↔ `SelectableItem` (`crewai_tool_to_selectable`, `crewai_tools_to_catalog`, `infer_crewai_namespace`, `load_crewai_catalog`, issue #193) |
 | `adapters/pydantic_ai.py` | Pydantic AI `Tool` ↔ `SelectableItem` and `ModelMessage` ↔ `ContextItem` lossless round-trip (`pydantic_ai_tool_to_selectable`, `pydantic_ai_tools_to_catalog`, `load_pydantic_ai_catalog`, `from_/to_pydantic_ai_messages`, issue #272) — heavy decode/encode helpers live in `adapters/_pydantic_ai_messages.py` |
 | `adapters/smolagents.py` | Hugging Face smolagents `Tool` ↔ `SelectableItem` and `MultiStepAgent.memory.steps` → `ContextItem`s (`smolagents_tool_to_selectable`, `smolagents_tools_to_catalog`, `load_smolagents_catalog`, `from_smolagents_agent`, issue #274) |
@@ -110,7 +112,7 @@ For full pipeline descriptions and design rationale, see [docs/agent-context/arc
 
 | Type | Purpose |
 |---|---|
-| `SelectableItem` | Unified tool/agent/skill/internal item. Alias: `ToolCard` (use `SelectableItem` in code). |
+| `SelectableItem` | Unified tool/agent/skill/flow/internal item (`kind="flow"` = external multi-step capability, e.g. a ChainWeaver flow). Alias: `ToolCard` (use `SelectableItem` in code). |
 | `ContextItem` | Event log entry with `parent_id` for dependency closure |
 | `ResultEnvelope` | Processed tool output: summary + facts + artifacts + views |
 | `ContextPack` | Rendered prompt + stats from a context build |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Feedback-aware routing score extension point (`contextweaver.routing.feedback`)**
+  (#318) — an opt-in seam for folding historical execution signals into the
+  routing score while keeping deterministic routing the default. Adds the
+  `RoutingScoreProvider` protocol, the contextweaver-native `ExecutionFeedback`
+  record (success / latency / token cost / quality), a `DeterministicScoreProvider`
+  (no-op default), a `FeedbackAwareScoreProvider` (bounded, deterministic
+  feedback deltas), and `aggregate_feedback`. Wired into `Router` via the new
+  optional `score_provider=` argument; `None` (default) is byte-equivalent to
+  prior behaviour. **Note:** `ExecutionFeedback` is a contextweaver type, not a
+  weaver-spec contract — weaver-spec does not define one.
+- **ChainWeaver flow import (`contextweaver.adapters.chainweaver`)** (#334) —
+  ingest a ChainWeaver flow export (plain data, no ChainWeaver install) into a
+  catalog. `chainweaver_flow_to_selectable` / `chainweaver_flows_to_catalog` /
+  `load_chainweaver_export` convert each flow into a `SelectableItem` with the
+  new `kind="flow"`, preserving name, description, and input/output schemas and
+  stamping the flow id/version under `metadata`. Imported flows route like any
+  other candidate and are tagged `"flow"` for gating.
+- **`kind="flow"` selectable kind** — `SelectableItem` and `ChoiceCard` now
+  accept `"flow"` (external multi-step capability). Published JSON Schemas
+  (`catalog`, `choice_card`) regenerated accordingly.
+- **`contextweaver → ChainWeaver` reference architecture** (#353) —
+  `examples/architectures/contextweaver_to_chainweaver/` demonstrates the
+  route (contextweaver, advisory) → execute (ChainWeaver, stubbed) → ingest
+  (contextweaver firewall) seam end-to-end, including the weaver-spec
+  `RoutingDecision` / `Frame` contract mapping. No hard ChainWeaver dependency.
+- **Routing-as-advisory-contract docs (#320)** — `docs/weaver_spec_mapping.md`
+  now documents the advisory routing boundary, how a host projects a
+  `RoutingDecision` into a neutral execution candidate (and why contextweaver
+  ships no `ExecutionCandidate` type while weaver-spec lacks one), and when to
+  route to a ChainWeaver flow vs a single-step tool.
 - **Evaluation harness (`contextweaver.eval`)** — a deterministic, pure-stdlib
   package for measuring routing and context quality (#12). `EvalDataset` /
   `EvalCase` load gold-standard `query → expected tool id` data;

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ architectures:
 	python examples/architectures/voice_agent/main.py
 	python examples/architectures/langgraph_agent_loop/main.py
 	python examples/architectures/eval_artifact_profile/main.py
+	python examples/architectures/contextweaver_to_chainweaver/main.py
 
 demo:
 	python -m contextweaver demo

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ contextweaver ─▶ ChainWeaver ─▶ agent-kernel ─▶ agentfence
 | Boundary | agent-kernel | Own the execution boundary; hand contextweaver `Frame`s, not raw output. |
 | Guardrails | agentfence | Apply output guardrails to the response. |
 
+The contextweaver → ChainWeaver handoff is **advisory**: contextweaver routes
+(it recommends a capability) and ingests results behind its firewall; the
+runtime owns authorization and execution. A runnable end-to-end example —
+route a catalog of tools + imported ChainWeaver flows, hand the selection to a
+(stubbed) ChainWeaver runtime, then ingest the result — lives at
+[`examples/architectures/contextweaver_to_chainweaver/`](examples/architectures/contextweaver_to_chainweaver/),
+and the contract boundary is documented in
+[`docs/weaver_spec_mapping.md`](docs/weaver_spec_mapping.md).
+
 Adjacent tools: **vibeguard** (code-diff safety gate), **lessonweaver** (lesson
 capture), and **skdr-eval** (offline evaluation). Every piece works
 **standalone** — contextweaver has **no hard dependency** on any sibling, so you

--- a/docs/schemas/v0/catalog.schema.json
+++ b/docs/schemas/v0/catalog.schema.json
@@ -3,7 +3,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "items": {
     "additionalProperties": false,
-    "description": "A unified representation of a tool, agent, skill, or internal function.",
+    "description": "A unified representation of a tool, agent, skill, flow, or internal function.",
     "properties": {
       "args_schema": {
         "additionalProperties": {},
@@ -46,7 +46,8 @@
           "tool",
           "agent",
           "skill",
-          "internal"
+          "internal",
+          "flow"
         ]
       },
       "metadata": {

--- a/docs/schemas/v0/choice_card.schema.json
+++ b/docs/schemas/v0/choice_card.schema.json
@@ -21,7 +21,8 @@
         "tool",
         "agent",
         "skill",
-        "internal"
+        "internal",
+        "flow"
       ]
     },
     "name": {

--- a/docs/weaver_spec_mapping.md
+++ b/docs/weaver_spec_mapping.md
@@ -129,6 +129,80 @@ contextweaver (no `_contextweaver` metadata key). In that case:
   entries.
 - `provenance` carries `redaction_notes` when the source set them.
 
+## Routing as an advisory Weaver contract (issue #320)
+
+contextweaver is **one compatible router** in the Weaver ecosystem: it emits a
+neutral `RoutingDecision`, and a host application resolves the selected
+candidate to a concrete runtime target (a ChainWeaver flow, an agent-kernel
+capability, an MCP tool, …). Two boundaries are load-bearing:
+
+- **Routing is advisory.** A `RoutingDecision` *recommends* a candidate. It
+  does **not** grant permission to execute. Authorization, policy enforcement,
+  audit logging, and execution stay with the host/runtime. Nothing in
+  `to_weaver_routing_decision` changes that — it only reshapes the
+  recommendation.
+- **contextweaver does not execute.** It routes (advisory) and ingests results
+  (the firewall). The execution layer is a separate runtime.
+
+### Mapping a routing result to an execution candidate
+
+A host typically resolves the **top card** of a `RoutingDecision` into an
+*execution candidate* — the neutral "this is the capability to run" record the
+runtime consumes. The conceptual shape (from issue #320) is:
+
+```json
+{
+  "candidate_id": "chainweaver:customer_summary_flow",
+  "candidate_type": "flow",
+  "name": "Summarize customer history",
+  "confidence": 0.58,
+  "reason_codes": ["choicecard_match", "phase_route"],
+  "metadata": {"runtime": "chainweaver", "runtime_flow_id": "customer_summary_flow"}
+}
+```
+
+> **No `ExecutionCandidate` library type (yet).** `weaver_contracts` does not
+> currently define an `ExecutionCandidate` (nor an `ExecutionFeedback`) type.
+> contextweaver therefore does **not** ship one — introducing a contextweaver
+> dataclass that mirrored an unreleased spec type would risk diverging from it.
+> The candidate above is a **host-side projection**: derive it from
+> `decision.choice_cards[0]` (id, score) plus the selected item's `kind` and
+> `metadata`. When the spec publishes an `ExecutionCandidate` contract, the
+> mapping moves into `adapters.weaver_contracts`. See issue #320 for status.
+
+### Routing to ChainWeaver flows (issue #334)
+
+A ChainWeaver **flow** is a multi-step capability. Import a flow export into a
+catalog with the ChainWeaver adapter; each flow becomes a `SelectableItem`
+with `kind="flow"` that routes like any other candidate:
+
+```python
+from contextweaver.adapters.chainweaver import load_chainweaver_export
+
+catalog = load_chainweaver_export(chainweaver_export)  # list or {"flows": [...]}
+```
+
+The adapter preserves `name`, `description`, input schema (`args_schema`),
+and output schema, and stamps `metadata["runtime"]="chainweaver"` plus the
+flow id/version so a host can resolve the candidate back to a concrete flow.
+Every imported flow is tagged `"flow"`, so a caller can gate them with
+`Router.route(..., allowed_tags={"flow"})` or exclude them with
+`exclude_tags={"flow"}`.
+
+**When to route to a flow vs a tool:** prefer a flow when the request needs a
+*deterministic multi-step sequence* (fetch → join → summarise) that no single
+tool answers, and you want the runtime — not the LLM — to own the step order.
+Prefer single-step tools when the LLM should compose the steps itself.
+
+### End-to-end example
+
+`examples/architectures/contextweaver_to_chainweaver/` shows the full seam:
+route a query over a mixed tool+flow catalog → map the decision to a
+weaver-spec `RoutingDecision` → hand the flow to a (stubbed) ChainWeaver
+runtime → ingest the result back through the firewall as a `Frame`. There is
+**no hard dependency on ChainWeaver** — the executor is a canned stub and the
+weaver-spec mapping degrades gracefully without the `[weaver-spec]` extra.
+
 ## Verifying conformance
 
 Round-trip + JSON-Schema validation runs in CI on every PR. To reproduce

--- a/examples/architectures/contextweaver_to_chainweaver/OUTPUT.md
+++ b/examples/architectures/contextweaver_to_chainweaver/OUTPUT.md
@@ -1,0 +1,63 @@
+# contextweaver → ChainWeaver — captured run
+
+Output of `python examples/architectures/contextweaver_to_chainweaver/main.py`
+from a clean checkout with the `[weaver-spec]` extra installed. Deterministic:
+routing is seed-stable, the ChainWeaver runtime is a canned stub, and the
+firewall is content-hashed. The run shows the route → execute → ingest seam.
+
+```
+
+============================================================================
+contextweaver -> ChainWeaver reference architecture
+============================================================================
+Loaded catalog: 5 items (2 ChainWeaver flows + 3 tools)
+
+============================================================================
+1. Route (contextweaver)
+============================================================================
+query: summarize this customer's recent billing and order history
+shortlist: ['chainweaver:customer_summary_flow', 'crm:lookup_customer', 'billing:get_invoice']
+selected:  chainweaver:customer_summary_flow  (kind='flow')
+routed to a ChainWeaver flow: True
+
+============================================================================
+2. Hand off (advisory routing decision)
+============================================================================
+host-side ExecutionCandidate (neutral; resolved to a ChainWeaver flow):
+{
+  "candidate_id": "chainweaver:customer_summary_flow",
+  "candidate_type": "flow",
+  "name": "Summarize customer history",
+  "confidence": 0.581,
+  "reason_codes": [
+    "choicecard_match",
+    "phase_route"
+  ],
+  "runtime": "chainweaver",
+  "runtime_flow_id": "customer_summary_flow",
+  "advisory": true
+}
+weaver-spec RoutingDecision id: rd-4437a513-6bc5-4670-9647-be58049b4a43
+
+============================================================================
+3. Execute (ChainWeaver stub)
+============================================================================
+ChainWeaver.execute(flow_id='customer_summary_flow', inputs={'customer_id': 'cust-42'})
+raw flow result: 4,002 chars
+
+============================================================================
+4. Ingest result (contextweaver firewall)
+============================================================================
+firewall: 4,002 chars -> 501-char summary (artifact artifact:result:tc1)
+weaver-spec Frame id: frame-cust-42 (capability chainweaver:customer_summary_flow)
+answer prompt: included=3 dropped=0 tokens=145
+
+============================================================================
+Scoreboard
+============================================================================
+routed to flow:        True
+firewall fired:        True
+weaver-spec mapped:    decision=True frame=True
+artifacts kept:        1
+Seam: contextweaver ROUTES (advisory) -> ChainWeaver EXECUTES -> contextweaver INGESTS the result behind the firewall.
+```

--- a/examples/architectures/contextweaver_to_chainweaver/README.md
+++ b/examples/architectures/contextweaver_to_chainweaver/README.md
@@ -1,0 +1,65 @@
+# contextweaver → ChainWeaver — reference architecture
+
+> The Weaver-stack handoff: contextweaver **routes** a request to the right
+> capability (advisory), ChainWeaver **executes** the deterministic flow
+> behind it, and contextweaver **ingests** the result behind its context
+> firewall. Builds on the ChainWeaver flow-import adapter (#334), the
+> weaver-spec routing-contract mapping (#320), and the end-to-end seam (#353).
+
+## Run it
+
+```bash
+python examples/architectures/contextweaver_to_chainweaver/main.py
+```
+
+(Or `make architectures` / `make example`.)
+
+A captured run lives in [`OUTPUT.md`](OUTPUT.md).
+
+## What this is (and isn't)
+
+This is a **reference architecture**, not a tutorial recipe. It wires four
+primitives together around the route → execute → ingest seam:
+
+1. **Route (contextweaver).** A `Router` shortlists a catalog of ordinary
+   tools **plus** ChainWeaver flows imported with
+   `contextweaver.adapters.chainweaver.load_chainweaver_export`. Imported
+   flows carry `kind="flow"` and route like any other candidate; a
+   multi-step request ("summarize this customer's history") routes to the
+   flow rather than to any single-step tool.
+2. **Hand off (advisory).** The `RoutingDecision` is mapped to the neutral
+   weaver-spec `RoutingDecision` via
+   `contextweaver.adapters.weaver_contracts.to_weaver_routing_decision`. The
+   decision is **advisory** — contextweaver selects a candidate; it does not
+   execute or authorise it. The example also projects the selection into a
+   host-side neutral candidate dict (the `ExecutionCandidate` shape from
+   #320; see the caveat below).
+3. **Execute (ChainWeaver).** A tiny in-process **stub** stands in for the
+   ChainWeaver runtime — there is **no hard dependency** on ChainWeaver. It
+   runs the selected flow deterministically and returns a large raw result.
+4. **Ingest (contextweaver firewall).** The raw flow output goes back through
+   `ContextManager.ingest_tool_result_sync`; the firewall stores the bytes
+   out-of-band and the prompt only sees a compact summary, mapped to a
+   weaver-spec `Frame`.
+
+It is **mocked**: the ChainWeaver executor returns canned data, no real
+runtime is invoked. The point is to show the seam, not to integrate with a
+live ChainWeaver deployment.
+
+## Notes
+
+- **No ChainWeaver dependency.** The flow *export* is plain data; the
+  executor is a stub. Standalone contextweaver use never imports ChainWeaver.
+- **weaver-spec mapping is optional.** The `to_weaver_*` calls require the
+  `contextweaver[weaver-spec]` extra. Without it the example prints a skip
+  notice and continues with the native `RoutingDecision`.
+- **`ExecutionCandidate` is host-side only.** weaver-spec does not (yet)
+  define an `ExecutionCandidate` contract type, so this example projects the
+  decision into a neutral dict rather than a library dataclass. See
+  [`docs/weaver_spec_mapping.md`](../../../docs/weaver_spec_mapping.md).
+
+## Related
+
+- #334 — ChainWeaver flow → catalog import (`adapters/chainweaver.py`)
+- #320 — routing outputs ↔ weaver-spec routing contracts (docs)
+- #353 — this end-to-end example

--- a/examples/architectures/contextweaver_to_chainweaver/__init__.py
+++ b/examples/architectures/contextweaver_to_chainweaver/__init__.py
@@ -1,0 +1,1 @@
+"""contextweaver -> ChainWeaver reference architecture (issue #353)."""

--- a/examples/architectures/contextweaver_to_chainweaver/main.py
+++ b/examples/architectures/contextweaver_to_chainweaver/main.py
@@ -1,0 +1,313 @@
+"""contextweaver routes -> ChainWeaver executes -> contextweaver ingests (#353).
+
+The strongest "sum > parts" pairing in the Weaver stack is the handoff from
+contextweaver (the *router* / context compiler) to ChainWeaver (the
+deterministic *flow* executor):
+
+1. **Route (contextweaver).** A :class:`Router` shortlists a small catalog
+   of ordinary tools *plus* ChainWeaver flows imported via
+   :func:`~contextweaver.adapters.chainweaver.load_chainweaver_export`
+   (issue #334). The flows carry ``kind="flow"`` and route like any other
+   candidate.
+2. **Hand off at the contract level (issue #320).** The
+   :class:`~contextweaver.envelope.RoutingDecision` is mapped to the neutral
+   weaver-spec ``RoutingDecision`` via
+   :func:`~contextweaver.adapters.weaver_contracts.to_weaver_routing_decision`
+   when the ``[weaver-spec]`` extra is installed. The decision is *advisory*:
+   contextweaver selects a candidate, it does not execute or authorise it.
+3. **Execute (ChainWeaver).** A tiny in-process stub stands in for the
+   ChainWeaver runtime — there is **no hard dependency** on ChainWeaver. It
+   runs the selected flow deterministically and returns a large raw result.
+4. **Ingest the result (contextweaver firewall).** The raw flow output goes
+   back through :meth:`ContextManager.ingest_tool_result_sync`; the firewall
+   stores the bytes out-of-band and the prompt only sees a compact summary,
+   which is then mapped to a weaver-spec ``Frame``.
+
+Everything here is deterministic and offline: the "ChainWeaver" executor is
+canned. The point is to demonstrate the route -> execute -> ingest seam, not
+to integrate with a live runtime. See ``docs/weaver_spec_mapping.md`` for the
+contract boundary this example exercises.
+
+Run standalone::
+
+    python examples/architectures/contextweaver_to_chainweaver/main.py
+
+Or via ``make example`` (the ``architectures`` umbrella target).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from contextweaver.adapters.chainweaver import load_chainweaver_export
+from contextweaver.config import ContextBudget
+from contextweaver.context.manager import ContextManager
+from contextweaver.envelope import RoutingDecision
+from contextweaver.routing.catalog import Catalog
+from contextweaver.routing.router import Router
+from contextweaver.routing.tree import TreeBuilder
+from contextweaver.types import ContextItem, ItemKind, Phase, SelectableItem
+
+# Ordinary single-step tools the agent already has.
+_TOOLS: list[SelectableItem] = [
+    SelectableItem(
+        id="crm:lookup_customer",
+        kind="tool",
+        name="lookup_customer",
+        description="Look up a single customer record by id.",
+        namespace="crm",
+        tags=["customer"],
+    ),
+    SelectableItem(
+        id="crm:send_email",
+        kind="tool",
+        name="send_email",
+        description="Send a one-off email to a customer.",
+        namespace="crm",
+        tags=["comm"],
+    ),
+    SelectableItem(
+        id="billing:get_invoice",
+        kind="tool",
+        name="get_invoice",
+        description="Fetch a single invoice PDF by invoice number.",
+        namespace="billing",
+        tags=["billing"],
+    ),
+]
+
+# A ChainWeaver *flow export* — plain data, no ChainWeaver install required.
+# Each flow is a multi-step capability ChainWeaver executes deterministically.
+_CHAINWEAVER_EXPORT: dict[str, Any] = {
+    "flows": [
+        {
+            "id": "customer_summary_flow",
+            "name": "Summarize customer history",
+            "description": (
+                "Multi-step flow: pull a customer's recent orders, invoices, and "
+                "support tickets, then produce a consolidated history summary."
+            ),
+            "version": "1.2.0",
+            "input_schema": {
+                "type": "object",
+                "properties": {"customer_id": {"type": "string"}},
+                "required": ["customer_id"],
+            },
+            "output_schema": {
+                "type": "object",
+                "properties": {"summary": {"type": "string"}},
+            },
+            "tags": ["customer", "summary", "billing"],
+        },
+        {
+            "id": "dunning_flow",
+            "name": "Run dunning sequence",
+            "description": "Multi-step flow that escalates overdue-invoice reminders.",
+            "version": "0.4.1",
+            "input_schema": {
+                "type": "object",
+                "properties": {"invoice_id": {"type": "string"}},
+            },
+            "tags": ["billing", "collections"],
+        },
+    ]
+}
+
+# The request that should route to the customer-summary *flow* rather than any
+# single-step tool, because no one tool answers it on its own.
+QUERY = "summarize this customer's recent billing and order history"
+
+
+def _print_header(title: str) -> None:
+    """Print a section banner consistent with the other architecture scripts."""
+    print()
+    print("=" * 76)
+    print(title)
+    print("=" * 76)
+
+
+def _build_catalog() -> Catalog:
+    """Combine ordinary tools with imported ChainWeaver flows in one catalog."""
+    catalog = Catalog()
+    for tool in _TOOLS:
+        catalog.register(tool)
+    for flow_item in load_chainweaver_export(_CHAINWEAVER_EXPORT).all():
+        catalog.register(flow_item)
+    return catalog
+
+
+def _host_candidate(
+    decision: RoutingDecision, item_lookup: dict[str, SelectableItem]
+) -> dict[str, Any]:
+    """Project the advisory routing decision into a host-side candidate dict.
+
+    This mirrors the neutral ``ExecutionCandidate`` shape described in issue
+    #320 *without* binding to a weaver-spec type (the spec does not yet define
+    one). A host resolves this candidate to a concrete runtime target — here,
+    a ChainWeaver flow id carried in the item's metadata.
+    """
+    top_card = decision.choice_cards[0]
+    item = item_lookup[top_card.id]
+    return {
+        "candidate_id": item.id,
+        "candidate_type": item.kind,  # "flow" for a ChainWeaver flow
+        "name": item.name,
+        "confidence": round(top_card.score, 4) if top_card.score is not None else None,
+        "reason_codes": ["choicecard_match", "phase_route"],
+        "runtime": item.metadata.get("runtime"),
+        "runtime_flow_id": item.metadata.get("chainweaver_flow_id"),
+        "advisory": True,  # routing never grants execution rights
+    }
+
+
+class _StubChainWeaverRuntime:
+    """Stand-in for the ChainWeaver runtime — deterministic, offline.
+
+    A real integration would hand the selected flow id + inputs to ChainWeaver
+    over its own transport. Here we return a canned, intentionally large result
+    so the contextweaver firewall is load-bearing on the way back in.
+    """
+
+    def execute(self, flow_id: str, inputs: dict[str, Any]) -> str:
+        """Return a canned multi-step flow result keyed by *flow_id*."""
+        if flow_id == "customer_summary_flow":
+            customer_id = inputs.get("customer_id", "unknown")
+            orders = [
+                {"order_id": f"ord-{i:04d}", "total": 19.0 + i, "status": "shipped"}
+                for i in range(60)
+            ]
+            return json.dumps(
+                {
+                    "customer_id": customer_id,
+                    "orders": orders,
+                    "open_invoices": [{"invoice_id": "inv-9001", "amount_due": 240.0}],
+                    "support_tickets": [{"ticket": "t-77", "state": "resolved"}],
+                    "summary": (
+                        f"Customer {customer_id}: 60 orders (all shipped), 1 open invoice "
+                        "($240.00 due), 1 resolved support ticket."
+                    ),
+                }
+            )
+        return json.dumps({"flow_id": flow_id, "status": "ok"})
+
+
+def main() -> None:
+    """Run the route -> execute -> ingest scenario end-to-end."""
+    _print_header("contextweaver -> ChainWeaver reference architecture")
+
+    catalog = _build_catalog()
+    item_lookup = {item.id: item for item in catalog.all()}
+    flow_count = sum(1 for item in catalog.all() if item.kind == "flow")
+    print(
+        f"Loaded catalog: {len(item_lookup)} items "
+        f"({flow_count} ChainWeaver flows + {len(item_lookup) - flow_count} tools)"
+    )
+
+    graph = TreeBuilder(max_children=20).build(catalog.all())
+    router = Router(graph, items=catalog.all(), top_k=3)
+    budget = ContextBudget(route=1500, call=2000, interpret=2500, answer=2500)
+    mgr = ContextManager(budget=budget)
+
+    # ------------------------------------------------------------------
+    # 1. Route (contextweaver) — bounded shortlist; the flow should win.
+    # ------------------------------------------------------------------
+    _print_header("1. Route (contextweaver)")
+    print(f"query: {QUERY}")
+    mgr.ingest_sync(ContextItem(id="u1", kind=ItemKind.user_turn, text=QUERY))
+    result = router.route(QUERY)
+    print(f"shortlist: {result.candidate_ids}")
+    selected_id = result.candidate_ids[0]
+    selected = item_lookup[selected_id]
+    print(f"selected:  {selected_id}  (kind={selected.kind!r})")
+    routed_to_flow = selected.kind == "flow"
+    print(f"routed to a ChainWeaver flow: {routed_to_flow}")
+
+    # ------------------------------------------------------------------
+    # 2. Hand off at the contract level (issue #320) — advisory only.
+    # ------------------------------------------------------------------
+    _print_header("2. Hand off (advisory routing decision)")
+    decision = result.to_routing_decision(
+        selected_item_id=selected_id,
+        context_summary="route customer-history request to a ChainWeaver flow",
+    )
+    candidate = _host_candidate(decision, item_lookup)
+    print("host-side ExecutionCandidate (neutral; resolved to a ChainWeaver flow):")
+    print(json.dumps(candidate, indent=2))
+
+    spec_mapped = False
+    try:
+        from contextweaver.adapters.weaver_contracts import to_weaver_routing_decision
+
+        spec_decision = to_weaver_routing_decision(decision)
+        spec_mapped = True
+        print(f"weaver-spec RoutingDecision id: {spec_decision.id}")
+    except Exception as exc:  # weaver_contracts not installed (core install)
+        print(
+            f"weaver-spec mapping skipped ({type(exc).__name__}); "
+            "install contextweaver[weaver-spec]"
+        )
+
+    # ------------------------------------------------------------------
+    # 3. Execute (ChainWeaver stub) — no hard dependency on ChainWeaver.
+    # ------------------------------------------------------------------
+    _print_header("3. Execute (ChainWeaver stub)")
+    runtime = _StubChainWeaverRuntime()
+    flow_id = selected.metadata["chainweaver_flow_id"]
+    inputs = {"customer_id": "cust-42"}
+    print(f"ChainWeaver.execute(flow_id={flow_id!r}, inputs={inputs})")
+    raw_result = runtime.execute(flow_id, inputs)
+    print(f"raw flow result: {len(raw_result):,} chars")
+
+    # ------------------------------------------------------------------
+    # 4. Ingest the result (contextweaver firewall) — large result compacted.
+    # ------------------------------------------------------------------
+    _print_header("4. Ingest result (contextweaver firewall)")
+    mgr.ingest_sync(
+        ContextItem(id="tc1", kind=ItemKind.tool_call, text=f"{flow_id}(...)", parent_id="u1")
+    )
+    item, envelope = mgr.ingest_tool_result_sync(
+        tool_call_id="tc1",
+        raw_output=raw_result,
+        tool_name=flow_id,
+        media_type="application/json",
+        firewall_threshold=2000,
+    )
+    firewalled = item.artifact_ref is not None and len(raw_result) > 2000
+    if firewalled:
+        print(
+            f"firewall: {len(raw_result):,} chars -> {len(item.text):,}-char summary "
+            f"(artifact {item.artifact_ref.handle})"
+        )
+
+    frame_mapped = False
+    if spec_mapped:
+        from contextweaver.adapters.weaver_contracts import to_weaver_frame
+
+        frame = to_weaver_frame(envelope, frame_id="frame-cust-42", capability_id=selected_id)
+        frame_mapped = True
+        print(f"weaver-spec Frame id: {frame.frame_id} (capability {frame.capability_id})")
+
+    answer = mgr.build_sync(phase=Phase.answer, query=QUERY)
+    ans_tokens = sum(answer.stats.tokens_per_section.values())
+    print(
+        f"answer prompt: included={answer.stats.included_count} "
+        f"dropped={answer.stats.dropped_count} tokens={ans_tokens}"
+    )
+
+    # ------------------------------------------------------------------
+    # Scoreboard.
+    # ------------------------------------------------------------------
+    _print_header("Scoreboard")
+    print(f"routed to flow:        {routed_to_flow}")
+    print(f"firewall fired:        {firewalled}")
+    print(f"weaver-spec mapped:    decision={spec_mapped} frame={frame_mapped}")
+    print(f"artifacts kept:        {len(list(mgr.artifact_store.list_refs()))}")
+    print(
+        "Seam: contextweaver ROUTES (advisory) -> ChainWeaver EXECUTES -> "
+        "contextweaver INGESTS the result behind the firewall."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -103,6 +103,15 @@ contextweaver ─▶ ChainWeaver ─▶ agent-kernel ─▶ agentfence
 | Boundary | agent-kernel | Own the execution boundary; hand contextweaver `Frame`s, not raw output. |
 | Guardrails | agentfence | Apply output guardrails to the response. |
 
+The contextweaver → ChainWeaver handoff is **advisory**: contextweaver routes
+(it recommends a capability) and ingests results behind its firewall; the
+runtime owns authorization and execution. A runnable end-to-end example —
+route a catalog of tools + imported ChainWeaver flows, hand the selection to a
+(stubbed) ChainWeaver runtime, then ingest the result — lives at
+[`examples/architectures/contextweaver_to_chainweaver/`](examples/architectures/contextweaver_to_chainweaver/),
+and the contract boundary is documented in
+[`docs/weaver_spec_mapping.md`](docs/weaver_spec_mapping.md).
+
 Adjacent tools: **vibeguard** (code-diff safety gate), **lessonweaver** (lesson
 capture), and **skdr-eval** (offline evaluation). Every piece works
 **standalone** — contextweaver has **no hard dependency** on any sibling, so you
@@ -2251,7 +2260,8 @@ make weaver-conformance  # round-trip + JSON-Schema validate the weaver-spec ada
 
 > Gating CI steps beyond `make ci`: `make scorecard-check`,
 > `make readme-version-check` (#347), `make context-rot-check` (#349),
-> `make schemas-check`, and `make weaver-conformance`.
+> and `make weaver-conformance`. (`make schemas-check` also gates, but it
+> runs *inside* `make ci`.)
 
 `make ci` runs all six targets in sequence. It is the single validation gate.
 

--- a/schemas/catalog.schema.json
+++ b/schemas/catalog.schema.json
@@ -3,7 +3,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "items": {
     "additionalProperties": false,
-    "description": "A unified representation of a tool, agent, skill, or internal function.",
+    "description": "A unified representation of a tool, agent, skill, flow, or internal function.",
     "properties": {
       "args_schema": {
         "additionalProperties": {},
@@ -46,7 +46,8 @@
           "tool",
           "agent",
           "skill",
-          "internal"
+          "internal",
+          "flow"
         ]
       },
       "metadata": {

--- a/schemas/choice_card.schema.json
+++ b/schemas/choice_card.schema.json
@@ -21,7 +21,8 @@
         "tool",
         "agent",
         "skill",
-        "internal"
+        "internal",
+        "flow"
       ]
     },
     "name": {

--- a/src/contextweaver/__init__.py
+++ b/src/contextweaver/__init__.py
@@ -84,6 +84,7 @@ from contextweaver.protocols import (
     RedactionHook,
     Reranker,
     Retriever,
+    RoutingScoreProvider,
     Summarizer,
     TokenEstimator,
 )
@@ -95,6 +96,12 @@ from contextweaver.routing.catalog import (
     load_catalog_dicts,
     load_catalog_json,
     load_catalog_yaml,
+)
+from contextweaver.routing.feedback import (
+    DeterministicScoreProvider,
+    ExecutionFeedback,
+    FeedbackAwareScoreProvider,
+    aggregate_feedback,
 )
 from contextweaver.routing.graph import ChoiceGraph
 from contextweaver.routing.graph_node import ChoiceNode
@@ -186,6 +193,7 @@ __all__ = [
     "RedactionHook",
     "Reranker",
     "Retriever",
+    "RoutingScoreProvider",
     "Summarizer",
     "TokenEstimator",
     # exceptions
@@ -239,7 +247,10 @@ __all__ = [
     "ChoiceGraph",
     "ChoiceNode",
     "DefaultCardPacker",
+    "DeterministicScoreProvider",
     "EngineRegistry",
+    "ExecutionFeedback",
+    "FeedbackAwareScoreProvider",
     "GraphManifest",
     "JaccardClusteringEngine",
     "KeywordLabeler",
@@ -253,6 +264,7 @@ __all__ = [
     "TfIdfRetriever",
     "TraceStep",
     "TreeBuilder",
+    "aggregate_feedback",
     "compute_catalog_hash",
     "default_registry",
     "generate_sample_catalog",

--- a/src/contextweaver/adapters/__init__.py
+++ b/src/contextweaver/adapters/__init__.py
@@ -42,6 +42,11 @@ from contextweaver.adapters.anthropic_messages import (
     from_anthropic_messages,
     to_anthropic_messages,
 )
+from contextweaver.adapters.chainweaver import (
+    chainweaver_flow_to_selectable,
+    chainweaver_flows_to_catalog,
+    load_chainweaver_export,
+)
 from contextweaver.adapters.crewai import (
     crewai_tool_to_selectable,
     crewai_tools_to_catalog,
@@ -132,6 +137,8 @@ __all__ = [
     "a2a_result_to_envelope",
     "agno_tool_to_selectable",
     "agno_tools_to_catalog",
+    "chainweaver_flow_to_selectable",
+    "chainweaver_flows_to_catalog",
     "crewai_tool_to_selectable",
     "crewai_tools_to_catalog",
     "dispatch_meta_tool",
@@ -158,6 +165,7 @@ __all__ = [
     "infer_smolagents_namespace",
     "load_a2a_session_jsonl",
     "load_agno_catalog",
+    "load_chainweaver_export",
     "load_crewai_catalog",
     "load_fastmcp_catalog",
     "load_mcp_session_jsonl",

--- a/src/contextweaver/adapters/chainweaver.py
+++ b/src/contextweaver/adapters/chainweaver.py
@@ -100,8 +100,11 @@ def chainweaver_flow_to_selectable(
         ChainWeaver flow.
 
     Raises:
-        CatalogError: If a required field is missing or non-string.
+        CatalogError: If *flow* is not a dict, or a required field is missing
+            or non-string.
     """
+    if not isinstance(flow, dict):
+        raise CatalogError(f"ChainWeaver flow export must be a dict; got {type(flow).__name__}.")
     raw_id = flow.get("id") or flow.get("flow_id")
     if not isinstance(raw_id, str) or not raw_id:
         raise CatalogError(

--- a/src/contextweaver/adapters/chainweaver.py
+++ b/src/contextweaver/adapters/chainweaver.py
@@ -1,0 +1,227 @@
+"""ChainWeaver flow-import adapter for contextweaver (issue #334).
+
+[ChainWeaver](https://github.com/dgenio/ChainWeaver) executes deterministic
+multi-step *flows*.  This adapter ingests a ChainWeaver **flow export** —
+plain data, no ChainWeaver install required — and converts each flow into a
+:class:`~contextweaver.types.SelectableItem` with ``kind="flow"`` so a
+contextweaver :class:`~contextweaver.routing.router.Router` can shortlist a
+flow alongside ordinary tools.  Routing stays *advisory*: contextweaver
+selects the flow candidate; a host/runtime (ChainWeaver) executes it.  See
+``docs/weaver_spec_mapping.md`` for the route → execute boundary.
+
+Expected flow-export shape
+--------------------------
+
+A single flow is a JSON-compatible dict::
+
+    {
+        "id": "customer_summary_flow",   # required; "flow_id" also accepted
+        "name": "Summarize customer history",   # required
+        "description": "Fetch + summarise a customer's recent activity.",  # required
+        "version": "1.2.0",              # optional
+        "input_schema": {...},           # optional JSON Schema (a.k.a. "inputs")
+        "output_schema": {...},          # optional JSON Schema (a.k.a. "outputs")
+        "tags": ["customer", "summary"]  # optional
+    }
+
+A full export is either a list of such dicts or a dict with a top-level
+``"flows"`` list::
+
+    {"flows": [ {...}, {...} ]}
+
+This module is a **pure, stateless converter** (per ``AGENTS.md`` adapter
+conventions): it does not import ChainWeaver and performs no I/O.  Callers
+that read an export from disk should ``json.load`` it and pass the result to
+:func:`load_chainweaver_export`.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any
+
+from contextweaver.exceptions import CatalogError
+from contextweaver.routing.catalog import Catalog
+from contextweaver.types import SelectableItem
+
+logger = logging.getLogger("contextweaver.adapters")
+
+_FALLBACK_NS = "chainweaver"
+#: Tag stamped on every imported flow so callers can gate with
+#: ``Router.route(allowed_tags={"flow"})`` or filter flows out explicitly.
+FLOW_TAG = "flow"
+
+
+def _schema_dict(raw: object) -> dict[str, Any]:
+    """Coerce an export schema value into a JSON-shaped dict.
+
+    Accepts an already-built JSON-Schema dict (deep-copied so the caller's
+    export is never mutated) or a Pydantic model class exposing
+    ``model_json_schema``.  Anything else yields ``{}``.
+    """
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return copy.deepcopy(raw)
+    schema_fn = getattr(raw, "model_json_schema", None)
+    if callable(schema_fn):
+        try:
+            schema = schema_fn()
+        except Exception:  # pragma: no cover - defensive; depends on user model
+            return {}
+        if isinstance(schema, dict):
+            return dict(schema)
+    return {}
+
+
+def chainweaver_flow_to_selectable(
+    flow: dict[str, Any],
+    *,
+    namespace: str | None = None,
+) -> SelectableItem:
+    """Convert one ChainWeaver flow-export dict to a :class:`SelectableItem`.
+
+    Args:
+        flow: A single flow-export dict (see the module docstring for the
+            expected shape).  ``id``/``flow_id``, ``name``, and
+            ``description`` are required; ``version``, ``input_schema``
+            (or ``inputs``), ``output_schema`` (or ``outputs``), and ``tags``
+            are optional.
+        namespace: Explicit namespace override.  Defaults to
+            ``"chainweaver"``.
+
+    Returns:
+        A :class:`SelectableItem` with ``kind="flow"``, ``id`` of the form
+        ``"chainweaver:{flow_id}"``, ``args_schema`` carrying the flow's
+        input schema, and ``output_schema`` carrying its output schema.  The
+        flow id, version, and ``runtime="chainweaver"`` are preserved under
+        ``metadata`` so a host can resolve the candidate back to a concrete
+        ChainWeaver flow.
+
+    Raises:
+        CatalogError: If a required field is missing or non-string.
+    """
+    raw_id = flow.get("id") or flow.get("flow_id")
+    if not isinstance(raw_id, str) or not raw_id:
+        raise CatalogError(
+            "ChainWeaver flow export is missing a non-empty 'id' (or 'flow_id') field."
+        )
+    raw_name = flow.get("name")
+    if not isinstance(raw_name, str) or not raw_name:
+        raise CatalogError(f"ChainWeaver flow {raw_id!r} is missing a non-empty 'name' field.")
+    raw_description = flow.get("description")
+    if not isinstance(raw_description, str) or not raw_description:
+        raise CatalogError(
+            f"ChainWeaver flow {raw_id!r} is missing a non-empty 'description' field."
+        )
+
+    ns = namespace if namespace is not None else _FALLBACK_NS
+    args_schema = _schema_dict(flow.get("input_schema", flow.get("inputs")))
+    output_schema_raw = _schema_dict(flow.get("output_schema", flow.get("outputs")))
+    output_schema = output_schema_raw or None
+
+    tags: set[str] = {FLOW_TAG}
+    raw_tags = flow.get("tags")
+    if isinstance(raw_tags, (list, set, tuple)):
+        for tag in raw_tags:
+            if isinstance(tag, str) and tag:
+                tags.add(tag)
+
+    metadata: dict[str, Any] = {"runtime": _FALLBACK_NS, "chainweaver_flow_id": raw_id}
+    raw_version = flow.get("version")
+    if isinstance(raw_version, str) and raw_version:
+        metadata["chainweaver_flow_version"] = raw_version
+
+    logger.debug(
+        "chainweaver_flow_to_selectable: id=%s, ns=%s, has_input=%s, has_output=%s",
+        raw_id,
+        ns,
+        bool(args_schema),
+        output_schema is not None,
+    )
+    return SelectableItem(
+        id=f"{_FALLBACK_NS}:{raw_id}",
+        kind="flow",
+        name=raw_name,
+        description=raw_description,
+        tags=sorted(tags),
+        namespace=ns,
+        args_schema=args_schema,
+        output_schema=output_schema,
+        metadata=metadata,
+    )
+
+
+def chainweaver_flows_to_catalog(
+    flows: list[dict[str, Any]],
+    *,
+    namespace: str | None = None,
+) -> Catalog:
+    """Convert a list of ChainWeaver flow-export dicts to a :class:`Catalog`.
+
+    Args:
+        flows: List of flow-export dicts.
+        namespace: Optional namespace override applied to every flow.
+
+    Returns:
+        A :class:`~contextweaver.routing.catalog.Catalog` of ``kind="flow"``
+        items.
+
+    Raises:
+        CatalogError: If a flow is invalid or duplicate IDs are encountered.
+    """
+    catalog = Catalog()
+    for flow in flows:
+        catalog.register(chainweaver_flow_to_selectable(flow, namespace=namespace))
+    logger.debug("chainweaver_flows_to_catalog: registered %d flows", len(flows))
+    return catalog
+
+
+def load_chainweaver_export(
+    export: list[dict[str, Any]] | dict[str, Any],
+    *,
+    namespace: str | None = None,
+) -> Catalog:
+    """Load a full ChainWeaver export into a :class:`Catalog`.
+
+    Accepts either a bare list of flow dicts or a dict with a top-level
+    ``"flows"`` list (the two shapes a ChainWeaver export may take).  This is
+    the convenience entry point; callers reading from disk should
+    ``json.load`` the file first.
+
+    Args:
+        export: A list of flow dicts, or ``{"flows": [...]}``.
+        namespace: Optional namespace override applied to every flow.
+
+    Returns:
+        A populated :class:`Catalog`.
+
+    Raises:
+        CatalogError: If *export* is neither a list nor a dict carrying a
+            ``"flows"`` list, or if any contained flow is invalid.
+    """
+    if isinstance(export, dict):
+        raw_flows = export.get("flows")
+        if not isinstance(raw_flows, list):
+            raise CatalogError(
+                "ChainWeaver export dict must carry a top-level 'flows' list; "
+                f"got keys {sorted(export)}."
+            )
+        flows = raw_flows
+    elif isinstance(export, list):
+        flows = export
+    else:
+        raise CatalogError(
+            "ChainWeaver export must be a list of flow dicts or a dict with a 'flows' list; "
+            f"got {type(export).__name__}."
+        )
+    return chainweaver_flows_to_catalog(flows, namespace=namespace)
+
+
+__all__ = [
+    "FLOW_TAG",
+    "chainweaver_flow_to_selectable",
+    "chainweaver_flows_to_catalog",
+    "load_chainweaver_export",
+]

--- a/src/contextweaver/envelope.py
+++ b/src/contextweaver/envelope.py
@@ -395,7 +395,7 @@ class ContextPack:
 CHOICE_CARD_NAME_MAX_LEN: int = 64
 CHOICE_CARD_TAG_MAX_LEN: int = 24
 CHOICE_CARD_TAGS_MAX_COUNT: int = 5
-CHOICE_CARD_KINDS: tuple[str, ...] = ("tool", "agent", "skill", "internal")
+CHOICE_CARD_KINDS: tuple[str, ...] = ("tool", "agent", "skill", "internal", "flow")
 
 
 @dataclass
@@ -422,7 +422,7 @@ class ChoiceCard:
     name: str
     description: str
     tags: list[str] = field(default_factory=list)
-    kind: Literal["tool", "agent", "skill", "internal"] = "tool"
+    kind: Literal["tool", "agent", "skill", "internal", "flow"] = "tool"
     namespace: str = ""
     has_schema: bool = False
     score: float | None = None

--- a/src/contextweaver/protocols.py
+++ b/src/contextweaver/protocols.py
@@ -367,6 +367,42 @@ class ClusteringEngine(Protocol):
 
 
 # ---------------------------------------------------------------------------
+# RoutingScoreProvider (issue #318)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class RoutingScoreProvider(Protocol):
+    """Optional feedback-aware adjuster for routing scores (issue #318).
+
+    A score provider takes the navigator's ranked ``(item_id, score)`` pairs
+    and returns adjusted pairs — typically folding in historical execution
+    signals (success rate, latency, token cost, result quality) via
+    :class:`~contextweaver.routing.feedback.ExecutionFeedback`.  It is the
+    routing engine's opt-in seam for *learned* or *feedback-aware* ranking;
+    the default :class:`~contextweaver.routing.router.Router` applies no
+    provider and stays purely deterministic.
+
+    Implementations MUST be deterministic: identical ``(query, scored)``
+    inputs must yield identical outputs, and ties must break by ascending
+    ``item_id`` (re-sort by ``(-score, id)``), exactly like the rest of the
+    routing engine.  The bundled
+    :class:`~contextweaver.routing.feedback.DeterministicScoreProvider` is a
+    no-op reference implementation;
+    :class:`~contextweaver.routing.feedback.FeedbackAwareScoreProvider`
+    applies bounded feedback deltas.
+    """
+
+    def adjust(
+        self,
+        query: str,
+        scored: list[tuple[str, float]],
+    ) -> list[tuple[str, float]]:
+        """Return *scored* re-scored and re-ranked (ties broken by id)."""
+        ...
+
+
+# ---------------------------------------------------------------------------
 # Navigator (issue #56)
 # ---------------------------------------------------------------------------
 

--- a/src/contextweaver/routing/__init__.py
+++ b/src/contextweaver/routing/__init__.py
@@ -19,6 +19,12 @@ from contextweaver.routing.cards import (
     truncate_description_to_tokens,
 )
 from contextweaver.routing.catalog import Catalog
+from contextweaver.routing.feedback import (
+    DeterministicScoreProvider,
+    ExecutionFeedback,
+    FeedbackAwareScoreProvider,
+    aggregate_feedback,
+)
 from contextweaver.routing.graph import ChoiceGraph
 from contextweaver.routing.graph_io import load_graph, save_graph
 from contextweaver.routing.graph_node import ChoiceNode
@@ -45,12 +51,16 @@ __all__ = [
     "ChoiceNode",
     "DEFAULT_CARD_HARD_CAP_TOKENS",
     "DEFAULT_CARD_TARGET_TOKENS",
+    "DeterministicScoreProvider",
+    "ExecutionFeedback",
+    "FeedbackAwareScoreProvider",
     "KeywordLabeler",
     "RouteResult",
     "Router",
     "SchemaSource",
     "ToolIdParts",
     "TreeBuilder",
+    "aggregate_feedback",
     "bound_browse_response",
     "canonical_tool_id",
     "cards_for_route",

--- a/src/contextweaver/routing/feedback.py
+++ b/src/contextweaver/routing/feedback.py
@@ -5,35 +5,22 @@ contextweaver routes deterministically by default.  This module adds an
 rate, latency, token cost, result quality — into the routing score without
 giving up determinism or coupling the library to any external router.
 
-The pieces:
+The pieces: :class:`ExecutionFeedback` (a contextweaver-native record of one
+past execution — **not** a weaver-spec contract type; the spec defines none),
+:class:`~contextweaver.protocols.RoutingScoreProvider` (the plug-point),
+:class:`DeterministicScoreProvider` (no-op default, byte-equivalent to passing
+no provider), :class:`FeedbackAwareScoreProvider` (bounded feedback deltas),
+and :func:`aggregate_feedback` (folds a history list into one record per id).
 
-* :class:`ExecutionFeedback` — a contextweaver-native record of one past
-  execution of a routable item.  **It is not a weaver-spec contract type**;
-  weaver-spec does not (yet) define an ``ExecutionFeedback`` shape, so this
-  dataclass deliberately makes no spec-compliance claim.
-* :class:`RoutingScoreProvider` (defined in
-  :mod:`contextweaver.protocols`) — the plug-point a custom provider
-  implements.
-* :class:`DeterministicScoreProvider` — the default provider.  Re-sorts by
-  ``(-score, id)`` and changes nothing else; passing it to
-  :class:`~contextweaver.routing.router.Router` is byte-equivalent to passing
-  no provider at all.
-* :class:`FeedbackAwareScoreProvider` — nudges base scores using an
-  aggregated :class:`ExecutionFeedback` per item, then re-sorts
-  deterministically.
-* :func:`aggregate_feedback` — folds a history list of
-  :class:`ExecutionFeedback` into one aggregated record per item id.
-
-Determinism guarantee: every provider here re-sorts results by
-``(-score, item_id)``, so ties always break by ascending id — identical to
-the rest of the routing engine.
+Determinism guarantee: every provider re-sorts by ``(-score, item_id)``, so
+ties always break by ascending id — identical to the rest of the engine.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from contextweaver.exceptions import ConfigError
@@ -109,7 +96,13 @@ class ExecutionFeedback:
         payloads round-trip cleanly.
         """
         raw_ts = data.get("timestamp")
-        timestamp = datetime.fromisoformat(raw_ts) if isinstance(raw_ts, str) and raw_ts else None
+        timestamp: datetime | None = None
+        if isinstance(raw_ts, str) and raw_ts:
+            timestamp = datetime.fromisoformat(raw_ts)
+            # Match RoutingDecision/Frame handling: coerce naive timestamps to
+            # UTC so a restored ``ExecutionFeedback`` is always tz-aware.
+            if timestamp.tzinfo is None:
+                timestamp = timestamp.replace(tzinfo=timezone.utc)
         raw_cost = data.get("token_cost")
         raw_quality = data.get("quality_score")
         raw_latency = data.get("latency_ms")
@@ -190,8 +183,11 @@ class FeedbackAwareScoreProvider:
 
         delta  = +success_weight        if feedback.success else -failure_penalty
         delta += quality_weight  * (2 * clamp01(quality_score) - 1)   # in [-w, +w]
-        delta -= latency_weight  * (latency_ms / latency_ref_ms)      # if weight > 0
-        delta -= cost_weight     * (token_cost / token_cost_ref)      # if weight > 0
+        delta -= latency_weight  * clamp01(latency_ms / latency_ref_ms)   # if weight > 0
+        delta -= cost_weight     * clamp01(token_cost / token_cost_ref)   # if weight > 0
+
+    The latency/cost ratios are clamped to ``[0, 1]`` so every term is bounded
+    by its weight — an outlier can never swamp the base retrieval score.
 
     Candidates with no feedback keep their base score.  Results are re-sorted
     by ``(-score, id)`` so ties still break by ascending id — feedback never
@@ -261,10 +257,12 @@ class FeedbackAwareScoreProvider:
         delta = self._success_weight if feedback.success else -self._failure_penalty
         if feedback.quality_score is not None:
             delta += self._quality_weight * (2.0 * _clamp01(feedback.quality_score) - 1.0)
+        # Clamp the latency/cost ratios to [0, 1] so each penalty is bounded by
+        # its weight; an outlier latency/cost can never swamp the base score.
         if self._latency_weight > 0 and feedback.latency_ms is not None:
-            delta -= self._latency_weight * (feedback.latency_ms / self._latency_ref_ms)
+            delta -= self._latency_weight * _clamp01(feedback.latency_ms / self._latency_ref_ms)
         if self._cost_weight > 0 and feedback.token_cost is not None:
-            delta -= self._cost_weight * (feedback.token_cost / self._token_cost_ref)
+            delta -= self._cost_weight * _clamp01(feedback.token_cost / self._token_cost_ref)
         return delta
 
     def adjust(self, query: str, scored: list[tuple[str, float]]) -> list[tuple[str, float]]:

--- a/src/contextweaver/routing/feedback.py
+++ b/src/contextweaver/routing/feedback.py
@@ -1,0 +1,302 @@
+"""Feedback-aware routing score extension point (issue #318).
+
+contextweaver routes deterministically by default.  This module adds an
+*opt-in* seam so callers can fold historical execution signals — success
+rate, latency, token cost, result quality — into the routing score without
+giving up determinism or coupling the library to any external router.
+
+The pieces:
+
+* :class:`ExecutionFeedback` — a contextweaver-native record of one past
+  execution of a routable item.  **It is not a weaver-spec contract type**;
+  weaver-spec does not (yet) define an ``ExecutionFeedback`` shape, so this
+  dataclass deliberately makes no spec-compliance claim.
+* :class:`RoutingScoreProvider` (defined in
+  :mod:`contextweaver.protocols`) — the plug-point a custom provider
+  implements.
+* :class:`DeterministicScoreProvider` — the default provider.  Re-sorts by
+  ``(-score, id)`` and changes nothing else; passing it to
+  :class:`~contextweaver.routing.router.Router` is byte-equivalent to passing
+  no provider at all.
+* :class:`FeedbackAwareScoreProvider` — nudges base scores using an
+  aggregated :class:`ExecutionFeedback` per item, then re-sorts
+  deterministically.
+* :func:`aggregate_feedback` — folds a history list of
+  :class:`ExecutionFeedback` into one aggregated record per item id.
+
+Determinism guarantee: every provider here re-sorts results by
+``(-score, item_id)``, so ties always break by ascending id — identical to
+the rest of the routing engine.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from contextweaver.exceptions import ConfigError
+
+# Default scoring weights.  Kept small so feedback *nudges* the base
+# retrieval score rather than overriding it; callers tune via the
+# :class:`FeedbackAwareScoreProvider` constructor.
+DEFAULT_SUCCESS_WEIGHT: float = 0.1
+DEFAULT_FAILURE_PENALTY: float = 0.2
+DEFAULT_QUALITY_WEIGHT: float = 0.1
+DEFAULT_LATENCY_WEIGHT: float = 0.0
+DEFAULT_COST_WEIGHT: float = 0.0
+DEFAULT_LATENCY_REF_MS: float = 1000.0
+DEFAULT_TOKEN_COST_REF: float = 1000.0
+
+
+def _clamp01(value: float) -> float:
+    """Clamp *value* into the closed unit interval ``[0.0, 1.0]``."""
+    return max(0.0, min(1.0, value))
+
+
+def _resort(scored: list[tuple[str, float]]) -> list[tuple[str, float]]:
+    """Return *scored* sorted by descending score, ties broken by ascending id."""
+    return sorted(scored, key=lambda pair: (-pair[1], pair[0]))
+
+
+@dataclass
+class ExecutionFeedback:
+    """A single historical execution signal for a routable item (issue #318).
+
+    Attributes:
+        item_id: The :class:`~contextweaver.types.SelectableItem` id this
+            feedback describes.
+        success: Whether the execution succeeded.  Defaults to ``True``.
+        latency_ms: Optional wall-clock latency in milliseconds.
+        token_cost: Optional token cost of the execution.
+        quality_score: Optional result-quality signal in ``[0.0, 1.0]``
+            (e.g. a rubric score or thumbs-up rate).
+        timestamp: Optional timezone-aware time the execution occurred.
+        metadata: Free-form provenance.  :func:`aggregate_feedback` writes
+            ``sample_count`` and ``success_rate`` here.
+    """
+
+    item_id: str
+    success: bool = True
+    latency_ms: float | None = None
+    token_cost: int | None = None
+    quality_score: float | None = None
+    timestamp: datetime | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-compatible dict.
+
+        ``timestamp`` is emitted as an ISO-8601 string (or ``None``);
+        all other optional fields round-trip as themselves.
+        """
+        return {
+            "item_id": self.item_id,
+            "success": self.success,
+            "latency_ms": self.latency_ms,
+            "token_cost": self.token_cost,
+            "quality_score": self.quality_score,
+            "timestamp": self.timestamp.isoformat() if self.timestamp is not None else None,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ExecutionFeedback:
+        """Deserialise from a dict previously produced by :meth:`to_dict`.
+
+        Missing optional keys fall back to the dataclass defaults so older
+        payloads round-trip cleanly.
+        """
+        raw_ts = data.get("timestamp")
+        timestamp = datetime.fromisoformat(raw_ts) if isinstance(raw_ts, str) and raw_ts else None
+        raw_cost = data.get("token_cost")
+        raw_quality = data.get("quality_score")
+        raw_latency = data.get("latency_ms")
+        return cls(
+            item_id=data["item_id"],
+            success=bool(data.get("success", True)),
+            latency_ms=float(raw_latency) if raw_latency is not None else None,
+            token_cost=int(raw_cost) if raw_cost is not None else None,
+            quality_score=float(raw_quality) if raw_quality is not None else None,
+            timestamp=timestamp,
+            metadata=dict(data.get("metadata", {})),
+        )
+
+
+def aggregate_feedback(entries: Iterable[ExecutionFeedback]) -> dict[str, ExecutionFeedback]:
+    """Fold a history of :class:`ExecutionFeedback` into one record per item.
+
+    Numeric signals (``latency_ms``, ``token_cost``, ``quality_score``) are
+    averaged over the entries that supplied them; ``success`` becomes the
+    majority vote (``success_rate >= 0.5``); ``timestamp`` is the most recent
+    non-null value.  The aggregated record's ``metadata`` carries
+    ``sample_count`` and the exact ``success_rate`` so callers keep the raw
+    signal.  Deterministic: item ids are processed in sorted order and the
+    arithmetic does not depend on input ordering.
+
+    Args:
+        entries: Historical feedback records, in any order.
+
+    Returns:
+        A mapping ``item_id -> ExecutionFeedback`` suitable for
+        :class:`FeedbackAwareScoreProvider`.
+    """
+    grouped: dict[str, list[ExecutionFeedback]] = {}
+    for entry in entries:
+        grouped.setdefault(entry.item_id, []).append(entry)
+
+    aggregated: dict[str, ExecutionFeedback] = {}
+    for item_id in sorted(grouped):
+        records = grouped[item_id]
+        count = len(records)
+        success_rate = sum(1 for r in records if r.success) / count
+        latencies = [r.latency_ms for r in records if r.latency_ms is not None]
+        costs = [r.token_cost for r in records if r.token_cost is not None]
+        qualities = [r.quality_score for r in records if r.quality_score is not None]
+        timestamps = [r.timestamp for r in records if r.timestamp is not None]
+        aggregated[item_id] = ExecutionFeedback(
+            item_id=item_id,
+            success=success_rate >= 0.5,
+            latency_ms=(sum(latencies) / len(latencies)) if latencies else None,
+            token_cost=round(sum(costs) / len(costs)) if costs else None,
+            quality_score=(sum(qualities) / len(qualities)) if qualities else None,
+            timestamp=max(timestamps) if timestamps else None,
+            metadata={"sample_count": count, "success_rate": success_rate},
+        )
+    return aggregated
+
+
+class DeterministicScoreProvider:
+    """The default :class:`~contextweaver.protocols.RoutingScoreProvider`.
+
+    Returns the candidates unchanged apart from enforcing the canonical
+    ``(-score, id)`` ordering.  Passing this provider to
+    :class:`~contextweaver.routing.router.Router` is byte-equivalent to
+    passing none — it exists so callers can be explicit, and as a base other
+    providers can fall back to.
+    """
+
+    def adjust(self, query: str, scored: list[tuple[str, float]]) -> list[tuple[str, float]]:
+        """Return *scored* in canonical deterministic order (no score change)."""
+        return _resort(scored)
+
+
+class FeedbackAwareScoreProvider:
+    """A :class:`~contextweaver.protocols.RoutingScoreProvider` that folds in feedback.
+
+    For every candidate that has an :class:`ExecutionFeedback` entry, a
+    bounded delta is added to the base retrieval score::
+
+        delta  = +success_weight        if feedback.success else -failure_penalty
+        delta += quality_weight  * (2 * clamp01(quality_score) - 1)   # in [-w, +w]
+        delta -= latency_weight  * (latency_ms / latency_ref_ms)      # if weight > 0
+        delta -= cost_weight     * (token_cost / token_cost_ref)      # if weight > 0
+
+    Candidates with no feedback keep their base score.  Results are re-sorted
+    by ``(-score, id)`` so ties still break by ascending id — feedback never
+    introduces nondeterminism.
+
+    Args:
+        feedback: Either a mapping ``item_id -> ExecutionFeedback`` (one
+            aggregated record per item) or a flat sequence of feedback
+            records, which is aggregated via :func:`aggregate_feedback`.
+        success_weight: Bonus added when ``feedback.success`` is ``True``.
+        failure_penalty: Penalty subtracted when ``feedback.success`` is
+            ``False``.
+        quality_weight: Scales the ``quality_score`` contribution.
+        latency_weight: Scales the latency penalty.  ``0.0`` (default)
+            disables it.
+        cost_weight: Scales the token-cost penalty.  ``0.0`` (default)
+            disables it.
+        latency_ref_ms: Latency that maps to a full ``latency_weight``
+            penalty.  Must be ``> 0``.
+        token_cost_ref: Token cost that maps to a full ``cost_weight``
+            penalty.  Must be ``> 0``.
+
+    Raises:
+        ConfigError: If any weight is negative or a reference value is not
+            strictly positive.
+    """
+
+    def __init__(
+        self,
+        feedback: Mapping[str, ExecutionFeedback] | Sequence[ExecutionFeedback],
+        *,
+        success_weight: float = DEFAULT_SUCCESS_WEIGHT,
+        failure_penalty: float = DEFAULT_FAILURE_PENALTY,
+        quality_weight: float = DEFAULT_QUALITY_WEIGHT,
+        latency_weight: float = DEFAULT_LATENCY_WEIGHT,
+        cost_weight: float = DEFAULT_COST_WEIGHT,
+        latency_ref_ms: float = DEFAULT_LATENCY_REF_MS,
+        token_cost_ref: float = DEFAULT_TOKEN_COST_REF,
+    ) -> None:
+        for name, value in (
+            ("success_weight", success_weight),
+            ("failure_penalty", failure_penalty),
+            ("quality_weight", quality_weight),
+            ("latency_weight", latency_weight),
+            ("cost_weight", cost_weight),
+        ):
+            if value < 0:
+                raise ConfigError(f"{name} must be >= 0, got {value}")
+        if latency_ref_ms <= 0:
+            raise ConfigError(f"latency_ref_ms must be > 0, got {latency_ref_ms}")
+        if token_cost_ref <= 0:
+            raise ConfigError(f"token_cost_ref must be > 0, got {token_cost_ref}")
+        if isinstance(feedback, Mapping):
+            self._feedback: dict[str, ExecutionFeedback] = dict(feedback)
+        else:
+            self._feedback = aggregate_feedback(feedback)
+        self._success_weight = success_weight
+        self._failure_penalty = failure_penalty
+        self._quality_weight = quality_weight
+        self._latency_weight = latency_weight
+        self._cost_weight = cost_weight
+        self._latency_ref_ms = latency_ref_ms
+        self._token_cost_ref = token_cost_ref
+
+    def _delta(self, feedback: ExecutionFeedback) -> float:
+        """Compute the bounded score delta for one feedback record."""
+        delta = self._success_weight if feedback.success else -self._failure_penalty
+        if feedback.quality_score is not None:
+            delta += self._quality_weight * (2.0 * _clamp01(feedback.quality_score) - 1.0)
+        if self._latency_weight > 0 and feedback.latency_ms is not None:
+            delta -= self._latency_weight * (feedback.latency_ms / self._latency_ref_ms)
+        if self._cost_weight > 0 and feedback.token_cost is not None:
+            delta -= self._cost_weight * (feedback.token_cost / self._token_cost_ref)
+        return delta
+
+    def adjust(self, query: str, scored: list[tuple[str, float]]) -> list[tuple[str, float]]:
+        """Apply feedback deltas to *scored* and re-sort deterministically.
+
+        Args:
+            query: The routing query (unused by this provider; part of the
+                :class:`~contextweaver.protocols.RoutingScoreProvider`
+                contract so query-aware providers can use it).
+            scored: ``(item_id, base_score)`` pairs.
+
+        Returns:
+            Adjusted ``(item_id, score)`` pairs sorted by ``(-score, id)``.
+        """
+        adjusted: list[tuple[str, float]] = []
+        for item_id, score in scored:
+            feedback = self._feedback.get(item_id)
+            new_score = score if feedback is None else score + self._delta(feedback)
+            adjusted.append((item_id, new_score))
+        return _resort(adjusted)
+
+
+__all__ = [
+    "DEFAULT_COST_WEIGHT",
+    "DEFAULT_FAILURE_PENALTY",
+    "DEFAULT_LATENCY_REF_MS",
+    "DEFAULT_LATENCY_WEIGHT",
+    "DEFAULT_QUALITY_WEIGHT",
+    "DEFAULT_SUCCESS_WEIGHT",
+    "DEFAULT_TOKEN_COST_REF",
+    "DeterministicScoreProvider",
+    "ExecutionFeedback",
+    "FeedbackAwareScoreProvider",
+    "aggregate_feedback",
+]

--- a/src/contextweaver/routing/feedback.py
+++ b/src/contextweaver/routing/feedback.py
@@ -110,7 +110,7 @@ class ExecutionFeedback:
             item_id=data["item_id"],
             success=bool(data.get("success", True)),
             latency_ms=float(raw_latency) if raw_latency is not None else None,
-            token_cost=int(raw_cost) if raw_cost is not None else None,
+            token_cost=round(float(raw_cost)) if raw_cost is not None else None,
             quality_score=float(raw_quality) if raw_quality is not None else None,
             timestamp=timestamp,
             metadata=dict(data.get("metadata", {})),

--- a/src/contextweaver/routing/router.py
+++ b/src/contextweaver/routing/router.py
@@ -27,7 +27,7 @@ from contextweaver._utils import BM25Scorer, FuzzyScorer, TfIdfScorer
 from contextweaver.envelope import RoutingDecision
 from contextweaver.exceptions import ConfigError, RouteError
 from contextweaver.profiles import RoutingConfig
-from contextweaver.protocols import EmbeddingBackend, Retriever
+from contextweaver.protocols import EmbeddingBackend, Retriever, RoutingScoreProvider
 from contextweaver.routing.cards import make_choice_cards
 from contextweaver.routing.explanation import explain_route, explain_route_dict
 from contextweaver.routing.filters import (
@@ -430,6 +430,15 @@ class Router:
             not called by :meth:`route` itself — cards are produced
             externally by :meth:`RouteResult.to_routing_decision`.
             Issue #56.
+        score_provider: Keyword-only.  Optional
+            :class:`~contextweaver.protocols.RoutingScoreProvider`
+            (issue #318).  When supplied, it adjusts the ranked
+            ``(item_id, score)`` pairs after navigation, reranking, and
+            history adjustment — typically folding in historical execution
+            feedback via
+            :class:`~contextweaver.routing.feedback.FeedbackAwareScoreProvider`.
+            ``None`` (default) keeps routing purely deterministic and is
+            byte-equivalent to pre-#318 behaviour.
 
     Raises:
         ConfigError: If *confidence_gap* is outside ``[0.0, 1.0]`` or
@@ -453,6 +462,7 @@ class Router:
         engine_registry: EngineRegistry | None = None,
         embedding_backend: EmbeddingBackend | None = None,
         pipeline: RoutingPipeline | None = None,
+        score_provider: RoutingScoreProvider | None = None,
     ) -> None:
         if routing_config is not None:
             beam_width = routing_config.beam_width
@@ -500,6 +510,7 @@ class Router:
         else:
             self._retriever = self._engine_registry.resolve("retriever")
             self._retriever_engine_name = self._engine_registry.default_for("retriever") or "tfidf"
+        self._score_provider = score_provider
         self._indexed = False
         self._doc_id_to_idx: dict[str, int] = {}
         self._pipeline = self._build_pipeline(pipeline)
@@ -681,6 +692,20 @@ class Router:
                 result_similarity=result_similarity,
             )
             all_sorted = [(iid, (score, id_to_path[iid])) for iid, score in adjusted]
+
+        # Feedback-aware scoring stage (issue #318): apply the optional
+        # score provider last so it has the final word over the ranking.
+        # ``None`` (default) leaves ``all_sorted`` untouched, keeping routing
+        # purely deterministic and byte-equivalent to pre-#318 behaviour.
+        if self._score_provider is not None and all_sorted:
+            id_to_path = {iid: path for iid, (_, path) in all_sorted}
+            provider_input = [(iid, score) for iid, (score, _) in all_sorted]
+            provider_output = self._score_provider.adjust(scoring_query, provider_input)
+            all_sorted = [
+                (iid, (score, id_to_path[iid]))
+                for iid, score in provider_output
+                if iid in id_to_path
+            ]
         top = all_sorted[: self._top_k]
 
         # Ambiguity reads from the untrimmed sorted view so that callers
@@ -705,6 +730,8 @@ class Router:
         trace.is_ambiguous = is_ambiguous
         trace.extra["context_hints"] = list(applied_hints)
         trace.extra["context_boost_applied"] = boost_applied
+        if self._score_provider is not None:
+            trace.extra["score_provider"] = type(self._score_provider).__name__
         if history_adjustments:
             trace.extra["history_adjustments"] = dict(history_adjustments)
         top_items = [active_items[iid] for iid, _ in top if iid in active_items]

--- a/src/contextweaver/routing/router.py
+++ b/src/contextweaver/routing/router.py
@@ -701,11 +701,20 @@ class Router:
             id_to_path = {iid: path for iid, (_, path) in all_sorted}
             provider_input = [(iid, score) for iid, (score, _) in all_sorted]
             provider_output = self._score_provider.adjust(scoring_query, provider_input)
-            all_sorted = [
-                (iid, (score, id_to_path[iid]))
-                for iid, score in provider_output
-                if iid in id_to_path
-            ]
+            # Defend the router's invariants against buggy custom providers:
+            # the output must carry exactly the input candidate ids — no
+            # additions, drops, or duplicates — or downstream slicing/ranking
+            # silently corrupts the result.
+            if sorted(iid for iid, _ in provider_output) != sorted(id_to_path):
+                raise RouteError(
+                    f"{type(self._score_provider).__name__}.adjust must return exactly the "
+                    "input candidate ids (no additions, drops, or duplicates)."
+                )
+            # Re-impose the canonical (-score, id) ordering regardless of how
+            # the provider ordered its output, so the determinism guarantee
+            # holds even if a provider forgets to re-sort.
+            reordered = sorted(provider_output, key=lambda pair: (-pair[1], pair[0]))
+            all_sorted = [(iid, (score, id_to_path[iid])) for iid, score in reordered]
         top = all_sorted[: self._top_k]
 
         # Ambiguity reads from the untrimmed sorted view so that callers

--- a/src/contextweaver/types.py
+++ b/src/contextweaver/types.py
@@ -58,10 +58,15 @@ class Phase(str, Enum):
 
 @dataclass
 class SelectableItem:
-    """A unified representation of a tool, agent, skill, or internal function.
+    """A unified representation of a tool, agent, skill, flow, or internal function.
 
     This is the single vocabulary the Routing Engine operates on.  Use the
     :data:`ToolCard` alias when you want to emphasise the tool-card framing.
+
+    ``kind="flow"`` denotes a multi-step capability executed by an external
+    runtime (e.g. a ChainWeaver flow imported via
+    :mod:`contextweaver.adapters.chainweaver`); contextweaver routes to it
+    like any other candidate but never executes it.
 
     The optional ``depends_on`` / ``provides`` / ``requires`` fields (issue
     #27 Phase 2) carry tool-dependency metadata used by history-aware
@@ -70,7 +75,7 @@ class SelectableItem:
     """
 
     id: str
-    kind: Literal["tool", "agent", "skill", "internal"]
+    kind: Literal["tool", "agent", "skill", "internal", "flow"]
     name: str
     description: str
     tags: list[str] = field(default_factory=list)

--- a/tests/test_adapters_chainweaver.py
+++ b/tests/test_adapters_chainweaver.py
@@ -117,6 +117,17 @@ def test_invalid_flow_raises(bad: dict[str, object]) -> None:
         chainweaver_flow_to_selectable(bad)
 
 
+def test_non_dict_flow_raises_catalog_error() -> None:
+    # A malformed export element must raise CatalogError, not AttributeError.
+    with pytest.raises(CatalogError):
+        chainweaver_flow_to_selectable("not a dict")  # type: ignore[arg-type]
+
+
+def test_flows_to_catalog_with_non_dict_element_raises_catalog_error() -> None:
+    with pytest.raises(CatalogError):
+        chainweaver_flows_to_catalog([_flow(), "oops"])  # type: ignore[list-item]
+
+
 # ---------------------------------------------------------------------------
 # Catalog / export loading
 # ---------------------------------------------------------------------------

--- a/tests/test_adapters_chainweaver.py
+++ b/tests/test_adapters_chainweaver.py
@@ -1,0 +1,171 @@
+"""Tests for contextweaver.adapters.chainweaver (issue #334)."""
+
+from __future__ import annotations
+
+import pytest
+
+from contextweaver.adapters.chainweaver import (
+    FLOW_TAG,
+    chainweaver_flow_to_selectable,
+    chainweaver_flows_to_catalog,
+    load_chainweaver_export,
+)
+from contextweaver.exceptions import CatalogError
+from contextweaver.routing.router import Router
+from contextweaver.routing.tree import TreeBuilder
+from contextweaver.types import SelectableItem
+
+
+def _flow(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "id": "customer_summary_flow",
+        "name": "Summarize customer history",
+        "description": "Fetch and summarise a customer's recent activity.",
+        "version": "1.2.0",
+        "input_schema": {"type": "object", "properties": {"customer_id": {"type": "string"}}},
+        "output_schema": {"type": "object", "properties": {"summary": {"type": "string"}}},
+        "tags": ["customer", "summary"],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Single-flow conversion
+# ---------------------------------------------------------------------------
+
+
+def test_flow_to_selectable_preserves_core_fields() -> None:
+    item = chainweaver_flow_to_selectable(_flow())
+    assert isinstance(item, SelectableItem)
+    assert item.id == "chainweaver:customer_summary_flow"
+    assert item.kind == "flow"
+    assert item.name == "Summarize customer history"
+    assert item.description.startswith("Fetch and summarise")
+    assert item.namespace == "chainweaver"
+
+
+def test_flow_to_selectable_preserves_schemas() -> None:
+    item = chainweaver_flow_to_selectable(_flow())
+    assert item.args_schema["properties"]["customer_id"]["type"] == "string"
+    assert item.output_schema is not None
+    assert item.output_schema["properties"]["summary"]["type"] == "string"
+
+
+def test_flow_to_selectable_stamps_metadata() -> None:
+    item = chainweaver_flow_to_selectable(_flow())
+    assert item.metadata["runtime"] == "chainweaver"
+    assert item.metadata["chainweaver_flow_id"] == "customer_summary_flow"
+    assert item.metadata["chainweaver_flow_version"] == "1.2.0"
+
+
+def test_flow_to_selectable_always_tagged_flow() -> None:
+    item = chainweaver_flow_to_selectable(_flow(tags=[]))
+    assert FLOW_TAG in item.tags
+
+
+def test_flow_to_selectable_does_not_mutate_export() -> None:
+    export = _flow()
+    chainweaver_flow_to_selectable(export)
+    # args_schema is deep-copied, so mutating the item must not touch the export.
+    item = chainweaver_flow_to_selectable(export)
+    item.args_schema["properties"]["injected"] = {"type": "string"}
+    assert "injected" not in export["input_schema"]  # type: ignore[index]
+
+
+def test_flow_id_alias_and_inputs_outputs_aliases() -> None:
+    item = chainweaver_flow_to_selectable(
+        {
+            "flow_id": "f1",
+            "name": "Flow One",
+            "description": "Alias-keyed flow.",
+            "inputs": {"type": "object"},
+            "outputs": {"type": "object"},
+        }
+    )
+    assert item.id == "chainweaver:f1"
+    assert item.args_schema == {"type": "object"}
+    assert item.output_schema == {"type": "object"}
+
+
+def test_namespace_override() -> None:
+    item = chainweaver_flow_to_selectable(_flow(), namespace="billing")
+    assert item.namespace == "billing"
+    # The id keeps the canonical chainweaver: prefix regardless of namespace.
+    assert item.id == "chainweaver:customer_summary_flow"
+
+
+def test_missing_output_schema_is_none() -> None:
+    item = chainweaver_flow_to_selectable(
+        {"id": "f", "name": "F", "description": "No output schema."}
+    )
+    assert item.output_schema is None
+    assert item.args_schema == {}
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"name": "x", "description": "y"},  # missing id
+        {"id": "f", "description": "y"},  # missing name
+        {"id": "f", "name": "x"},  # missing description
+        {"id": "", "name": "x", "description": "y"},  # empty id
+    ],
+)
+def test_invalid_flow_raises(bad: dict[str, object]) -> None:
+    with pytest.raises(CatalogError):
+        chainweaver_flow_to_selectable(bad)
+
+
+# ---------------------------------------------------------------------------
+# Catalog / export loading
+# ---------------------------------------------------------------------------
+
+
+def test_flows_to_catalog_registers_all() -> None:
+    catalog = chainweaver_flows_to_catalog(
+        [_flow(), _flow(id="refund_flow", name="Refund", description="Issue a refund.")]
+    )
+    ids = {it.id for it in catalog.all()}
+    assert ids == {"chainweaver:customer_summary_flow", "chainweaver:refund_flow"}
+
+
+def test_load_export_accepts_list() -> None:
+    catalog = load_chainweaver_export([_flow()])
+    assert len(catalog.all()) == 1
+
+
+def test_load_export_accepts_flows_dict() -> None:
+    catalog = load_chainweaver_export({"flows": [_flow()]})
+    assert len(catalog.all()) == 1
+
+
+def test_load_export_rejects_dict_without_flows() -> None:
+    with pytest.raises(CatalogError):
+        load_chainweaver_export({"not_flows": []})
+
+
+def test_load_export_rejects_bad_type() -> None:
+    with pytest.raises(CatalogError):
+        load_chainweaver_export("nope")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Routing integration: a flow is routable and renders to a flow card
+# ---------------------------------------------------------------------------
+
+
+def test_imported_flow_is_routable_and_renders_flow_card() -> None:
+    items = [
+        SelectableItem(
+            id="t1", kind="tool", name="lookup", description="Look up a customer record"
+        ),
+        chainweaver_flow_to_selectable(_flow()),
+    ]
+    graph = TreeBuilder(max_children=20).build(items)
+    router = Router(graph, items=items, top_k=20)
+    result = router.route("summarize customer history")
+    assert "chainweaver:customer_summary_flow" in result.candidate_ids
+    decision = result.to_routing_decision()
+    flow_cards = [c for c in decision.choice_cards if c.kind == "flow"]
+    assert any(c.id == "chainweaver:customer_summary_flow" for c in flow_cards)

--- a/tests/test_architectures_contextweaver_to_chainweaver.py
+++ b/tests/test_architectures_contextweaver_to_chainweaver.py
@@ -1,0 +1,74 @@
+"""Smoke test for the contextweaver -> ChainWeaver reference architecture (#353).
+
+The architecture is exercised by ``make example`` via the ``architectures``
+umbrella target. This unit test pins the deterministic invariants of the
+route -> execute -> ingest seam so regressions in flow import (#334), routing
+to a ``kind="flow"`` candidate, the firewall, or the weaver-spec contract
+mapping (#320) surface immediately.
+
+The run is deterministic and offline (the ChainWeaver runtime is stubbed), so
+we assert specific outcomes rather than just "ran without exception".
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_MAIN_PATH = _REPO_ROOT / "examples" / "architectures" / "contextweaver_to_chainweaver" / "main.py"
+_spec = importlib.util.spec_from_file_location("cw_to_chainweaver_main", _MAIN_PATH)
+assert _spec is not None and _spec.loader is not None
+cw_to_chainweaver = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cw_to_chainweaver)
+
+
+@pytest.fixture
+def run_output() -> str:
+    """Run ``main()`` once and capture stdout for assertions."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        cw_to_chainweaver.main()
+    return buf.getvalue()
+
+
+def test_catalog_mixes_tools_and_flows(run_output: str) -> None:
+    assert "Loaded catalog: 5 items (2 ChainWeaver flows + 3 tools)" in run_output
+
+
+def test_routes_to_a_flow(run_output: str) -> None:
+    """The customer-history query must route to the ChainWeaver flow, not a tool."""
+    assert "selected:  chainweaver:customer_summary_flow  (kind='flow')" in run_output
+    assert "routed to a ChainWeaver flow: True" in run_output
+
+
+def test_advisory_candidate_is_a_flow(run_output: str) -> None:
+    assert '"candidate_type": "flow"' in run_output
+    assert '"advisory": true' in run_output
+    assert '"runtime_flow_id": "customer_summary_flow"' in run_output
+
+
+def test_weaver_spec_contract_mapping_runs(run_output: str) -> None:
+    """The [weaver-spec] extra is in the dev env, so the mapping must succeed."""
+    assert "weaver-spec RoutingDecision id: rd-" in run_output
+    assert "weaver-spec Frame id: frame-cust-42" in run_output
+    assert "weaver-spec mapped:    decision=True frame=True" in run_output
+
+
+def test_firewall_fires_on_flow_result(run_output: str) -> None:
+    assert "firewall: 4,002 chars ->" in run_output
+    assert "char summary" in run_output
+    assert "firewall fired:        True" in run_output
+    assert "artifacts kept:        1" in run_output
+
+
+def test_stub_runtime_is_deterministic() -> None:
+    runtime = cw_to_chainweaver._StubChainWeaverRuntime()
+    first = runtime.execute("customer_summary_flow", {"customer_id": "cust-42"})
+    second = runtime.execute("customer_summary_flow", {"customer_id": "cust-42"})
+    assert first == second
+    assert "cust-42" in first

--- a/tests/test_routing_feedback.py
+++ b/tests/test_routing_feedback.py
@@ -63,6 +63,13 @@ def test_execution_feedback_round_trip_minimal() -> None:
     assert restored.timestamp is None
 
 
+def test_execution_feedback_from_dict_rounds_float_token_cost() -> None:
+    # A malformed payload carrying a float token_cost is rounded (matching
+    # aggregate_feedback) rather than silently truncated toward zero.
+    restored = ExecutionFeedback.from_dict({"item_id": "db_read", "token_cost": 100.7})
+    assert restored.token_cost == 101
+
+
 # ------------------------------------------------------------------
 # aggregate_feedback
 # ------------------------------------------------------------------
@@ -108,6 +115,17 @@ def test_aggregate_feedback_independent_of_order() -> None:
         ExecutionFeedback("a", success=True, latency_ms=30),
     ]
     assert aggregate_feedback(entries) == aggregate_feedback(list(reversed(entries)))
+
+
+def test_aggregate_feedback_tie_counts_as_success() -> None:
+    # A 50/50 success_rate is treated as success (rule: success_rate >= 0.5).
+    entries = [
+        ExecutionFeedback("x", success=True),
+        ExecutionFeedback("x", success=False),
+    ]
+    record = aggregate_feedback(entries)["x"]
+    assert record.success is True
+    assert record.metadata["success_rate"] == pytest.approx(0.5)
 
 
 # ------------------------------------------------------------------

--- a/tests/test_routing_feedback.py
+++ b/tests/test_routing_feedback.py
@@ -1,0 +1,252 @@
+"""Tests for contextweaver.routing.feedback (issue #318)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from contextweaver.exceptions import ConfigError
+from contextweaver.routing.feedback import (
+    DeterministicScoreProvider,
+    ExecutionFeedback,
+    FeedbackAwareScoreProvider,
+    aggregate_feedback,
+)
+from contextweaver.routing.router import Router
+from contextweaver.routing.tree import TreeBuilder
+from contextweaver.types import SelectableItem
+
+
+def _item(iid: str, name: str, description: str, tags: list[str] | None = None) -> SelectableItem:
+    return SelectableItem(id=iid, kind="tool", name=name, description=description, tags=tags or [])
+
+
+def _catalog() -> list[SelectableItem]:
+    return [
+        _item("db_read", "read_db", "Read rows from the database", tags=["data"]),
+        _item("db_write", "write_db", "Write rows to the database", tags=["data"]),
+        _item("send_email", "send_email", "Send an email notification", tags=["comm"]),
+    ]
+
+
+def _build_router(**kwargs: object) -> Router:
+    items = _catalog()
+    graph = TreeBuilder(max_children=20).build(items)
+    return Router(graph, items=items, top_k=20, **kwargs)  # type: ignore[arg-type]
+
+
+# ------------------------------------------------------------------
+# ExecutionFeedback serialisation
+# ------------------------------------------------------------------
+
+
+def test_execution_feedback_round_trip_full() -> None:
+    fb = ExecutionFeedback(
+        item_id="db_read",
+        success=False,
+        latency_ms=120.5,
+        token_cost=42,
+        quality_score=0.8,
+        timestamp=datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        metadata={"run": "abc"},
+    )
+    restored = ExecutionFeedback.from_dict(fb.to_dict())
+    assert restored == fb
+
+
+def test_execution_feedback_round_trip_minimal() -> None:
+    fb = ExecutionFeedback(item_id="db_read")
+    restored = ExecutionFeedback.from_dict(fb.to_dict())
+    assert restored == fb
+    assert restored.success is True
+    assert restored.timestamp is None
+
+
+# ------------------------------------------------------------------
+# aggregate_feedback
+# ------------------------------------------------------------------
+
+
+def test_aggregate_feedback_means_and_majority() -> None:
+    entries = [
+        ExecutionFeedback(
+            "db_read", success=True, latency_ms=100, token_cost=10, quality_score=1.0
+        ),
+        ExecutionFeedback(
+            "db_read", success=True, latency_ms=300, token_cost=30, quality_score=0.0
+        ),
+        ExecutionFeedback(
+            "db_read", success=False, latency_ms=200, token_cost=20, quality_score=0.5
+        ),
+    ]
+    agg = aggregate_feedback(entries)
+    assert set(agg) == {"db_read"}
+    record = agg["db_read"]
+    # success_rate = 2/3 >= 0.5 -> success True
+    assert record.success is True
+    assert record.latency_ms == pytest.approx(200.0)
+    assert record.token_cost == 20
+    assert record.quality_score == pytest.approx(0.5)
+    assert record.metadata["sample_count"] == 3
+    assert record.metadata["success_rate"] == pytest.approx(2 / 3)
+
+
+def test_aggregate_feedback_majority_failure() -> None:
+    entries = [
+        ExecutionFeedback("x", success=False),
+        ExecutionFeedback("x", success=False),
+        ExecutionFeedback("x", success=True),
+    ]
+    assert aggregate_feedback(entries)["x"].success is False
+
+
+def test_aggregate_feedback_independent_of_order() -> None:
+    entries = [
+        ExecutionFeedback("a", success=True, latency_ms=10),
+        ExecutionFeedback("b", success=False, latency_ms=20),
+        ExecutionFeedback("a", success=True, latency_ms=30),
+    ]
+    assert aggregate_feedback(entries) == aggregate_feedback(list(reversed(entries)))
+
+
+# ------------------------------------------------------------------
+# DeterministicScoreProvider
+# ------------------------------------------------------------------
+
+
+def test_deterministic_provider_is_identity_resort() -> None:
+    provider = DeterministicScoreProvider()
+    scored = [("b", 0.5), ("a", 0.5), ("c", 0.9)]
+    out = provider.adjust("q", scored)
+    # Scores unchanged; ties broken by ascending id.
+    assert out == [("c", 0.9), ("a", 0.5), ("b", 0.5)]
+
+
+# ------------------------------------------------------------------
+# FeedbackAwareScoreProvider
+# ------------------------------------------------------------------
+
+
+def test_feedback_success_boosts_failure_penalises() -> None:
+    provider = FeedbackAwareScoreProvider(
+        {
+            "good": ExecutionFeedback("good", success=True),
+            "bad": ExecutionFeedback("bad", success=False),
+        }
+    )
+    out = dict(provider.adjust("q", [("good", 0.5), ("bad", 0.5), ("none", 0.5)]))
+    assert out["good"] == pytest.approx(0.6)  # +success_weight 0.1
+    assert out["bad"] == pytest.approx(0.3)  # -failure_penalty 0.2
+    assert out["none"] == pytest.approx(0.5)  # no feedback -> unchanged
+
+
+def test_feedback_quality_adjusts_within_bounds() -> None:
+    provider = FeedbackAwareScoreProvider(
+        {
+            "hi": ExecutionFeedback("hi", success=True, quality_score=1.0),
+            "lo": ExecutionFeedback("lo", success=True, quality_score=0.0),
+        },
+        success_weight=0.0,  # isolate the quality term
+        quality_weight=0.1,
+    )
+    out = dict(provider.adjust("q", [("hi", 0.5), ("lo", 0.5)]))
+    assert out["hi"] == pytest.approx(0.6)  # +0.1 * (2*1 - 1)
+    assert out["lo"] == pytest.approx(0.4)  # +0.1 * (2*0 - 1)
+
+
+def test_feedback_reorders_ranking() -> None:
+    # Equal base scores; feedback should push the successful item above the failed one.
+    provider = FeedbackAwareScoreProvider(
+        {
+            "a": ExecutionFeedback("a", success=False),
+            "b": ExecutionFeedback("b", success=True),
+        }
+    )
+    out = provider.adjust("q", [("a", 0.5), ("b", 0.5)])
+    assert [iid for iid, _ in out] == ["b", "a"]
+
+
+def test_feedback_deterministic_tie_break_by_id() -> None:
+    # Identical feedback on tied scores must break by ascending id, not input order.
+    provider = FeedbackAwareScoreProvider(
+        {
+            "b": ExecutionFeedback("b", success=True),
+            "a": ExecutionFeedback("a", success=True),
+        }
+    )
+    out = provider.adjust("q", [("b", 0.5), ("a", 0.5)])
+    assert [iid for iid, _ in out] == ["a", "b"]
+
+
+def test_feedback_latency_and_cost_penalties_opt_in() -> None:
+    fb = {"x": ExecutionFeedback("x", success=True, latency_ms=1000, token_cost=1000)}
+    # Default weights leave latency/cost off.
+    default = dict(FeedbackAwareScoreProvider(fb).adjust("q", [("x", 0.5)]))
+    assert default["x"] == pytest.approx(0.6)
+    # Enabling the penalties subtracts a full reference unit each.
+    penalised = dict(
+        FeedbackAwareScoreProvider(fb, latency_weight=0.05, cost_weight=0.05).adjust(
+            "q", [("x", 0.5)]
+        )
+    )
+    assert penalised["x"] == pytest.approx(0.6 - 0.05 - 0.05)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"success_weight": -0.1},
+        {"failure_penalty": -0.1},
+        {"quality_weight": -0.1},
+        {"latency_weight": -0.1},
+        {"cost_weight": -0.1},
+        {"latency_ref_ms": 0.0},
+        {"token_cost_ref": 0.0},
+    ],
+)
+def test_feedback_invalid_config_raises(kwargs: dict[str, float]) -> None:
+    with pytest.raises(ConfigError):
+        FeedbackAwareScoreProvider({}, **kwargs)
+
+
+def test_feedback_provider_accepts_history_sequence() -> None:
+    # A flat history list is aggregated internally.
+    history = [
+        ExecutionFeedback("a", success=True),
+        ExecutionFeedback("a", success=True),
+        ExecutionFeedback("a", success=False),
+    ]
+    provider = FeedbackAwareScoreProvider(history)
+    out = dict(provider.adjust("q", [("a", 0.5)]))
+    assert out["a"] == pytest.approx(0.6)  # success_rate 2/3 -> success True
+
+
+# ------------------------------------------------------------------
+# Router integration
+# ------------------------------------------------------------------
+
+
+def test_router_default_unchanged_without_provider() -> None:
+    baseline = _build_router().route("read rows from the database")
+    explicit_none = _build_router(score_provider=None).route("read rows from the database")
+    assert explicit_none.candidate_ids == baseline.candidate_ids
+    assert explicit_none.scores == pytest.approx(baseline.scores)
+
+
+def test_router_deterministic_provider_matches_default() -> None:
+    baseline = _build_router().route("send an email")
+    with_det = _build_router(score_provider=DeterministicScoreProvider()).route("send an email")
+    assert with_det.candidate_ids == baseline.candidate_ids
+    assert with_det.trace.extra.get("score_provider") == "DeterministicScoreProvider"
+
+
+def test_router_feedback_provider_promotes_successful_item() -> None:
+    # Heavily penalise db_read so it sinks below db_write for a "data" query.
+    provider = FeedbackAwareScoreProvider(
+        {"db_read": ExecutionFeedback("db_read", success=False)},
+        failure_penalty=10.0,
+    )
+    routed = _build_router(score_provider=provider).route("database rows data")
+    assert routed.candidate_ids[-1] == "db_read"
+    assert routed.trace.extra.get("score_provider") == "FeedbackAwareScoreProvider"

--- a/tests/test_routing_feedback.py
+++ b/tests/test_routing_feedback.py
@@ -241,6 +241,81 @@ def test_router_deterministic_provider_matches_default() -> None:
     assert with_det.trace.extra.get("score_provider") == "DeterministicScoreProvider"
 
 
+def test_execution_feedback_from_dict_coerces_naive_timestamp_to_utc() -> None:
+    # A naive ISO string (no offset) must restore as tz-aware UTC.
+    restored = ExecutionFeedback.from_dict({"item_id": "x", "timestamp": "2026-01-02T03:04:05"})
+    assert restored.timestamp is not None
+    assert restored.timestamp.tzinfo is timezone.utc
+
+
+def test_feedback_latency_ratio_is_clamped() -> None:
+    # latency far above the reference must not penalise beyond the weight.
+    provider = FeedbackAwareScoreProvider(
+        {"x": ExecutionFeedback("x", success=True, latency_ms=10_000)},
+        success_weight=0.0,
+        latency_weight=0.1,
+        latency_ref_ms=1000.0,  # ratio would be 10.0 unclamped
+    )
+    out = dict(provider.adjust("q", [("x", 0.5)]))
+    assert out["x"] == pytest.approx(0.5 - 0.1)  # clamped to exactly one weight
+
+
+def test_feedback_cost_ratio_is_clamped() -> None:
+    provider = FeedbackAwareScoreProvider(
+        {"x": ExecutionFeedback("x", success=True, token_cost=50_000)},
+        success_weight=0.0,
+        cost_weight=0.1,
+        token_cost_ref=1000,  # ratio would be 50.0 unclamped
+    )
+    out = dict(provider.adjust("q", [("x", 0.5)]))
+    assert out["x"] == pytest.approx(0.5 - 0.1)
+
+
+class _BadProvider:
+    """A provider that violates the id-preservation contract."""
+
+    def __init__(self, output: list[tuple[str, float]]) -> None:
+        self._output = output
+
+    def adjust(self, query: str, scored: list[tuple[str, float]]) -> list[tuple[str, float]]:
+        return self._output
+
+
+class _UnsortedProvider:
+    """A provider that returns the right ids+scores but in scrambled order."""
+
+    def adjust(self, query: str, scored: list[tuple[str, float]]) -> list[tuple[str, float]]:
+        return list(reversed(scored))  # deliberately not re-sorted
+
+
+def test_router_rejects_provider_that_drops_ids() -> None:
+    from contextweaver.exceptions import RouteError
+
+    bad = _BadProvider([("db_read", 0.9)])  # drops the other candidates
+    with pytest.raises(RouteError):
+        _build_router(score_provider=bad).route("database rows data")
+
+
+def test_router_rejects_provider_that_duplicates_ids() -> None:
+    from contextweaver.exceptions import RouteError
+
+    # Capture the real candidate ids, then return a duplicate-laden output.
+    real = _build_router().route("database rows data").candidate_ids
+    dup = _BadProvider([(real[0], 0.9)] * len(real))
+    with pytest.raises(RouteError):
+        _build_router(score_provider=dup).route("database rows data")
+
+
+def test_router_reimposes_canonical_order_when_provider_skips_resort() -> None:
+    # The provider returns the same scores in reversed order; the router must
+    # re-impose the canonical (-score, id) ordering, matching the no-provider
+    # baseline exactly.
+    baseline = _build_router().route("database rows data")
+    routed = _build_router(score_provider=_UnsortedProvider()).route("database rows data")
+    assert routed.candidate_ids == baseline.candidate_ids
+    assert routed.scores == pytest.approx(baseline.scores)
+
+
 def test_router_feedback_provider_promotes_successful_item() -> None:
     # Heavily penalise db_read so it sinks below db_write for a "data" query.
     provider = FeedbackAwareScoreProvider(


### PR DESCRIPTION
## Summary

Implements the "Weaver routing contracts + ChainWeaver routing interop" issue group as one coherent PR. contextweaver gains a feedback-aware scoring seam, can import ChainWeaver flows as routable catalog items, ships a runnable route → execute → ingest example, and documents the advisory routing-as-contract boundary.

Closes #318
Closes #334
Closes #353
Addresses #320 (docs-only — see scope note)

## Changes

**#318 — feedback-aware routing scores** (`src/contextweaver/routing/feedback.py`, `protocols.py`, `routing/router.py`)
- New `RoutingScoreProvider` protocol + `ExecutionFeedback` record, `DeterministicScoreProvider` (no-op default), `FeedbackAwareScoreProvider` (bounded, deterministic feedback deltas), and `aggregate_feedback`.
- Wired into `Router` via the optional `score_provider=` argument, applied as the final scoring stage. `None` (default) is byte-equivalent to prior behaviour; ties always break by id.

**#334 — ChainWeaver flow import** (`src/contextweaver/adapters/chainweaver.py`, `types.py`, `envelope.py`)
- `chainweaver_flow_to_selectable` / `chainweaver_flows_to_catalog` / `load_chainweaver_export` convert a flow export (plain data, no ChainWeaver install) into `SelectableItem`s, preserving name/description/input+output schemas and stamping flow id/version + runtime under `metadata`.
- Added `"flow"` as a first-class `SelectableItem`/`ChoiceCard` kind; regenerated the `catalog`/`choice_card` JSON Schemas.

**#353 — end-to-end example** (`examples/architectures/contextweaver_to_chainweaver/`)
- Route a mixed tool+flow catalog → map to a weaver-spec `RoutingDecision` → execute on a stubbed ChainWeaver runtime → ingest the result through the firewall as a `Frame`. No hard ChainWeaver dependency; weaver-spec mapping degrades gracefully without the extra. Registered in `make architectures` and pinned by a smoke test.

**#320 — docs** (`docs/weaver_spec_mapping.md`, `README.md`)
- Documents the advisory routing boundary, the host-side projection of a `RoutingDecision` into a neutral execution candidate, and when to route to a flow vs a tool.

## Why / scope decisions (Mode B)

Two decisions were confirmed with the maintainer before coding:

1. **`weaver_contracts` 0.6.0 defines neither `ExecutionCandidate` nor `ExecutionFeedback`.** Per maintainer direction, #320 is **docs-only** — no contextweaver `ExecutionCandidate` dataclass is introduced (that would mirror an unreleased spec type and risk divergence). #318's `ExecutionFeedback` ships as an explicitly **contextweaver-native** type, not a spec contract.
2. **#318 plugs in via an optional `Router` param with a deterministic default** (not a standalone helper), per the issue's "deterministic by default" non-goal.

Scope addition (documented per Mode B): a new `"flow"` selectable kind. It's required because #353 routes a flow → `ChoiceCard`, and `ChoiceCard.__post_init__` hard-validates `kind`. Blast radius is contained (two Literals + `CHOICE_CARD_KINDS` + regenerated schemas); the runtime `ItemKind` enum is unaffected.

## How verified

Full gate is green:
- `make test` — **1851 passed**, 12 skipped, 1 xfailed (incl. 22 new feedback, 18 new chainweaver, 6 new architecture tests)
- `make lint` / `ruff format --check` — clean (265 files)
- `make type` (mypy) — no issues in 108 files
- `make example` (runs the new architecture) / `make demo` — exit 0
- `make weaver-conformance` — 6/6 (flow cards round-trip cleanly)
- `make schemas-check` / `readme-version-check` / `scorecard-check` / `context-rot-check` / `llms-check` — all pass

Routing defaults are unchanged (`score_provider` defaults to `None`), so benchmark scorecards do not drift.

## Tradeoffs / risks

- **Cross-repo coupling:** the ChainWeaver flow-export shape is a documented neutral dict, not a fetched ChainWeaver schema (ChainWeaver is out of scope/network). The `id`/`flow_id` + `input_schema`/`inputs` aliases hedge against minor shape differences; confirm against a real export before relying on it.
- **`ExecutionCandidate` remains host-side only** until weaver-spec publishes the contract; the mapping is documented, not codified.

## Checklist

- [x] Tests added for every new/changed public function
- [x] `make ci` passes locally (fmt + lint + type + test + example + demo)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docstrings added for all new public APIs (Google-style)
- [x] Every modified module stays ≤ 300 lines (new modules: feedback.py, chainweaver.py)
- [x] Related issues linked above
- [x] Agent-facing docs updated (AGENTS.md module map, weaver_spec_mapping.md, regenerated llms-full.txt)

## Notes for reviewers

- The `"flow"` kind is the one change that touches a core type — see the scope note above for why it's required and contained.
- `ExecutionFeedback` deliberately makes no weaver-spec compliance claim (documented inline and in AGENTS.md), per the contract-type decision.

https://claude.ai/code/session_016bgBxQYoBbFF52z8vxNDSQ

---
_Generated by [Claude Code](https://claude.ai/code/session_016bgBxQYoBbFF52z8vxNDSQ)_