### PR TITLE
ci: enforce generated artifact drift checks (#389-#393)

### DIFF
--- a/.github/prompts/add-eval.prompt.md
+++ b/.github/prompts/add-eval.prompt.md
@@ -64,7 +64,8 @@ benchmark output.
    _Success: non-latency keys in `latest.json` are byte-identical to the
    committed file._
 
-7. **Run `make ci`.** All six targets (`fmt lint type test example demo`)
+7. **Run `make ci`.** All declared targets
+   (`fmt lint type test schemas-check example demo`)
    plus the `scorecard-check` CI step must pass.
    _Success: `make ci` exits 0; `python scripts/render_scorecard.py
    --check` exits 0._

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Fixes # <!-- issue number, if applicable -->
 ## Checklist
 
 - [ ] Tests added or updated for every new/changed public function
-- [ ] `make ci` passes locally (fmt + lint + type + test + example + demo)
+- [ ] `make ci` passes locally (fmt + lint + type + test + schemas-check + example + demo)
 - [ ] `CHANGELOG.md` updated under `## [Unreleased]`
 - [ ] Docstrings added for all new public APIs (Google-style)
 - [ ] Every modified module stays ≤ 300 lines (or a decomposition issue is linked above)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,12 @@ jobs:
       - name: Demo
         run: make demo
 
+      - name: "Recorded demo drift check (gating, issue #390)"
+        if: ${{ matrix.python-version == '3.12' }}
+        # The casts are deterministic and interpreter-independent, so one
+        # matrix cell is sufficient to enforce the committed artifacts.
+        run: python scripts/record_demo.py --check
+
       - name: Scorecard drift check (gating)
         # Runs before the benchmark step so it validates the committed pair
         # (benchmarks/results/latest.json + benchmarks/scorecard.md). The
@@ -70,11 +76,23 @@ jobs:
         # numbers, which would otherwise make the check non-portable.
         run: python scripts/render_scorecard.py --check
 
+      - name: "Gateway scorecard drift check (gating, issue #391)"
+        if: ${{ matrix.python-version == '3.12' }}
+        # Mirrors the main scorecard gate for the committed gateway benchmark
+        # JSON/Markdown pair without repeating identical work in every cell.
+        run: python scripts/render_gateway_scorecard.py --check
+
       - name: README version drift check (gating, issue #347)
         # Fails when a tracked README version reference (the "Current package
         # version" line or the comparison-table self-reference) lags the
         # version in pyproject.toml. Stdlib-only; no install required.
         run: python scripts/check_readme_version.py
+
+      - name: "LLMs drift check (gating, issue #389)"
+        if: ${{ matrix.python-version == '3.12' }}
+        # llms.txt and llms-full.txt are deterministic generated docs; checking
+        # one matrix cell avoids four identical full-document comparisons.
+        run: python scripts/gen_llms.py --check
 
       - name: Context-rot SVG drift check (gating, issue #349)
         # Re-renders docs/assets/context_rot.svg from the committed
@@ -101,6 +119,13 @@ jobs:
               -o ".weaver-schemas/${s}.schema.json"
           done
           python scripts/weaver_spec_conformance.py --schemas-dir .weaver-schemas
+
+      - name: "Smoke evaluation (non-gating, issue #392)"
+        if: ${{ matrix.python-version == '3.12' }}
+        continue-on-error: true
+        # Deterministic and credential-free by default. Keep this informational:
+        # it exercises the evaluation path continuously but is not a release gate.
+        run: python benchmarks/smoke_eval.py
 
       - name: Benchmark (informational, non-gating)
         continue-on-error: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,9 @@ make docs     # mkdocs build --clean (docs site)
 make docs-serve  # mkdocs serve (live preview)
 make benchmark        # run benchmark harness (non-gating; writes benchmarks/results/latest.json)
 make benchmark-matrix # benchmark + per-backend × per-size matrix (#208) and per-namespace breakdown (#209)
-make smoke-eval       # optional, non-gating smoke-evaluation over fixed fixtures (#331); deterministic, credential-free
+make gateway-scorecard-check  # verify gateway scorecard matches its committed JSON (gating CI; #391)
+make record-demos-check       # verify committed demo casts match current output (gating CI; #390)
+make smoke-eval       # non-gating CI smoke-evaluation over fixed fixtures (#331/#392); deterministic, credential-free
 make scorecard        # render benchmarks/scorecard.md from benchmarks/results/latest.json
 make scorecard-check  # verify scorecard.md is up to date (exits non-zero on drift)
 make schemas         # regenerate schemas/ + docs/schemas/v0/ (issue #225)
@@ -171,7 +173,7 @@ make context-rot       # render the context-rot demo: benchmarks/results/context
 make context-rot-check # verify context_rot.svg matches its committed JSON (gating in CI; exits non-zero on drift)
 make readme-version-check  # verify README version references match pyproject.toml (gating in CI; #347)
 make llms        # regenerate llms.txt and llms-full.txt from canonical docs
-make llms-check  # verify llms.txt and llms-full.txt are up to date (exits non-zero on drift)
+make llms-check  # verify llms.txt and llms-full.txt are up to date (gating in CI; #389)
 make weaver-conformance  # round-trip + JSON-Schema validate the weaver-spec adapter (CI gating, fetches schemas)
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ make test     # python -m pytest --cov=contextweaver --cov-report=term-missing -
 make example  # run all example scripts (includes architectures via the umbrella target)
 make architectures  # run reference architecture scripts under examples/architectures/
 make demo     # python -m contextweaver demo
-make ci       # fmt + lint + type + test + example + demo
+make ci       # fmt + lint + type + test + schemas-check + example + demo
 make docs     # mkdocs build --clean (docs site)
 make docs-serve  # mkdocs serve (live preview)
 make benchmark        # run benchmark harness (non-gating; writes benchmarks/results/latest.json)
@@ -256,7 +256,7 @@ See [docs/agent-context/invariants.md](docs/agent-context/invariants.md) for the
 ## Adding a Feature
 
 1. Identify the relevant module, modify it, add tests in `tests/test_<module>.py`.
-2. Run `make ci` to verify (all 6 targets must pass).
+2. Run `make ci` to verify (all declared targets must pass).
 3. Update `CHANGELOG.md` and add docstrings to new public APIs.
 4. Update agent-facing docs and examples if the pipeline or public API changed.
 5. **If the feature can move recall@k / drops / dedup / token counts**: follow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI now exercises every committed generated-artifact drift check
+  (#389–#393).** `llms.txt` / `llms-full.txt`, recorded demo casts, and the
+  gateway scorecard are gating checks on the Python 3.12 matrix cell; the
+  deterministic smoke evaluation also runs there as a non-gating signal.
+
 ## [0.14.0] – 2026-06-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ Run the full suite yourself:
 git clone https://github.com/dgenio/contextweaver.git
 cd contextweaver
 pip install -e ".[dev]"
-make ci  # fmt + lint + type + test + example + demo (all pass)
+make ci  # fmt + lint + type + test + schemas-check + example + demo (all pass)
 ```
 
 > Most agent libraries fail unpredictably when context exceeds token limits. contextweaver's
@@ -758,7 +758,7 @@ make type     # type-check (mypy)
 make test     # run tests (pytest)
 make example  # run all examples
 make demo     # run the built-in demo
-make ci       # all of the above
+make ci       # all validation targets, including schemas-check
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, and

--- a/docs/agent-context/lessons-learned.md
+++ b/docs/agent-context/lessons-learned.md
@@ -65,7 +65,8 @@ When a bad change is caught in review or causes a regression:
 
 ### 5. `make ci` composition drift
 
-**Mistake:** `AGENTS.md` described `make ci` as 4 targets when the Makefile runs 6.
+**Mistake:** `AGENTS.md` described `make ci` with a stale fixed target count and
+omitted a target that the Makefile runs.
 
 **Lesson:** Do not describe command composition from memory. Check the `Makefile` for ground truth.
 

--- a/docs/agent-context/review-checklist.md
+++ b/docs/agent-context/review-checklist.md
@@ -5,7 +5,7 @@ maintainer review (when reviewing PRs). Items are grouped by category.
 
 ## Validation
 
-- [ ] `make ci` passes (all 6 targets: fmt, lint, type, test, example, demo)
+- [ ] `make ci` passes (fmt, lint, type, test, schemas-check, example, demo)
 - [ ] No new warnings introduced
 
 ## Hard Rules

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -10,7 +10,7 @@ make test     # pytest --cov=contextweaver --cov-report=term-missing -q
 make example  # run all example scripts (includes architectures)
 make architectures  # run reference architecture scripts under examples/architectures/
 make demo     # python -m contextweaver demo
-make ci       # fmt + lint + type + test + example + demo  (6 targets)
+make ci       # fmt + lint + type + test + schemas-check + example + demo
 make docs     # mkdocs build --clean (docs site — not part of CI)
 make docs-serve  # mkdocs serve (live preview)
 make benchmark        # run benchmark harness (non-gating; writes benchmarks/results/latest.json)
@@ -37,7 +37,7 @@ make weaver-conformance  # round-trip + JSON-Schema validate the weaver-spec ada
 > `make smoke-eval` (#392) also runs in CI but remains non-gating.
 > (`make schemas-check` also gates, but it runs *inside* `make ci`.)
 
-`make ci` runs all six core targets in sequence. Run the additional gating checks
+`make ci` runs all declared targets in sequence. Run the additional gating checks
 listed above before opening a PR when the affected artifacts or integrations change.
 
 ## Command-Selection Rules
@@ -80,7 +80,7 @@ Pre-commit hooks run `ruff format`, `ruff check --fix`, and file hygiene checks 
 2. Modify only the targeted module.
 3. Update `protocols.py` if adding a new protocol.
 4. Add tests in `tests/test_<module>.py`.
-5. Run `make ci` — all six targets must pass.
+5. Run `make ci` — all declared targets must pass.
 6. Update `CHANGELOG.md` under `## [Unreleased]`.
 7. Add Google-style docstrings to any new public APIs.
 8. Update examples/demos if the feature is user-facing.
@@ -96,7 +96,7 @@ Pre-commit hooks run `ruff format`, `ruff check --fix`, and file hygiene checks 
 
 A change is complete when **all** of the following are true:
 
-- [ ] `make ci` passes (all 6 targets)
+- [ ] `make ci` passes (all declared targets)
 - [ ] `CHANGELOG.md` updated
 - [ ] Google-style docstrings on all new public APIs
 - [ ] Type hints on all new public functions and methods

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -22,17 +22,23 @@ make context-rot       # render context-rot demo JSON + docs/assets/context_rot.
 make context-rot-check # verify context_rot.svg matches its committed JSON (gating CI step; exits non-zero on drift)
 make readme-version-check  # verify README version references match pyproject.toml (gating CI step; #347)
 make llms        # regenerate llms.txt and llms-full.txt from canonical docs
-make llms-check  # verify llms.txt and llms-full.txt are up to date (exits non-zero on drift)
+make llms-check  # verify llms.txt and llms-full.txt are up to date (gating CI step; exits non-zero on drift)
+make gateway-scorecard-check  # verify gateway scorecard Markdown matches its committed JSON (gating CI step)
+make record-demos-check  # verify committed asciinema casts match demo output (gating CI step)
+make smoke-eval  # deterministic, credential-free smoke evaluation (non-gating CI step)
 make weaver-conformance  # round-trip + JSON-Schema validate the weaver-spec adapter
                          # (fetches schemas from raw.githubusercontent.com; CI runs it as a gate)
 ```
 
 > Gating CI steps beyond `make ci`: `make scorecard-check`,
 > `make readme-version-check` (#347), `make context-rot-check` (#349),
-> and `make weaver-conformance`. (`make schemas-check` also gates, but it
-> runs *inside* `make ci`.)
+> `make llms-check` (#389), `make record-demos-check` (#390),
+> `make gateway-scorecard-check` (#391), and `make weaver-conformance`.
+> `make smoke-eval` (#392) also runs in CI but remains non-gating.
+> (`make schemas-check` also gates, but it runs *inside* `make ci`.)
 
-`make ci` runs all six targets in sequence. It is the single validation gate.
+`make ci` runs all six core targets in sequence. Run the additional gating checks
+listed above before opening a PR when the affected artifacts or integrations change.
 
 ## Command-Selection Rules
 
@@ -45,10 +51,13 @@ make weaver-conformance  # round-trip + JSON-Schema validate the weaver-spec ada
 | Run all tests | `make test` |
 | Verify examples work | `make example` |
 | Interactive demo | `make demo` |
+| Verify recorded demo casts | `make record-demos-check` |
 | Build docs site | `make docs` |
 | Live docs preview | `make docs-serve` |
 | Run benchmark harness | `make benchmark` (non-gating; writes `benchmarks/results/latest.json`) |
 | Run full per-backend × per-size matrix | `make benchmark-matrix` (#208 + #209) |
+| Verify gateway benchmark scorecard | `make gateway-scorecard-check` |
+| Run deterministic smoke evaluation | `make smoke-eval` (non-gating) |
 | Run scoring-weight sweep | `make sweep-scoring` (#214; writes `benchmarks/sweep_scoring.md`) |
 | Add an eval for a feature | follow [`.github/prompts/add-eval.prompt.md`](../../.github/prompts/add-eval.prompt.md) (#216) |
 | Regenerate llms.txt / llms-full.txt | `make llms` (after editing canonical docs) |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -486,7 +486,7 @@ Run the full suite yourself:
 git clone https://github.com/dgenio/contextweaver.git
 cd contextweaver
 pip install -e ".[dev]"
-make ci  # fmt + lint + type + test + example + demo (all pass)
+make ci  # fmt + lint + type + test + schemas-check + example + demo (all pass)
 ```
 
 > Most agent libraries fail unpredictably when context exceeds token limits. contextweaver's
@@ -786,7 +786,7 @@ make type     # type-check (mypy)
 make test     # run tests (pytest)
 make example  # run all examples
 make demo     # run the built-in demo
-make ci       # all of the above
+make ci       # all validation targets, including schemas-check
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, and
@@ -2241,7 +2241,7 @@ make test     # pytest --cov=contextweaver --cov-report=term-missing -q
 make example  # run all example scripts (includes architectures)
 make architectures  # run reference architecture scripts under examples/architectures/
 make demo     # python -m contextweaver demo
-make ci       # fmt + lint + type + test + example + demo  (6 targets)
+make ci       # fmt + lint + type + test + schemas-check + example + demo
 make docs     # mkdocs build --clean (docs site — not part of CI)
 make docs-serve  # mkdocs serve (live preview)
 make benchmark        # run benchmark harness (non-gating; writes benchmarks/results/latest.json)
@@ -2268,7 +2268,7 @@ make weaver-conformance  # round-trip + JSON-Schema validate the weaver-spec ada
 > `make smoke-eval` (#392) also runs in CI but remains non-gating.
 > (`make schemas-check` also gates, but it runs *inside* `make ci`.)
 
-`make ci` runs all six core targets in sequence. Run the additional gating checks
+`make ci` runs all declared targets in sequence. Run the additional gating checks
 listed above before opening a PR when the affected artifacts or integrations change.
 
 ## Command-Selection Rules
@@ -2311,7 +2311,7 @@ Pre-commit hooks run `ruff format`, `ruff check --fix`, and file hygiene checks 
 2. Modify only the targeted module.
 3. Update `protocols.py` if adding a new protocol.
 4. Add tests in `tests/test_<module>.py`.
-5. Run `make ci` — all six targets must pass.
+5. Run `make ci` — all declared targets must pass.
 6. Update `CHANGELOG.md` under `## [Unreleased]`.
 7. Add Google-style docstrings to any new public APIs.
 8. Update examples/demos if the feature is user-facing.
@@ -2327,7 +2327,7 @@ Pre-commit hooks run `ruff format`, `ruff check --fix`, and file hygiene checks 
 
 A change is complete when **all** of the following are true:
 
-- [ ] `make ci` passes (all 6 targets)
+- [ ] `make ci` passes (all declared targets)
 - [ ] `CHANGELOG.md` updated
 - [ ] Google-style docstrings on all new public APIs
 - [ ] Type hints on all new public functions and methods
@@ -2470,7 +2470,8 @@ When a bad change is caught in review or causes a regression:
 
 ### 5. `make ci` composition drift
 
-**Mistake:** `AGENTS.md` described `make ci` as 4 targets when the Makefile runs 6.
+**Mistake:** `AGENTS.md` described `make ci` with a stale fixed target count and
+omitted a target that the Makefile runs.
 
 **Lesson:** Do not describe command composition from memory. Check the `Makefile` for ground truth.
 
@@ -2498,7 +2499,7 @@ maintainer review (when reviewing PRs). Items are grouped by category.
 
 ## Validation
 
-- [ ] `make ci` passes (all 6 targets: fmt, lint, type, test, example, demo)
+- [ ] `make ci` passes (fmt, lint, type, test, schemas-check, example, demo)
 - [ ] No new warnings introduced
 
 ## Hard Rules

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2253,17 +2253,23 @@ make context-rot       # render context-rot demo JSON + docs/assets/context_rot.
 make context-rot-check # verify context_rot.svg matches its committed JSON (gating CI step; exits non-zero on drift)
 make readme-version-check  # verify README version references match pyproject.toml (gating CI step; #347)
 make llms        # regenerate llms.txt and llms-full.txt from canonical docs
-make llms-check  # verify llms.txt and llms-full.txt are up to date (exits non-zero on drift)
+make llms-check  # verify llms.txt and llms-full.txt are up to date (gating CI step; exits non-zero on drift)
+make gateway-scorecard-check  # verify gateway scorecard Markdown matches its committed JSON (gating CI step)
+make record-demos-check  # verify committed asciinema casts match demo output (gating CI step)
+make smoke-eval  # deterministic, credential-free smoke evaluation (non-gating CI step)
 make weaver-conformance  # round-trip + JSON-Schema validate the weaver-spec adapter
                          # (fetches schemas from raw.githubusercontent.com; CI runs it as a gate)
 ```
 
 > Gating CI steps beyond `make ci`: `make scorecard-check`,
 > `make readme-version-check` (#347), `make context-rot-check` (#349),
-> and `make weaver-conformance`. (`make schemas-check` also gates, but it
-> runs *inside* `make ci`.)
+> `make llms-check` (#389), `make record-demos-check` (#390),
+> `make gateway-scorecard-check` (#391), and `make weaver-conformance`.
+> `make smoke-eval` (#392) also runs in CI but remains non-gating.
+> (`make schemas-check` also gates, but it runs *inside* `make ci`.)
 
-`make ci` runs all six targets in sequence. It is the single validation gate.
+`make ci` runs all six core targets in sequence. Run the additional gating checks
+listed above before opening a PR when the affected artifacts or integrations change.
 
 ## Command-Selection Rules
 
@@ -2276,10 +2282,13 @@ make weaver-conformance  # round-trip + JSON-Schema validate the weaver-spec ada
 | Run all tests | `make test` |
 | Verify examples work | `make example` |
 | Interactive demo | `make demo` |
+| Verify recorded demo casts | `make record-demos-check` |
 | Build docs site | `make docs` |
 | Live docs preview | `make docs-serve` |
 | Run benchmark harness | `make benchmark` (non-gating; writes `benchmarks/results/latest.json`) |
 | Run full per-backend × per-size matrix | `make benchmark-matrix` (#208 + #209) |
+| Verify gateway benchmark scorecard | `make gateway-scorecard-check` |
+| Run deterministic smoke evaluation | `make smoke-eval` (non-gating) |
 | Run scoring-weight sweep | `make sweep-scoring` (#214; writes `benchmarks/sweep_scoring.md`) |
 | Add an eval for a feature | follow [`.github/prompts/add-eval.prompt.md`](../../.github/prompts/add-eval.prompt.md) (#216) |
 | Regenerate llms.txt / llms-full.txt | `make llms` (after editing canonical docs) |

--- a/scripts/gen_llms.py
+++ b/scripts/gen_llms.py
@@ -4,7 +4,7 @@
 Run via `make llms`. Both output files are deterministic and should
 match the committed copies byte-for-byte after each documentation
 change. Intended for CI to run with `--check` to fail builds when
-drift is introduced; CI integration is deferred to a follow-up.
+drift is introduced.
 
 Layout of each output:
 

--- a/scripts/record_demo.py
+++ b/scripts/record_demo.py
@@ -16,7 +16,7 @@ mkdocs/material can embed via ``asciinema-player`` (an optional ~30 KB
 JS asset).
 
 Determinism contract: ``--check`` exits non-zero if the rendered casts
-differ from the committed files. Wire this into CI to catch drift when
+differ from the committed files. CI runs this check to catch drift when
 a demo's stdout changes without the cast being regenerated.
 
 Usage::


### PR DESCRIPTION
## Summary

Closes #389
Closes #390
Closes #391
Closes #392
Closes #393

Adds the missing CI coverage for deterministic generated artifacts and the smoke evaluation. The three artifact checks are gating on the Python 3.12 matrix cell; the smoke evaluation is intentionally informational and non-gating.

## Changes

- `.github/workflows/ci.yml` — run `gen_llms.py --check`, `record_demo.py --check`, and `render_gateway_scorecard.py --check` as Python 3.12 gates; run `smoke_eval.py` there with `continue-on-error: true`.
- `scripts/gen_llms.py` and `scripts/record_demo.py` — update stale module guidance now that CI integration exists.
- `AGENTS.md` and `docs/agent-context/workflows.md` — document the new gating/non-gating behavior and local commands.
- `CHANGELOG.md` — record the CI coverage under Unreleased.
- `llms-full.txt` — regenerate the derived AI-facing documentation artifact.

## Checklist

- [x] Tests added for new public functions/classes — N/A; no public API or runtime behavior was added.
- [x] `make ci` passes locally — `make` is unavailable on this Windows environment, so every constituent command was run directly with the repository virtual environment.
- [x] `CHANGELOG.md` updated under `[Unreleased]`.
- [x] Docstrings added for new public API — N/A; no public API was added.
- [x] New modules are ≤300 lines — N/A; no modules were added.
- [x] Issue linked with `Closes #N` above.
- [x] Agent-facing docs updated where project workflow conventions changed.

## How verified

- `.venv\Scripts\ruff.exe format --check src/ tests/ examples/ scripts/` — 281 files already formatted.
- `.venv\Scripts\ruff.exe check src/ tests/ examples/ scripts/` — all checks passed.
- `.venv\Scripts\mypy.exe src/` — success, no issues in 119 source files.
- `.venv\Scripts\python.exe -m pytest --cov=contextweaver --cov-report=term-missing -q` — 1,888 passed, 67 skipped, 1 xfailed; 82% total coverage.
- `.venv\Scripts\python.exe -m pytest tests/test_record_demo.py tests/test_gateway_benchmark.py tests/test_smoke_eval.py -q` — 24 passed.
- `.venv\Scripts\python.exe scripts\gen_schemas.py --check` — schemas up to date.
- All 29 scripts from the Makefile `example` and `architectures` targets — passed.
- `.venv\Scripts\python.exe -m contextweaver demo` — passed.
- `.venv\Scripts\python.exe -m mkdocs build --clean` — documentation built successfully; existing link warnings remain.
- New CI commands — all passed; smoke evaluation reported 5/5 deterministic checks.
- Deliberate stale-output probes for llms, recorded demos, and gateway scorecard — each returned exit code 1 as required.
- Parsed `.github/workflows/ci.yml` with PyYAML and asserted all four steps' commands, Python 3.12 guards, and gating semantics — 4/4 passed.

## Tradeoffs / risks

- The new checks run in one matrix cell because their outputs are deterministic and interpreter-independent; this avoids four identical artifact comparisons.
- Smoke evaluation remains non-gating by design, so regressions surface without blocking unrelated changes.
- CI will still exercise the supported Python 3.10-3.13 matrix and the network-backed weaver conformance step.

## Scope notes

Mode B was used, but changes remain limited to issues #389-#393 and the documentation/generated artifact required to describe them.

## Notes for reviewers

Please focus on whether Python 3.12 is the preferred single matrix cell for deterministic checks and whether the smoke evaluation should remain informational.

## Reproducibility

The added checks are credential-free and deterministic. No benchmark result files or model-dependent outputs are regenerated by CI.