### PR TITLE
feat(firewall): deterministic, non-destructive, single-call firewall surface (#399, #402, #403, #404, #405, #406)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,15 @@ It prepares context and routes tools but never calls models or executes tools.
 | `_version.py` | Single-source version derived from `importlib.metadata`; fallback `"0.0.0+local"` |
 | `_demos.py` | Demo logic for the CLI `demo` subcommand (exempt from `print()` rule) |
 | `serde.py` | Serialisation helpers for `to_dict` / `from_dict` |
+| `tokens.py` | Built-in token counter (`count()`, `get_token_counter()`, `heuristic_counter()`, `TokenCounter` alias). Owns the `tiktoken` dependency so callers never wire it directly; firewall / `FirewallStats` numbers are computed through the same counter (issue #405). |
 | `store/` | In-memory data stores: `EventLog`, `ArtifactStore`, `EpisodicStore`, `FactStore`, `StoreBundle` |
 | `store/_sqlite_base.py` | Shared SQLite connection + migration scaffolding (WAL, `foreign_keys=ON`, `_contextweaver_schema_version` table). Reused by every SQLite-backed store (issue #174). |
 | `store/sqlite_event_log.py` | `SqliteEventLog` — first persistent `EventLog` backend; single-process, sync, append-only, schema-versioned (issue #223). |
 | `store/json_file_artifacts.py` | `JsonFileArtifactStore` — filesystem `ArtifactStore` backend; `{handle}.data` + `{handle}.json` per artifact, re-instantiable against an existing directory (issue #42). |
 | `summarize/` | `SummarizationRule`, `RuleEngine`, `extract_facts()` |
+| `summarize/structured.py` | Lossless JSON field projection for the firewall: `parse_path` / `project` + `StructuredFirewall(keep=[...])`. Deterministic, no LLM — keeps an allow-list of JSON paths inline and offloads the rest (issue #406). |
 | `context/` | Full context pipeline, sensitivity enforcement, view registry, `ContextManager` |
+| `context/firewall_api.py` | Single-call firewall facade: `compact_tool_result` / `firewalled_tool_result` → `CompactResult`. Composes structured/text strategies, schema-preserving pass-through (reserved `_cw` sidecar), the built-in token counter, and fail-closed `deterministic` mode (issues #399, #402, #403, #404, #405, #406). |
 | `context/manager.py` | `ContextManager` — thin orchestrator (`__init__`, properties, `drilldown`, mixin composition). Public method stubs live in flat partial-class mixins; pipeline logic lives in the delegate modules below (issue #101). |
 | `context/_manager_base.py` | `_ManagerState` — private-attribute + `_build` contract the manager mixins inherit and the delegate pipeline modules type their `manager` parameter against (`ContextManager` inherits it via the mixins). Not public API (issue #101). |
 | `context/_manager_ingest.py` / `_manager_build.py` / `_manager_routing.py` | `_IngestMixin` / `_BuildMixin` / `_RoutingMixin` — partial-class mixins holding `ContextManager`'s ingestion, build, and route/call-prompt method surface as thin delegations; keep `manager.py` ≤300 lines (issue #101). Not public API. |
@@ -124,7 +127,10 @@ For full pipeline descriptions and design rationale, see [docs/agent-context/arc
 | `ContextItem` | Event log entry with `parent_id` for dependency closure |
 | `ResultEnvelope` | Processed tool output: summary + facts + artifacts + views |
 | `ContextPack` | Rendered prompt + stats from a context build |
-| `BuildStats` | What was kept, dropped, and why — diagnostic output of every build |
+| `BuildStats` | What was kept, dropped, and why — diagnostic output of every build. Carries `firewall_events: list[FirewallStats]` + `firewall_summary()` (issue #402) |
+| `FirewallStats` | Per-firewall diagnostics: `triggered`, `strategy`, original/summary chars+tokens, `artifact_ref`, `summarized_by_llm` (issues #402 / #404) |
+| `CompactResult` | Output of the single-call `compact_tool_result` facade: `firewalled`, `payload`, `summary`, `facts`, `artifact_ref`, `stats` (issue #399) |
+| `StructuredFirewall` | Non-summarising firewall strategy — keep an allow-list of JSON paths inline, offload the rest (issue #406) |
 | `ChoiceCard` | LLM-friendly compact card (never includes full schemas) |
 | `RoutingDecision` | Routing output shaped for weaver-spec interop (id, choice_cards, timestamp, selection). `choice_cards` is a flat list of CW 1:1 cards; for schema-valid spec JSON, go through `adapters.weaver_contracts.to_weaver_routing_decision()`. Build with `RouteResult.to_routing_decision(...)`. |
 | `ChoiceGraph` | Bounded DAG for routing, serializable, validated on load |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   JSON paths inline, offload the rest to the artifact store (retrievable via
   `drilldown`), no LLM. Selectable through `compact_tool_result(strategy=...)`
   and `ContextManager.ingest_tool_result(..., firewall=StructuredFirewall(...))`.
+  An explicit `strategy="structured"` now raises `ConfigError` on non-JSON
+  input instead of silently downgrading to a text summary; `ingest_tool_result`
+  applies `firewall=` only above `firewall_threshold`.
 - **First-class firewall diagnostics — `FirewallStats` (#402).** Records
   `triggered`, `strategy`, original/summary chars+tokens (`chars_saved` /
   `tokens_saved`), `artifact_ref`, and `summarized_by_llm`. Surfaced on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Single-call firewall facade — `compact_tool_result()` /
+  `firewalled_tool_result()` (#399).** Shrink one large tool result before it
+  enters the prompt without standing up a `ContextManager`. Returns a
+  `CompactResult` (`firewalled`, `payload`, `summary`, `facts`, `artifact_ref`,
+  `stats`). Exported from the top level.
+- **Structured (lossless) firewall mode (#406).** New `StructuredFirewall(keep=[...])`
+  plus `summarize.structured.project` / `parse_path`: keep an allow-list of
+  JSON paths inline, offload the rest to the artifact store (retrievable via
+  `drilldown`), no LLM. Selectable through `compact_tool_result(strategy=...)`
+  and `ContextManager.ingest_tool_result(..., firewall=StructuredFirewall(...))`.
+- **First-class firewall diagnostics — `FirewallStats` (#402).** Records
+  `triggered`, `strategy`, original/summary chars+tokens (`chars_saved` /
+  `tokens_saved`), `artifact_ref`, and `summarized_by_llm`. Surfaced on
+  `ResultEnvelope.firewall_stats`, and aggregated on `BuildStats.firewall_events`
+  / `BuildStats.firewall_summary()`.
+- **Determinism guarantee — `deterministic=True` (#404).** `ContextManager(deterministic=True)`
+  and `compact_tool_result(deterministic=...)` *fail closed* with the new
+  `DeterminismError` rather than passing data through an LLM-backed summariser;
+  `FirewallStats.strategy` / `summarized_by_llm` make the path auditable.
+- **Built-in token counter — `contextweaver.tokens` (#405).** Public
+  `count()` / `get_token_counter()` / `heuristic_counter()` (and `TokenCounter`
+  alias) so callers never wire `tiktoken` directly; firewall/`FirewallStats`
+  numbers use the same counter. New no-op `contextweaver[tokenizers]` extra
+  documents the contract (`tiktoken` is already core, with offline fallback).
+
 ### Changed
 
 - **CI now exercises every committed generated-artifact drift check

--- a/docs/context_firewall.md
+++ b/docs/context_firewall.md
@@ -99,8 +99,8 @@ It composes the firewall primitives:
   structured line-of-business data (billing, CRM, catalog lookups).
 - **Determinism guarantee** (issue #404). `deterministic=True` (the default
   for this facade) *fails closed*: if the chosen path would invoke an
-  LLM-backed summariser it raises
-  [`DeterminismError`](#) instead of silently passing data through a model.
+  LLM-backed summariser it raises `DeterminismError` instead of silently
+  passing data through a model.
   `FirewallStats.summarized_by_llm` / `strategy` record exactly what happened,
   so the guarantee is observable and citable in a compliance review.
 - **Built-in token counter** (issue #405). Savings are measured with

--- a/docs/context_firewall.md
+++ b/docs/context_firewall.md
@@ -64,6 +64,73 @@ runnable recipe.
 > [Firewall Boundary (Frame seam)](context_firewall_boundary.md) for who
 > firewalls what and the canonical `ingest_envelope()` path.
 
+## Single-call firewall (`compact_tool_result`)
+
+When you just have **one** large tool result and want to shrink it before it
+enters the prompt — without standing up a `ContextManager` or a synthetic
+turn — use the single-call facade (issue #399):
+
+```python
+from contextweaver import compact_tool_result
+
+out = compact_tool_result(
+    {"invoices": [...]},
+    threshold_chars=2000,
+    keep=["invoices[].invoiceNumber", "invoices[].amount", "invoices[].status"],
+)
+out.firewalled          # True
+out.payload             # projected subset + {"_cw": {...}} sidecar
+out.stats.tokens_saved  # how much stayed out of the prompt
+```
+
+It composes the firewall primitives:
+
+- **Schema-preserving pass-through** (issue #403). When the payload is at or
+  below `threshold_chars`, the caller's shape is returned **unchanged** —
+  same keys, same nesting — with firewall metadata attached only on a
+  reserved, namespaced `_cw` sidecar key (dicts) and never an in-place rewrite.
+  Lists and strings are returned byte-identical. Downstream code that reads
+  `result.response.x` keeps working whether or not the firewall fired.
+- **Structured (lossless) mode** (issue #406). Pass a `keep` JSON-path
+  allow-list (or `strategy="structured"`) and the firewall keeps only the
+  allow-listed paths inline, offloads the full payload to the artifact store,
+  and leaves the dropped fields retrievable via `drilldown`. This is
+  deterministic and performs **no LLM call** — the right primitive for
+  structured line-of-business data (billing, CRM, catalog lookups).
+- **Determinism guarantee** (issue #404). `deterministic=True` (the default
+  for this facade) *fails closed*: if the chosen path would invoke an
+  LLM-backed summariser it raises
+  [`DeterminismError`](#) instead of silently passing data through a model.
+  `FirewallStats.summarized_by_llm` / `strategy` record exactly what happened,
+  so the guarantee is observable and citable in a compliance review.
+- **Built-in token counter** (issue #405). Savings are measured with
+  `contextweaver.tokens.count` — the same counter the firewall uses
+  internally — so reported numbers match what callers measure. `tiktoken` is
+  a core dependency and degrades to a character heuristic offline.
+
+### Firewall diagnostics (`FirewallStats`)
+
+Every firewall decision now records a `FirewallStats` (issue #402) answering
+the two questions an integrator cares about — *was the firewall triggered?*
+and *how much was saved?*:
+
+```python
+mgr = ContextManager()
+mgr.ingest_sync(ContextItem(id="result:tc1", kind=ItemKind.tool_result, text=big))
+pack = mgr.build_sync(phase=Phase.interpret, query="...")
+
+fs = pack.stats.firewall_summary()   # roll-up across the build
+fs.triggered, fs.strategy            # True, "summary"
+fs.chars_saved, fs.tokens_saved      # how much stayed out of the prompt
+pack.stats.firewall_events           # per-item FirewallStats
+```
+
+`ResultEnvelope.firewall_stats` carries the same per-result diagnostics on the
+ingest path. Pass `ContextManager(deterministic=True)` to extend the
+fail-closed guarantee to the whole build pipeline, and
+`ingest_tool_result(..., firewall=StructuredFirewall(keep=[...]))` to select
+structured projection at ingest time.
+
 ## Drilling down to raw bytes
 
 `ArtifactRef` supports four built-in drilldown selectors so the LLM can

--- a/docs/schemas/v0/build_stats.schema.json
+++ b/docs/schemas/v0/build_stats.schema.json
@@ -1,4 +1,51 @@
 {
+  "$defs": {
+    "FirewallStats": {
+      "additionalProperties": false,
+      "description": "First-class diagnostics for a single context-firewall decision (issue #402).",
+      "properties": {
+        "artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "original_chars": {
+          "type": "integer"
+        },
+        "original_tokens": {
+          "type": "integer"
+        },
+        "strategy": {
+          "type": "string"
+        },
+        "summarized_by_llm": {
+          "type": "boolean"
+        },
+        "summary_chars": {
+          "type": "integer"
+        },
+        "summary_tokens": {
+          "type": "integer"
+        },
+        "threshold_chars": {
+          "type": "integer"
+        },
+        "triggered": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "strategy",
+        "triggered"
+      ],
+      "type": "object"
+    }
+  },
   "$id": "https://dgenio.github.io/contextweaver/schemas/v0/build_stats.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
@@ -18,6 +65,12 @@
         "type": "integer"
       },
       "type": "object"
+    },
+    "firewall_events": {
+      "items": {
+        "$ref": "#/$defs/FirewallStats"
+      },
+      "type": "array"
     },
     "header_footer_tokens": {
       "type": "integer"

--- a/docs/schemas/v0/result_envelope.schema.json
+++ b/docs/schemas/v0/result_envelope.schema.json
@@ -27,6 +27,51 @@
       ],
       "type": "object"
     },
+    "FirewallStats": {
+      "additionalProperties": false,
+      "description": "First-class diagnostics for a single context-firewall decision (issue #402).",
+      "properties": {
+        "artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "original_chars": {
+          "type": "integer"
+        },
+        "original_tokens": {
+          "type": "integer"
+        },
+        "strategy": {
+          "type": "string"
+        },
+        "summarized_by_llm": {
+          "type": "boolean"
+        },
+        "summary_chars": {
+          "type": "integer"
+        },
+        "summary_tokens": {
+          "type": "integer"
+        },
+        "threshold_chars": {
+          "type": "integer"
+        },
+        "triggered": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "strategy",
+        "triggered"
+      ],
+      "type": "object"
+    },
     "ViewSpec": {
       "additionalProperties": false,
       "description": "Specifies a named view (a filtered/projected representation) of an artifact.",
@@ -75,6 +120,16 @@
         "type": "string"
       },
       "type": "array"
+    },
+    "firewall_stats": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/FirewallStats"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "provenance": {
       "additionalProperties": {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,14 @@ docs = [
 # Kept as a no-op for one cycle so existing requirements pins do not break;
 # scheduled for removal in v0.6.
 cli = []
+# Built-in token counting (issue #405).  ``tiktoken`` is already a *core*
+# dependency (see ``dependencies`` above), so ``contextweaver.tokens.count``
+# resolves an exact tokenizer out of the box and degrades to the character
+# heuristic when offline.  This extras group is intentionally empty — it exists
+# so callers can pin the tokenizer contract explicitly
+# (``pip install 'contextweaver[tokenizers]'``) without changing the install
+# surface, mirroring the no-op ``cli`` / ``sqlite`` groups.
+tokenizers = []
 # Fuzzy lexical retrieval backend (rapidfuzz) — supplements the default BM25
 # scorer for typo / abbreviation tolerance.
 retrieval = [

--- a/schemas/build_stats.schema.json
+++ b/schemas/build_stats.schema.json
@@ -1,4 +1,51 @@
 {
+  "$defs": {
+    "FirewallStats": {
+      "additionalProperties": false,
+      "description": "First-class diagnostics for a single context-firewall decision (issue #402).",
+      "properties": {
+        "artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "original_chars": {
+          "type": "integer"
+        },
+        "original_tokens": {
+          "type": "integer"
+        },
+        "strategy": {
+          "type": "string"
+        },
+        "summarized_by_llm": {
+          "type": "boolean"
+        },
+        "summary_chars": {
+          "type": "integer"
+        },
+        "summary_tokens": {
+          "type": "integer"
+        },
+        "threshold_chars": {
+          "type": "integer"
+        },
+        "triggered": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "strategy",
+        "triggered"
+      ],
+      "type": "object"
+    }
+  },
   "$id": "https://dgenio.github.io/contextweaver/schemas/v0/build_stats.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
@@ -18,6 +65,12 @@
         "type": "integer"
       },
       "type": "object"
+    },
+    "firewall_events": {
+      "items": {
+        "$ref": "#/$defs/FirewallStats"
+      },
+      "type": "array"
     },
     "header_footer_tokens": {
       "type": "integer"

--- a/schemas/result_envelope.schema.json
+++ b/schemas/result_envelope.schema.json
@@ -27,6 +27,51 @@
       ],
       "type": "object"
     },
+    "FirewallStats": {
+      "additionalProperties": false,
+      "description": "First-class diagnostics for a single context-firewall decision (issue #402).",
+      "properties": {
+        "artifact_ref": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "original_chars": {
+          "type": "integer"
+        },
+        "original_tokens": {
+          "type": "integer"
+        },
+        "strategy": {
+          "type": "string"
+        },
+        "summarized_by_llm": {
+          "type": "boolean"
+        },
+        "summary_chars": {
+          "type": "integer"
+        },
+        "summary_tokens": {
+          "type": "integer"
+        },
+        "threshold_chars": {
+          "type": "integer"
+        },
+        "triggered": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "strategy",
+        "triggered"
+      ],
+      "type": "object"
+    },
     "ViewSpec": {
       "additionalProperties": false,
       "description": "Specifies a named view (a filtered/projected representation) of an artifact.",
@@ -75,6 +120,16 @@
         "type": "string"
       },
       "type": "array"
+    },
+    "firewall_stats": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/FirewallStats"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "provenance": {
       "additionalProperties": {},

--- a/src/contextweaver/__init__.py
+++ b/src/contextweaver/__init__.py
@@ -20,7 +20,7 @@ Quick start::
 
 from __future__ import annotations
 
-from contextweaver import config, envelope, exceptions, profiles, protocols, types
+from contextweaver import config, envelope, exceptions, profiles, protocols, tokens, types
 from contextweaver._utils import BM25Scorer, FuzzyScorer, TfIdfScorer, jaccard
 from contextweaver._version import __version__  # noqa: F401
 from contextweaver.config import ContextBudget, ContextPolicy, ScoringConfig
@@ -28,6 +28,11 @@ from contextweaver.context.explanation import (
     EXPLANATION_VERSION,
     CandidateExplanation,
     ContextBuildExplanation,
+)
+from contextweaver.context.firewall_api import (
+    CompactResult,
+    compact_tool_result,
+    firewalled_tool_result,
 )
 from contextweaver.context.handoff import (
     HANDOFF_CATEGORIES,
@@ -51,6 +56,7 @@ from contextweaver.envelope import (
     BuildStats,
     ChoiceCard,
     ContextPack,
+    FirewallStats,
     HydrationResult,
     ResultEnvelope,
     RoutingDecision,
@@ -61,6 +67,7 @@ from contextweaver.exceptions import (
     CatalogError,
     ConfigError,
     ContextWeaverError,
+    DeterminismError,
     DuplicateItemError,
     GraphBuildError,
     ItemNotFoundError,
@@ -133,6 +140,7 @@ from contextweaver.store import (
 )
 from contextweaver.summarize.extract import StructuredExtractor
 from contextweaver.summarize.rules import RuleBasedSummarizer
+from contextweaver.summarize.structured import StructuredFirewall, project
 from contextweaver.types import (
     ArtifactRef,
     ContextItem,
@@ -151,6 +159,7 @@ __all__ = [
     "exceptions",
     "profiles",
     "protocols",
+    "tokens",
     "types",
     # utilities
     "BM25Scorer",
@@ -163,6 +172,7 @@ __all__ = [
     "ChoiceCard",
     "ContextItem",
     "ContextPack",
+    "FirewallStats",
     "HydrationResult",
     "ItemKind",
     "Phase",
@@ -202,6 +212,7 @@ __all__ = [
     "CatalogError",
     "ConfigError",
     "ContextWeaverError",
+    "DeterminismError",
     "DuplicateItemError",
     "GraphBuildError",
     "ItemNotFoundError",
@@ -218,9 +229,12 @@ __all__ = [
     "StoreBundle",
     # context engine
     "CandidateExplanation",
+    "CompactResult",
     "ContextBuildExplanation",
     "ContextManager",
     "EXPLANATION_VERSION",
+    "compact_tool_result",
+    "firewalled_tool_result",
     "HANDOFF_CATEGORIES",
     "HANDOFF_PACK_VERSION",
     "HandoffEntry",
@@ -277,4 +291,6 @@ __all__ = [
     # summarize
     "RuleBasedSummarizer",
     "StructuredExtractor",
+    "StructuredFirewall",
+    "project",
 ]

--- a/src/contextweaver/context/_manager_base.py
+++ b/src/contextweaver/context/_manager_base.py
@@ -56,6 +56,9 @@ class _ManagerState:
     _metrics: MetricsCollector | None
     _profile: ProfileConfig | None
     _mode: Mode
+    #: When ``True`` the context firewall fails closed instead of invoking an
+    #: LLM-backed summariser (issue #404).
+    _deterministic: bool
 
     if TYPE_CHECKING:
         # Implemented by ``_BuildMixin``; declared here (type-only, no runtime

--- a/src/contextweaver/context/_manager_ingest.py
+++ b/src/contextweaver/context/_manager_ingest.py
@@ -20,6 +20,7 @@ from contextweaver.store.facts import Fact
 
 if TYPE_CHECKING:
     from contextweaver.envelope import ResultEnvelope
+    from contextweaver.summarize.structured import StructuredFirewall
     from contextweaver.types import ContextItem
 
 
@@ -102,6 +103,8 @@ class _IngestMixin(_ManagerState):
         tool_name: str = "",
         media_type: str = "text/plain",
         firewall_threshold: int = 2000,
+        *,
+        firewall: StructuredFirewall | None = None,
     ) -> tuple[ContextItem, ResultEnvelope]:
         """Ingest a *raw* tool result, running the context firewall locally.
 
@@ -117,9 +120,8 @@ class _IngestMixin(_ManagerState):
 
         If the raw output exceeds *firewall_threshold* characters it is stored
         in the artifact store and the LLM sees only a summary.  Small outputs
-        are also stored in the artifact store (with ``artifact_ref`` set on the
-        returned item) to enable drilldown on all tool results regardless of
-        size.
+        are also stored (with ``artifact_ref`` set) so drilldown works on all
+        tool results regardless of size.
 
         Args:
             tool_call_id: ID of the originating tool call.
@@ -128,10 +130,13 @@ class _IngestMixin(_ManagerState):
             media_type: MIME type of the output.
             firewall_threshold: Character threshold above which the firewall
                 stores the raw output out-of-band.
+            firewall: Optional :class:`StructuredFirewall` for lossless JSON
+                projection over summarisation (#406); ``deterministic`` (#404)
+                applies automatically.
 
         Returns:
-            A ``(ContextItem, ResultEnvelope)`` tuple.  The item always has a
-            non-``None`` ``artifact_ref``.
+            A ``(ContextItem, ResultEnvelope)`` tuple; the item always has an
+            ``artifact_ref`` and the envelope carries ``firewall_stats``.
         """
         return _ingest.ingest_tool_result(
             event_log=self._event_log,
@@ -146,6 +151,8 @@ class _IngestMixin(_ManagerState):
             tool_name=tool_name,
             media_type=media_type,
             firewall_threshold=firewall_threshold,
+            deterministic=self._deterministic,
+            firewall=firewall,
         )
 
     def ingest_tool_result_sync(
@@ -155,10 +162,17 @@ class _IngestMixin(_ManagerState):
         tool_name: str = "",
         media_type: str = "text/plain",
         firewall_threshold: int = 2000,
+        *,
+        firewall: StructuredFirewall | None = None,
     ) -> tuple[ContextItem, ResultEnvelope]:
         """Synchronous alias for :meth:`ingest_tool_result`."""
         return self.ingest_tool_result(
-            tool_call_id, raw_output, tool_name, media_type, firewall_threshold
+            tool_call_id,
+            raw_output,
+            tool_name,
+            media_type,
+            firewall_threshold,
+            firewall=firewall,
         )
 
     def ingest_mcp_result(
@@ -167,6 +181,8 @@ class _IngestMixin(_ManagerState):
         mcp_result: dict[str, Any],
         tool_name: str,
         firewall_threshold: int = 2000,
+        *,
+        firewall: StructuredFirewall | None = None,
     ) -> tuple[ContextItem, ResultEnvelope]:
         """Ingest a raw MCP tool result with full artifact persistence.
 
@@ -180,12 +196,9 @@ class _IngestMixin(_ManagerState):
             happy-path for direct MCP integration where contextweaver owns the
             firewall.
 
-        It:
-
-        1. Parses the MCP result via :func:`mcp_result_to_envelope`.
-        2. Stores binary artifacts (images, resources) in the artifact store.
-        3. Applies the context firewall for large text outputs.
-        4. Appends the resulting :class:`ContextItem` to the event log.
+        It parses the MCP result via :func:`mcp_result_to_envelope`, stores
+        binary artifacts (images, resources), applies the context firewall for
+        large text outputs, and appends the resulting :class:`ContextItem`.
 
         Args:
             tool_call_id: ID of the originating tool call.
@@ -193,6 +206,9 @@ class _IngestMixin(_ManagerState):
             tool_name: Human-readable tool name.
             firewall_threshold: Character threshold above which text output
                 is stored out-of-band via the firewall.
+            firewall: Optional :class:`StructuredFirewall` for lossless JSON
+                projection over summarisation (#406); ``deterministic`` (#404)
+                applies automatically.
 
         Returns:
             A ``(ContextItem, ResultEnvelope)`` tuple with all artifacts
@@ -209,6 +225,8 @@ class _IngestMixin(_ManagerState):
             mcp_result=mcp_result,
             tool_name=tool_name,
             firewall_threshold=firewall_threshold,
+            deterministic=self._deterministic,
+            firewall=firewall,
         )
 
     def ingest_mcp_result_sync(
@@ -217,9 +235,13 @@ class _IngestMixin(_ManagerState):
         mcp_result: dict[str, Any],
         tool_name: str,
         firewall_threshold: int = 2000,
+        *,
+        firewall: StructuredFirewall | None = None,
     ) -> tuple[ContextItem, ResultEnvelope]:
         """Synchronous alias for :meth:`ingest_mcp_result`."""
-        return self.ingest_mcp_result(tool_call_id, mcp_result, tool_name, firewall_threshold)
+        return self.ingest_mcp_result(
+            tool_call_id, mcp_result, tool_name, firewall_threshold, firewall=firewall
+        )
 
     # ------------------------------------------------------------------
     # Fact / episodic memory writes

--- a/src/contextweaver/context/_manager_ingest.py
+++ b/src/contextweaver/context/_manager_ingest.py
@@ -132,7 +132,9 @@ class _IngestMixin(_ManagerState):
                 stores the raw output out-of-band.
             firewall: Optional :class:`StructuredFirewall` for lossless JSON
                 projection over summarisation (#406); ``deterministic`` (#404)
-                applies automatically.
+                applies automatically.  Only takes effect when the payload
+                exceeds *firewall_threshold*; smaller payloads pass through
+                inline unprojected (there is nothing to offload below it).
 
         Returns:
             A ``(ContextItem, ResultEnvelope)`` tuple; the item always has an
@@ -208,7 +210,9 @@ class _IngestMixin(_ManagerState):
                 is stored out-of-band via the firewall.
             firewall: Optional :class:`StructuredFirewall` for lossless JSON
                 projection over summarisation (#406); ``deterministic`` (#404)
-                applies automatically.
+                applies automatically.  Only takes effect when the payload
+                exceeds *firewall_threshold*; smaller payloads pass through
+                inline unprojected (there is nothing to offload below it).
 
         Returns:
             A ``(ContextItem, ResultEnvelope)`` tuple with all artifacts

--- a/src/contextweaver/context/build.py
+++ b/src/contextweaver/context/build.py
@@ -100,6 +100,7 @@ def run_build_pipeline(
         manager._hook,
         summarizer=manager._summarizer,
         extractor=manager._extractor,
+        deterministic=manager._deterministic,
     )
 
     # 5. Score
@@ -136,6 +137,11 @@ def run_build_pipeline(
     stats.dedup_removed = dedup_removed
     stats.dependency_closures = closures
     stats.header_footer_tokens = hf_tokens
+    # Surface per-item firewall diagnostics (issue #402): one FirewallStats per
+    # offloaded tool result.  Read ``stats.firewall_summary()`` for the roll-up.
+    stats.firewall_events = [
+        env.firewall_stats for env in envelopes if env.firewall_stats is not None
+    ]
     if sensitivity_drops > 0:
         # Account for items dropped by sensitivity filtering in both the
         # total candidate count and the drop breakdown so that

--- a/src/contextweaver/context/firewall.py
+++ b/src/contextweaver/context/firewall.py
@@ -157,7 +157,11 @@ def apply_firewall(
     # when an allow-list is supplied and the payload is JSON; it is always
     # model-free.  Otherwise summarise — LLM-backed only when the supplied
     # summariser declares itself so.
-    use_structured = keep is not None and _looks_like_json(item.text)
+    # ``bool(keep)`` (not ``keep is not None``) so an empty allow-list means
+    # "no structured projection requested" and falls through to summarisation,
+    # rather than constructing ``StructuredFirewall(keep=[])`` and having its
+    # ConfigError swallowed by the projection try/except below.
+    use_structured = bool(keep) and _looks_like_json(item.text)
     summarized_by_llm = (not use_structured) and _summarizer_is_llm(summarizer)
     if deterministic and summarized_by_llm:
         raise DeterminismError(

--- a/src/contextweaver/context/firewall.py
+++ b/src/contextweaver/context/firewall.py
@@ -9,13 +9,17 @@ containing a human-readable summary, extracted facts, and an
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 from typing import Literal
 
 from contextweaver.context.views import ViewRegistry, generate_views
-from contextweaver.envelope import ResultEnvelope
+from contextweaver.envelope import FirewallStats, ResultEnvelope
+from contextweaver.exceptions import DeterminismError
 from contextweaver.protocols import ArtifactStore, EventHook, Extractor, NoOpHook, Summarizer
 from contextweaver.summarize.extract import extract_facts
+from contextweaver.summarize.structured import StructuredFirewall
+from contextweaver.tokens import count as count_tokens
 from contextweaver.types import ArtifactRef, ContextItem, ItemKind
 
 logger = logging.getLogger("contextweaver.context")
@@ -29,6 +33,23 @@ def _default_summary(raw: str, max_chars: int = 500) -> str:
     return first_para
 
 
+def _looks_like_json(text: str) -> bool:
+    """Return ``True`` when *text* plausibly starts a JSON object/array."""
+    stripped = text.lstrip()
+    return stripped.startswith(("{", "["))
+
+
+def _summarizer_is_llm(summarizer: Summarizer | None) -> bool:
+    """Return ``True`` when *summarizer* declares itself LLM-backed (issue #404).
+
+    Convention: LLM-backed summarisers (e.g.
+    :class:`~contextweaver.extras.llm_summarizer.LlmSummarizer`) set the
+    class attribute ``is_llm = True``.  Deterministic rule-based summarisers do
+    not, so the firewall can decide whether a path is model-free.
+    """
+    return summarizer is not None and bool(getattr(summarizer, "is_llm", False))
+
+
 def apply_firewall(
     item: ContextItem,
     artifact_store: ArtifactStore,
@@ -36,6 +57,10 @@ def apply_firewall(
     view_registry: ViewRegistry | None = None,
     summarizer: Summarizer | None = None,
     extractor: Extractor | None = None,
+    *,
+    deterministic: bool = False,
+    keep: list[str] | None = None,
+    threshold_chars: int = 0,
 ) -> tuple[ContextItem, ResultEnvelope | None]:
     """Intercept a ``tool_result`` item and store its content out-of-band.
 
@@ -53,14 +78,32 @@ def apply_firewall(
         extractor: Optional :class:`~contextweaver.protocols.Extractor`
             implementation.  When provided it replaces the built-in
             :func:`~contextweaver.summarize.extract.extract_facts` call.
+        deterministic: When ``True`` (issue #404) the firewall *fails closed* —
+            if the chosen path would invoke an LLM-backed *summarizer* it raises
+            :class:`~contextweaver.exceptions.DeterminismError` instead of
+            calling the model.  Structured projection and the rule-based
+            summary are always model-free and unaffected.
+        keep: Optional JSON path allow-list (issue #406).  When supplied and the
+            payload parses as JSON, the firewall uses lossless field projection
+            (``strategy="structured"``) instead of text summarisation; the full
+            payload is still offloaded so dropped fields stay retrievable via
+            ``drilldown``.
+        threshold_chars: The character threshold the caller compared against,
+            recorded on :class:`~contextweaver.envelope.FirewallStats` for
+            diagnostics.  Does not gate execution (the caller already decided to
+            fire); ``0`` means "not recorded".
 
     Returns:
         A 2-tuple ``(processed_item, envelope_or_none)``.  When the firewall
         fires, *processed_item* has its ``text`` replaced with the summary and
         ``artifact_ref`` populated; *envelope_or_none* is a
-        :class:`~contextweaver.types.ResultEnvelope`.  When no interception
-        occurs, the original *item* is returned with ``None`` as the second
-        element.
+        :class:`~contextweaver.types.ResultEnvelope` carrying a populated
+        :attr:`~contextweaver.envelope.ResultEnvelope.firewall_stats`.  When no
+        interception occurs, the original *item* is returned with ``None``.
+
+    Raises:
+        DeterminismError: If *deterministic* is ``True`` and the path would
+            invoke an LLM-backed summariser.
     """
     _hook = hook or NoOpHook()
 
@@ -110,26 +153,68 @@ def apply_firewall(
         content_hash=content_hash,
     )
 
-    status: Literal["ok", "partial", "error"] = "ok"
-    try:
-        if summarizer is not None:
-            summary = summarizer.summarize(item.text, dict(item.metadata))
-        else:
-            summary = _default_summary(item.text)
-    except Exception:  # noqa: BLE001
-        summary = "(summary unavailable)"
-        status = "error"
+    # Choose a strategy.  Structured projection (issue #406) takes precedence
+    # when an allow-list is supplied and the payload is JSON; it is always
+    # model-free.  Otherwise summarise — LLM-backed only when the supplied
+    # summariser declares itself so.
+    use_structured = keep is not None and _looks_like_json(item.text)
+    summarized_by_llm = (not use_structured) and _summarizer_is_llm(summarizer)
+    if deterministic and summarized_by_llm:
+        raise DeterminismError(
+            f"deterministic=True but an LLM-backed summarizer would process item "
+            f"{item.id!r}; refusing to pass data through a model. Supply a "
+            f"structured `keep` allow-list or a rule-based summarizer instead."
+        )
 
-    try:
-        if extractor is not None:
-            facts = extractor.extract(item.text, dict(item.metadata))
-        else:
-            facts = extract_facts(item.text, item.metadata)
-    except Exception:  # noqa: BLE001
-        facts = []
-        status = "error" if status == "error" else "partial"
+    status: Literal["ok", "partial", "error"] = "ok"
+    facts: list[str]
+    strategy: str
+
+    if use_structured:
+        strategy = "structured"
+        try:
+            projected, facts = StructuredFirewall(keep=list(keep or [])).compact(
+                json.loads(item.text)
+            )
+            summary = json.dumps(projected, sort_keys=True)
+        except Exception:  # noqa: BLE001 - malformed projection degrades safely
+            strategy = "summary"
+            summary = _default_summary(item.text)
+            facts = []
+            status = "partial"
+    else:
+        strategy = "llm_summary" if summarized_by_llm else "summary"
+        try:
+            if summarizer is not None:
+                summary = summarizer.summarize(item.text, dict(item.metadata))
+            else:
+                summary = _default_summary(item.text)
+        except Exception:  # noqa: BLE001
+            summary = "(summary unavailable)"
+            status = "error"
+
+        try:
+            if extractor is not None:
+                facts = extractor.extract(item.text, dict(item.metadata))
+            else:
+                facts = extract_facts(item.text, item.metadata)
+        except Exception:  # noqa: BLE001
+            facts = []
+            status = "error" if status == "error" else "partial"
 
     views = generate_views(ref, raw_bytes, registry=view_registry)
+
+    firewall_stats = FirewallStats(
+        triggered=True,
+        strategy=strategy,
+        threshold_chars=threshold_chars,
+        original_chars=len(item.text),
+        original_tokens=count_tokens(item.text),
+        summary_chars=len(summary),
+        summary_tokens=count_tokens(summary),
+        artifact_ref=ref.handle,
+        summarized_by_llm=summarized_by_llm,
+    )
 
     envelope = ResultEnvelope(
         status=status,
@@ -138,6 +223,7 @@ def apply_firewall(
         artifacts=[ref],
         views=views,
         provenance={"source_item_id": item.id},
+        firewall_stats=firewall_stats,
     )
 
     processed = ContextItem(
@@ -151,7 +237,12 @@ def apply_firewall(
     )
 
     _hook.on_firewall_triggered(item, "tool_result intercepted")
-    logger.debug("firewall: intercepted item_id=%s, summary_len=%d", item.id, len(summary))
+    logger.debug(
+        "firewall: intercepted item_id=%s, strategy=%s, summary_len=%d",
+        item.id,
+        strategy,
+        len(summary),
+    )
     return processed, envelope
 
 
@@ -162,6 +253,8 @@ def apply_firewall_to_batch(
     view_registry: ViewRegistry | None = None,
     summarizer: Summarizer | None = None,
     extractor: Extractor | None = None,
+    *,
+    deterministic: bool = False,
 ) -> tuple[list[ContextItem], list[ResultEnvelope]]:
     """Apply the firewall to a list of items.
 
@@ -174,6 +267,9 @@ def apply_firewall_to_batch(
             passed through to each :func:`apply_firewall` call.
         extractor: Optional :class:`~contextweaver.protocols.Extractor`
             passed through to each :func:`apply_firewall` call.
+        deterministic: Forwarded to each :func:`apply_firewall` call (issue
+            #404).  When ``True`` the build fails closed rather than passing any
+            item through an LLM-backed summariser.
 
     Returns:
         A 2-tuple of ``(processed_items, envelopes)``.
@@ -181,7 +277,15 @@ def apply_firewall_to_batch(
     processed = []
     envelopes = []
     for item in items:
-        p, env = apply_firewall(item, artifact_store, hook, view_registry, summarizer, extractor)
+        p, env = apply_firewall(
+            item,
+            artifact_store,
+            hook,
+            view_registry,
+            summarizer,
+            extractor,
+            deterministic=deterministic,
+        )
         processed.append(p)
         if env is not None:
             envelopes.append(env)

--- a/src/contextweaver/context/firewall_api.py
+++ b/src/contextweaver/context/firewall_api.py
@@ -37,6 +37,7 @@ Example::
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass, field
 from typing import Any, Literal
@@ -94,10 +95,24 @@ class CompactResult:
 
 
 def _to_text(data: Any) -> tuple[str, str]:  # noqa: ANN401 — arbitrary JSON tool result
-    """Return ``(text, media_type)`` for *data* (deterministic JSON for non-str)."""
+    """Return ``(text, media_type)`` for *data* (deterministic JSON for non-str).
+
+    Raises:
+        ConfigError: If *data* is not JSON-serialisable.  We deliberately do
+            *not* fall back to ``json.dumps(default=str)`` — silently
+            stringifying arbitrary objects would break the determinism promise
+            (e.g. ``str(set)`` ordering) and could leak ``repr`` details such as
+            memory addresses into the prompt.
+    """
     if isinstance(data, str):
         return data, "text/plain"
-    return json.dumps(data, sort_keys=True, default=str), "application/json"
+    try:
+        return json.dumps(data, sort_keys=True), "application/json"
+    except TypeError as exc:
+        raise ConfigError(
+            "compact_tool_result requires JSON-serialisable data (dict / list / "
+            f"str); got a non-serialisable value: {exc}"
+        ) from exc
 
 
 def _sidecar(stats: FirewallStats) -> dict[str, Any]:
@@ -190,8 +205,12 @@ def compact_tool_result(
     # Over threshold (or forced) — offload via the shared firewall primitive.
     store = artifact_store if artifact_store is not None else InMemoryArtifactStore()
     keep_for_call = keep if strategy in ("auto", "structured") else None
+    # Content-derived id so the artifact handle (``artifact:{id}``) is unique
+    # per payload — two same-length payloads must not collide in a shared
+    # ArtifactStore.  A digest (not a UUID) keeps the id deterministic.
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
     item = ContextItem(
-        id=f"compact:{original_chars}",
+        id=f"compact:{digest}",
         kind=ItemKind.tool_result,
         text=text,
         metadata={"media_type": media_type},

--- a/src/contextweaver/context/firewall_api.py
+++ b/src/contextweaver/context/firewall_api.py
@@ -166,7 +166,8 @@ def compact_tool_result(
         A :class:`CompactResult`.
 
     Raises:
-        ConfigError: If ``strategy="structured"`` without a non-empty *keep*.
+        ConfigError: If ``strategy="structured"`` without a non-empty *keep*,
+            or if ``strategy="structured"`` is given non-JSON data.
         DeterminismError: If ``deterministic=True`` and the text strategy would
             invoke an LLM-backed summariser.
     """
@@ -174,6 +175,20 @@ def compact_tool_result(
         raise ConfigError("strategy='structured' requires a non-empty `keep` allow-list")
 
     text, media_type = _to_text(data)
+    if strategy == "structured":
+        # Fail loud rather than silently downgrade to a text summary: structured
+        # projection needs a JSON payload (the firewall's ``use_structured`` path
+        # requires ``_looks_like_json`` + ``json.loads``).  ``"auto"`` may fall
+        # back to text on non-JSON, but an *explicit* ``"structured"`` request
+        # must not quietly become a summary.
+        try:
+            json.loads(text)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise ConfigError(
+                "strategy='structured' requires JSON-parseable data (dict, list, "
+                "or a JSON string); the given payload is not valid JSON. Use "
+                "strategy='auto' or 'text' for free-form text."
+            ) from exc
     original_chars = len(text)
     original_tokens = count_tokens(text, model=token_model)
 

--- a/src/contextweaver/context/firewall_api.py
+++ b/src/contextweaver/context/firewall_api.py
@@ -1,0 +1,256 @@
+"""Single-call context-firewall facade (issues #399, #403).
+
+The canonical firewall path goes through ``ContextManager.ingest_* ->
+build``, which is the right tool when you are compiling a *whole* phase prompt.
+But the most common integration question is narrower:
+
+    "I have one large tool-result dict/list — how do I shrink it before it
+    enters the LLM prompt, without rewriting my tool layer?"
+
+:func:`compact_tool_result` answers exactly that in one call.  It composes the
+firewall primitives:
+
+- deterministic **structured** field projection (issue #406) when you pass a
+  ``keep`` allow-list, or rule-based/LLM text summarisation otherwise;
+- a **schema-preserving pass-through** (issue #403): when the payload is under
+  threshold the original shape is returned unchanged, with firewall metadata
+  attached only on a reserved namespaced ``_cw`` sidecar key — never an
+  in-place rewrite of the caller's fields;
+- the built-in **token counter** (issue #405) so reported savings match what
+  callers measure;
+- a fail-closed **deterministic** mode (issue #404, on by default here) so
+  financial/regulated callers can guarantee no LLM touched the data.
+
+Example::
+
+    from contextweaver import compact_tool_result
+
+    out = compact_tool_result(
+        {"invoices": [...]},
+        threshold_chars=2000,
+        keep=["invoices[].invoiceNumber", "invoices[].amount", "invoices[].status"],
+    )
+    out.firewalled          # True
+    out.payload             # projected subset + {"_cw": {...}} sidecar
+    out.stats.tokens_saved  # how much stayed out of the prompt
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from contextweaver.envelope import FirewallStats
+from contextweaver.exceptions import ConfigError
+from contextweaver.protocols import ArtifactStore, Extractor, Summarizer
+from contextweaver.store.artifacts import InMemoryArtifactStore
+from contextweaver.tokens import count as count_tokens
+from contextweaver.types import ContextItem, ItemKind
+
+#: Reserved sidecar key for firewall metadata.  Chosen to be namespaced so it
+#: will not collide with caller fields (issue #403).
+CW_SIDECAR_KEY: str = "_cw"
+
+Strategy = Literal["auto", "structured", "text", "passthrough"]
+
+
+@dataclass
+class CompactResult:
+    """Result of :func:`compact_tool_result`.
+
+    Attributes:
+        firewalled: ``True`` when the payload was offloaded out-of-band;
+            ``False`` for the under-threshold pass-through.
+        payload: The object to hand to the LLM.  On pass-through this is the
+            caller's payload shape-unchanged (plus a ``_cw`` sidecar when it is
+            a dict).  When firewalled it is the projected subset (structured)
+            or a ``{"_cw_summary", "_cw_artifact_ref", "_cw"}`` envelope (text).
+        summary: The inline summary text, or ``None`` on pass-through.
+        facts: Structured facts derived from the payload (may be empty).
+        artifact_ref: Handle of the offloaded raw payload, or ``None``.
+        stats: The :class:`~contextweaver.envelope.FirewallStats` for this call.
+    """
+
+    firewalled: bool
+    payload: Any
+    summary: str | None
+    facts: list[str] = field(default_factory=list)
+    artifact_ref: str | None = None
+    stats: FirewallStats = field(
+        default_factory=lambda: FirewallStats(triggered=False, strategy="noop")
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-compatible dict."""
+        return {
+            "firewalled": self.firewalled,
+            "payload": self.payload,
+            "summary": self.summary,
+            "facts": list(self.facts),
+            "artifact_ref": self.artifact_ref,
+            "stats": self.stats.to_dict(),
+        }
+
+
+def _to_text(data: Any) -> tuple[str, str]:  # noqa: ANN401 — arbitrary JSON tool result
+    """Return ``(text, media_type)`` for *data* (deterministic JSON for non-str)."""
+    if isinstance(data, str):
+        return data, "text/plain"
+    return json.dumps(data, sort_keys=True, default=str), "application/json"
+
+
+def _sidecar(stats: FirewallStats) -> dict[str, Any]:
+    """Build the reserved ``_cw`` sidecar payload from *stats*."""
+    return {
+        "firewalled": stats.triggered,
+        "strategy": stats.strategy,
+        "artifact_ref": stats.artifact_ref,
+        "original_chars": stats.original_chars,
+        "summary_chars": stats.summary_chars,
+        "summarized_by_llm": stats.summarized_by_llm,
+    }
+
+
+def compact_tool_result(
+    data: dict[str, Any] | list[Any] | str,
+    *,
+    threshold_chars: int = 2000,
+    budget: int = 800,
+    strategy: Strategy = "auto",
+    keep: list[str] | None = None,
+    artifact_store: ArtifactStore | None = None,
+    summarizer: Summarizer | None = None,
+    extractor: Extractor | None = None,
+    deterministic: bool = True,
+    token_model: str | None = None,
+) -> CompactResult:
+    """Compact a single tool result in one call (firewall-only pattern).
+
+    Args:
+        data: The tool result — a dict, list, or string.
+        threshold_chars: Payloads at or below this size are passed through
+            unchanged (issue #403); larger payloads are firewalled.
+        budget: Soft token budget for the inline *text* summary.  When the text
+            summary would exceed it the summary is truncated.  Ignored for the
+            structured strategy (which is lossless within the allow-list).
+        strategy: ``"auto"`` (structured when *keep* is given, else text),
+            ``"structured"`` (requires *keep*), ``"text"`` (force summarisation),
+            or ``"passthrough"`` (never offload; only attach the sidecar).
+        keep: JSON path allow-list for structured projection (issue #406).
+        artifact_store: Where to offload the raw payload.  A private
+            :class:`~contextweaver.store.artifacts.InMemoryArtifactStore` is
+            created when ``None``; pass one to retain handles for ``drilldown``.
+        summarizer: Optional summariser for the text strategy.
+        extractor: Optional fact extractor for the text strategy.
+        deterministic: When ``True`` (default) the call fails closed rather than
+            invoking an LLM-backed *summarizer* (issue #404).
+        token_model: Optional model/encoding name for token counting (#405).
+
+    Returns:
+        A :class:`CompactResult`.
+
+    Raises:
+        ConfigError: If ``strategy="structured"`` without a non-empty *keep*.
+        DeterminismError: If ``deterministic=True`` and the text strategy would
+            invoke an LLM-backed summariser.
+    """
+    if strategy == "structured" and not keep:
+        raise ConfigError("strategy='structured' requires a non-empty `keep` allow-list")
+
+    text, media_type = _to_text(data)
+    original_chars = len(text)
+    original_tokens = count_tokens(text, model=token_model)
+
+    # Under threshold → schema-preserving pass-through for every strategy
+    # (issue #403); ``strategy="passthrough"`` forces it regardless of size.
+    # To force a firewall on a small payload, pass ``threshold_chars=0``.
+    passthrough = strategy == "passthrough" or original_chars <= threshold_chars
+
+    if passthrough:
+        stats = FirewallStats(
+            triggered=False,
+            strategy="passthrough",
+            threshold_chars=threshold_chars,
+            original_chars=original_chars,
+            original_tokens=original_tokens,
+            summary_chars=original_chars,
+            summary_tokens=original_tokens,
+        )
+        # Shape-preserving: attach the sidecar only to dicts; lists/strings are
+        # returned byte-identical so downstream field access never breaks (#403).
+        if isinstance(data, dict):
+            payload: Any = {**data, CW_SIDECAR_KEY: _sidecar(stats)}
+        else:
+            payload = data
+        return CompactResult(
+            firewalled=False, payload=payload, summary=None, artifact_ref=None, stats=stats
+        )
+
+    # Over threshold (or forced) — offload via the shared firewall primitive.
+    store = artifact_store if artifact_store is not None else InMemoryArtifactStore()
+    keep_for_call = keep if strategy in ("auto", "structured") else None
+    item = ContextItem(
+        id=f"compact:{original_chars}",
+        kind=ItemKind.tool_result,
+        text=text,
+        metadata={"media_type": media_type},
+    )
+    from contextweaver.context.firewall import apply_firewall
+
+    processed, envelope = apply_firewall(
+        item,
+        store,
+        summarizer=summarizer,
+        extractor=extractor,
+        deterministic=deterministic,
+        keep=keep_for_call,
+        threshold_chars=threshold_chars,
+    )
+    assert envelope is not None  # tool_result always produces an envelope here
+    stats = envelope.firewall_stats or FirewallStats(triggered=True, strategy="summary")
+    handle = stats.artifact_ref
+    summary = envelope.summary
+
+    if stats.strategy == "structured":
+        try:
+            projected = json.loads(summary)
+        except (json.JSONDecodeError, ValueError):
+            projected = summary
+        if isinstance(projected, dict):
+            payload = {**projected, CW_SIDECAR_KEY: _sidecar(stats)}
+        else:
+            payload = {"_cw_data": projected, CW_SIDECAR_KEY: _sidecar(stats)}
+    else:
+        summary = _truncate_to_budget(summary, budget, token_model)
+        stats.summary_chars = len(summary)
+        stats.summary_tokens = count_tokens(summary, model=token_model)
+        payload = {
+            "_cw_summary": summary,
+            "_cw_artifact_ref": handle,
+            CW_SIDECAR_KEY: _sidecar(stats),
+        }
+
+    return CompactResult(
+        firewalled=True,
+        payload=payload,
+        summary=summary,
+        facts=list(envelope.facts),
+        artifact_ref=handle,
+        stats=stats,
+    )
+
+
+def _truncate_to_budget(summary: str, budget: int, token_model: str | None) -> str:
+    """Truncate *summary* so its token count stays within *budget* (soft cap)."""
+    if budget <= 0 or count_tokens(summary, model=token_model) <= budget:
+        return summary
+    # Approximate: ~4 chars/token, then trim until under budget.
+    trimmed = summary[: max(budget * 4, 1)]
+    while trimmed and count_tokens(trimmed, model=token_model) > budget:
+        trimmed = trimmed[: max(len(trimmed) - 64, 0)]
+    return trimmed + "…"
+
+
+#: Alias matching the name suggested in issue #399.
+firewalled_tool_result = compact_tool_result

--- a/src/contextweaver/context/ingest.py
+++ b/src/contextweaver/context/ingest.py
@@ -14,7 +14,7 @@ from typing import Any, Literal
 
 from contextweaver.context.firewall import apply_firewall
 from contextweaver.context.views import ViewRegistry, generate_views
-from contextweaver.envelope import ResultEnvelope
+from contextweaver.envelope import FirewallStats, ResultEnvelope
 from contextweaver.protocols import (
     ArtifactStore,
     EventHook,
@@ -23,6 +23,8 @@ from contextweaver.protocols import (
     Summarizer,
     TokenEstimator,
 )
+from contextweaver.summarize.structured import StructuredFirewall
+from contextweaver.tokens import count as count_tokens
 from contextweaver.types import ArtifactRef, ContextItem, ItemKind
 
 logger = logging.getLogger(__name__)
@@ -118,6 +120,8 @@ def ingest_tool_result(
     tool_name: str = "",
     media_type: str = "text/plain",
     firewall_threshold: int = 2000,
+    deterministic: bool = False,
+    firewall: StructuredFirewall | None = None,
 ) -> tuple[ContextItem, ResultEnvelope]:
     """Ingest a raw tool result via :meth:`ContextManager.ingest_tool_result` logic."""
     item = ContextItem(
@@ -137,6 +141,9 @@ def ingest_tool_result(
             view_registry=view_registry,
             summarizer=summarizer,
             extractor=extractor,
+            deterministic=deterministic,
+            keep=firewall.keep if firewall is not None else None,
+            threshold_chars=firewall_threshold,
         )
         if envelope is None:
             # Shouldn't happen for tool_result items, but be safe
@@ -172,6 +179,7 @@ def ingest_tool_result(
         label=f"raw tool result for {item.id}",
     )
     views = generate_views(ref, raw_bytes, registry=view_registry)
+    _tokens = count_tokens(raw_output)
     envelope = ResultEnvelope(
         status=status,
         summary=raw_output,
@@ -179,6 +187,16 @@ def ingest_tool_result(
         artifacts=[ref],
         views=views,
         provenance={"source_item_id": item.id, "tool_name": tool_name},
+        firewall_stats=FirewallStats(
+            triggered=False,
+            strategy="passthrough",
+            threshold_chars=firewall_threshold,
+            original_chars=len(raw_output),
+            original_tokens=_tokens,
+            summary_chars=len(raw_output),
+            summary_tokens=_tokens,
+            artifact_ref=ref.handle,
+        ),
     )
     item = ContextItem(
         id=item.id,
@@ -210,6 +228,8 @@ def ingest_mcp_result(
     mcp_result: dict[str, Any],
     tool_name: str,
     firewall_threshold: int = 2000,
+    deterministic: bool = False,
+    firewall: StructuredFirewall | None = None,
 ) -> tuple[ContextItem, ResultEnvelope]:
     """Ingest an MCP result via :meth:`ContextManager.ingest_mcp_result` logic."""
     from contextweaver.adapters.mcp import mcp_result_to_envelope
@@ -247,6 +267,9 @@ def ingest_mcp_result(
             view_registry=None,
             summarizer=summarizer,
             extractor=extractor,
+            deterministic=deterministic,
+            keep=firewall.keep if firewall is not None else None,
+            threshold_chars=firewall_threshold,
         )
         if fw_envelope is not None:
             # Merge: keep MCP artifacts, use firewall summary/facts, preserve views
@@ -257,6 +280,7 @@ def ingest_mcp_result(
                 artifacts=list(envelope.artifacts) + list(fw_envelope.artifacts),
                 provenance=envelope.provenance,
                 views=list(envelope.views) + list(fw_envelope.views),
+                firewall_stats=fw_envelope.firewall_stats,
             )
         item = processed
 

--- a/src/contextweaver/context/manager.py
+++ b/src/contextweaver/context/manager.py
@@ -87,6 +87,13 @@ class ContextManager(_IngestMixin, _BuildMixin, _RoutingMixin):
             :class:`~contextweaver.routing.router.Router` and
             :class:`~contextweaver.routing.tree.TreeBuilder` directly via
             their ``routing_config`` parameters.
+        deterministic: Keyword-only.  When ``True`` (issue #404) the context
+            firewall *fails closed*: any build or ingest that would pass data
+            through an LLM-backed summariser raises
+            :class:`~contextweaver.exceptions.DeterminismError` instead.  The
+            default rule-based and structured firewall paths are unaffected.
+            Suitable for regulated/financial workloads that must guarantee no
+            model touched the data.
     """
 
     def __init__(
@@ -104,6 +111,7 @@ class ContextManager(_IngestMixin, _BuildMixin, _RoutingMixin):
         *,
         metrics: MetricsCollector | None = None,
         profile: ProfileConfig | None = None,
+        deterministic: bool = False,
     ) -> None:
         _stores = stores or StoreBundle()
         self._event_log: EventLog = event_log or _stores.event_log or InMemoryEventLog()
@@ -128,6 +136,7 @@ class ContextManager(_IngestMixin, _BuildMixin, _RoutingMixin):
         self._metrics: MetricsCollector | None = metrics
         self._profile: ProfileConfig | None = profile
         self._mode: Mode = profile.mode if profile is not None else Mode.strict
+        self._deterministic: bool = deterministic
 
     # ------------------------------------------------------------------
     # Properties
@@ -182,6 +191,11 @@ class ContextManager(_IngestMixin, _BuildMixin, _RoutingMixin):
     def budget(self) -> ContextBudget:
         """The active per-phase :class:`~contextweaver.config.ContextBudget`."""
         return self._budget
+
+    @property
+    def deterministic(self) -> bool:
+        """Whether the firewall fails closed on LLM summarisation (issue #404)."""
+        return self._deterministic
 
     # ------------------------------------------------------------------
     # Drilldown

--- a/src/contextweaver/envelope.py
+++ b/src/contextweaver/envelope.py
@@ -21,6 +21,102 @@ from contextweaver.types import ArtifactRef, Phase, SelectableItem, ViewSpec
 #: backwards-incompatible field changes.
 BUILD_STATS_REPORT_VERSION: int = 1
 
+#: Canonical firewall strategy labels recorded on :class:`FirewallStats`
+#: (issues #402 / #404 / #406).
+#:
+#: - ``"noop"`` — firewall not applicable (e.g. non-``tool_result`` item).
+#: - ``"passthrough"`` — under threshold; caller payload returned shape-unchanged
+#:   (issue #403).
+#: - ``"summary"`` — deterministic, rule-based text summary (no LLM).
+#: - ``"structured"`` — lossless JSON field projection (issue #406; no LLM).
+#: - ``"llm_summary"`` — model-assisted summary (issue #384; LLM touched the data).
+FIREWALL_STRATEGIES: tuple[str, ...] = (
+    "noop",
+    "passthrough",
+    "summary",
+    "structured",
+    "llm_summary",
+)
+
+
+@dataclass
+class FirewallStats:
+    """First-class diagnostics for a single context-firewall decision (issue #402).
+
+    Answers the two questions an integrator cares about that the aggregate
+    :class:`BuildStats` counters cannot: **was the firewall triggered at all?**
+    and **if so, how much was saved?** — in both characters and tokens.
+
+    The ``strategy`` and ``summarized_by_llm`` fields double as the
+    determinism provenance signal (issue #404): a value of ``"structured"`` /
+    ``"summary"`` with ``summarized_by_llm=False`` is a model-free,
+    byte-deterministic path suitable for citing in a compliance review;
+    ``"llm_summary"`` means a model produced the inline representation.
+
+    Attributes:
+        triggered: ``True`` when the firewall offloaded the payload out-of-band
+            (``strategy`` in ``{"summary", "structured", "llm_summary"}``);
+            ``False`` for ``"noop"`` / ``"passthrough"``.
+        strategy: One of :data:`FIREWALL_STRATEGIES`.
+        threshold_chars: The character threshold the payload was compared
+            against.  ``0`` when not applicable.
+        original_chars / original_tokens: Size of the raw payload.
+        summary_chars / summary_tokens: Size of the inline representation that
+            reached the prompt.
+        artifact_ref: Handle of the offloaded raw payload, or ``None`` when the
+            payload was passed through / not stored.
+        summarized_by_llm: ``True`` only when an LLM produced the summary.
+    """
+
+    triggered: bool
+    strategy: str
+    threshold_chars: int = 0
+    original_chars: int = 0
+    original_tokens: int = 0
+    summary_chars: int = 0
+    summary_tokens: int = 0
+    artifact_ref: str | None = None
+    summarized_by_llm: bool = False
+
+    @property
+    def chars_saved(self) -> int:
+        """Characters kept out of the prompt (``original - summary``, ≥ 0)."""
+        return max(self.original_chars - self.summary_chars, 0)
+
+    @property
+    def tokens_saved(self) -> int:
+        """Tokens kept out of the prompt (``original - summary``, ≥ 0)."""
+        return max(self.original_tokens - self.summary_tokens, 0)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-compatible dict."""
+        return {
+            "triggered": self.triggered,
+            "strategy": self.strategy,
+            "threshold_chars": self.threshold_chars,
+            "original_chars": self.original_chars,
+            "original_tokens": self.original_tokens,
+            "summary_chars": self.summary_chars,
+            "summary_tokens": self.summary_tokens,
+            "artifact_ref": self.artifact_ref,
+            "summarized_by_llm": self.summarized_by_llm,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FirewallStats:
+        """Deserialise from a JSON-compatible dict."""
+        return cls(
+            triggered=bool(data.get("triggered", False)),
+            strategy=str(data.get("strategy", "noop")),
+            threshold_chars=int(data.get("threshold_chars", 0)),
+            original_chars=int(data.get("original_chars", 0)),
+            original_tokens=int(data.get("original_tokens", 0)),
+            summary_chars=int(data.get("summary_chars", 0)),
+            summary_tokens=int(data.get("summary_tokens", 0)),
+            artifact_ref=data.get("artifact_ref"),
+            summarized_by_llm=bool(data.get("summarized_by_llm", False)),
+        )
+
 
 @dataclass
 class ResultEnvelope:
@@ -36,10 +132,11 @@ class ResultEnvelope:
     artifacts: list[ArtifactRef] = field(default_factory=list)
     views: list[ViewSpec] = field(default_factory=list)
     provenance: dict[str, Any] = field(default_factory=dict)
+    firewall_stats: FirewallStats | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise to a JSON-compatible dict."""
-        return {
+        out: dict[str, Any] = {
             "status": self.status,
             "summary": self.summary,
             "facts": list(self.facts),
@@ -47,10 +144,14 @@ class ResultEnvelope:
             "views": [v.to_dict() for v in self.views],
             "provenance": dict(self.provenance),
         }
+        if self.firewall_stats is not None:
+            out["firewall_stats"] = self.firewall_stats.to_dict()
+        return out
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ResultEnvelope:
         """Deserialise from a JSON-compatible dict."""
+        fw_raw = data.get("firewall_stats")
         return cls(
             status=data["status"],
             summary=data["summary"],
@@ -58,6 +159,7 @@ class ResultEnvelope:
             artifacts=[ArtifactRef.from_dict(a) for a in data.get("artifacts", [])],
             views=[ViewSpec.from_dict(v) for v in data.get("views", [])],
             provenance=dict(data.get("provenance", {})),
+            firewall_stats=FirewallStats.from_dict(fw_raw) if fw_raw else None,
         )
 
 
@@ -73,6 +175,10 @@ class BuildStats:
     dedup_removed: int = 0
     dependency_closures: int = 0
     header_footer_tokens: int = 0
+    #: One :class:`FirewallStats` per item the firewall offloaded during the
+    #: build (issue #402).  Empty when nothing was firewalled.  Always-on and
+    #: cheap — populated from the build's :class:`ResultEnvelope` list.
+    firewall_events: list[FirewallStats] = field(default_factory=list)
 
     @property
     def prompt_tokens(self) -> int:
@@ -86,6 +192,39 @@ class BuildStats:
         """
         return sum(self.tokens_per_section.values()) + self.header_footer_tokens
 
+    def firewall_summary(self) -> FirewallStats:
+        """Aggregate every :attr:`firewall_events` entry into one :class:`FirewallStats`.
+
+        Returns a single roll-up answering "did the firewall fire, and how much
+        did it save across this build?" (issue #402):
+
+        - ``triggered`` — ``True`` if any event fired.
+        - ``original_*`` / ``summary_*`` — summed across events.
+        - ``strategy`` — the common strategy, or ``"mixed"`` when events used
+          more than one; ``"noop"`` when there were none.
+        - ``summarized_by_llm`` — ``True`` if any event used an LLM.
+        - ``artifact_ref`` — the first event's handle (``None`` when none).
+
+        For per-item attribution, read :attr:`firewall_events` directly.
+        """
+        events = self.firewall_events
+        if not events:
+            return FirewallStats(triggered=False, strategy="noop")
+        strategies = {e.strategy for e in events}
+        strategy = next(iter(strategies)) if len(strategies) == 1 else "mixed"
+        first_ref = next((e.artifact_ref for e in events if e.artifact_ref), None)
+        return FirewallStats(
+            triggered=any(e.triggered for e in events),
+            strategy=strategy,
+            threshold_chars=max((e.threshold_chars for e in events), default=0),
+            original_chars=sum(e.original_chars for e in events),
+            original_tokens=sum(e.original_tokens for e in events),
+            summary_chars=sum(e.summary_chars for e in events),
+            summary_tokens=sum(e.summary_tokens for e in events),
+            artifact_ref=first_ref,
+            summarized_by_llm=any(e.summarized_by_llm for e in events),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         """Serialise to a JSON-compatible dict."""
         return {
@@ -97,6 +236,7 @@ class BuildStats:
             "dedup_removed": self.dedup_removed,
             "dependency_closures": self.dependency_closures,
             "header_footer_tokens": self.header_footer_tokens,
+            "firewall_events": [e.to_dict() for e in self.firewall_events],
         }
 
     @classmethod
@@ -111,6 +251,7 @@ class BuildStats:
             dedup_removed=int(data.get("dedup_removed", 0)),
             dependency_closures=int(data.get("dependency_closures", 0)),
             header_footer_tokens=int(data.get("header_footer_tokens", 0)),
+            firewall_events=[FirewallStats.from_dict(e) for e in data.get("firewall_events", [])],
         )
 
     def report(

--- a/src/contextweaver/exceptions.py
+++ b/src/contextweaver/exceptions.py
@@ -47,6 +47,16 @@ class ConfigError(ContextWeaverError):
     """Raised when a configuration value or preset name is invalid."""
 
 
+class DeterminismError(ContextWeaverError):
+    """Raised when a ``deterministic=True`` firewall path would invoke an LLM.
+
+    The context firewall's ``deterministic`` mode (issue #404) *fails closed*:
+    rather than silently summarising data through a model, it raises this error
+    so regulated/financial/legal callers can guarantee — and prove — that no
+    user or account data was passed through a summarisation model.
+    """
+
+
 class PathInvalidError(CatalogError):
     """Raised when a ``tool_browse`` path violates the §3.2 grammar."""
 

--- a/src/contextweaver/extras/llm_summarizer.py
+++ b/src/contextweaver/extras/llm_summarizer.py
@@ -90,6 +90,11 @@ class LlmSummarizer:
             :class:`~contextweaver.summarize.rules.RuleBasedSummarizer`.
     """
 
+    #: Marks this summariser as LLM-backed so the context firewall's
+    #: ``deterministic=True`` mode (issue #404) can fail closed rather than
+    #: silently passing data through a model.
+    is_llm: bool = True
+
     def __init__(
         self,
         call_fn: Callable[[str], str],
@@ -130,6 +135,10 @@ class LlmExtractor:
             ``call_fn`` raises or yields no facts.  Defaults to a
             :class:`~contextweaver.summarize.extract.StructuredExtractor`.
     """
+
+    #: Marks this extractor as LLM-backed (issue #404), mirroring
+    #: :attr:`LlmSummarizer.is_llm` for callers that introspect provenance.
+    is_llm: bool = True
 
     def __init__(
         self,

--- a/src/contextweaver/summarize/__init__.py
+++ b/src/contextweaver/summarize/__init__.py
@@ -14,14 +14,18 @@ from contextweaver.summarize.extract import (
     extract_numbered_list,
 )
 from contextweaver.summarize.rules import RuleBasedSummarizer, RuleEngine, SummarizationRule
+from contextweaver.summarize.structured import StructuredFirewall, parse_path, project
 
 __all__ = [
     "RuleBasedSummarizer",
     "RuleEngine",
     "StructuredExtractor",
+    "StructuredFirewall",
     "SummarizationRule",
     "extract_bullet_list",
     "extract_facts",
     "extract_key_value_pairs",
     "extract_numbered_list",
+    "parse_path",
+    "project",
 ]

--- a/src/contextweaver/summarize/structured.py
+++ b/src/contextweaver/summarize/structured.py
@@ -1,0 +1,184 @@
+"""Structured (lossless) firewall projection for contextweaver (issue #406).
+
+The text-summarising firewall is the wrong primitive for **structured JSON
+tool results** — the dominant shape for line-of-business agents (billing,
+invoicing, CRM, catalog lookups).  For those, the correct reduction is
+**field allow-listing / projection**: keep an allow-listed set of JSON paths
+inline, offload everything else to the artifact store, and make the dropped
+data retrievable by selector via the existing ``drilldown`` protocol.
+
+This is *lossless within the chosen schema*, deterministic, and auditable —
+properties text summarisation cannot provide, and it performs **no LLM call**
+(pure structural transform).
+
+Path grammar
+------------
+
+A path is a dotted sequence of object keys.  A ``[]`` suffix on a segment
+expands across every element of a list and descends into the remaining path
+for each element::
+
+    result.response.invoices[].invoiceNumber
+    result.response.invoices[].amount
+    result.response.total
+
+A path with no further segments keeps the matched value whole (object, array,
+or scalar).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from contextweaver.exceptions import ConfigError
+from contextweaver.summarize.extract import StructuredExtractor
+
+# Sentinel distinguishing "path did not match" from a legitimately-present
+# ``None`` value in the source payload.
+_MISSING: Any = object()
+
+#: Marker segment produced by :func:`parse_path` for a ``[]`` list-expansion.
+_LIST = "[]"
+
+
+def parse_path(path: str) -> list[str]:
+    """Split a dotted allow-list *path* into key / ``[]`` segments.
+
+    Args:
+        path: A path such as ``"result.response.invoices[].amount"``.
+
+    Returns:
+        The ordered segments, e.g.
+        ``["result", "response", "invoices", "[]", "amount"]``.
+
+    Raises:
+        ConfigError: If *path* is empty or whitespace-only.
+    """
+    cleaned = path.strip()
+    if not cleaned:
+        raise ConfigError("StructuredFirewall keep-path must be a non-empty string")
+    segments: list[str] = []
+    for part in cleaned.split("."):
+        token = part
+        while token.endswith(_LIST):
+            key = token[: -len(_LIST)]
+            if key:
+                segments.append(key)
+            segments.append(_LIST)
+            token = ""
+        if token:
+            segments.append(token)
+    return segments
+
+
+def _extract(obj: Any, segments: list[str]) -> Any:  # noqa: ANN401 — arbitrary JSON
+    """Return the pruned substructure of *obj* for one path's *segments*.
+
+    Returns :data:`_MISSING` when the path does not resolve against *obj*.
+    """
+    if not segments:
+        return obj
+    head, rest = segments[0], segments[1:]
+    if head == _LIST:
+        if not isinstance(obj, list):
+            return _MISSING
+        out: list[Any] = []
+        for element in obj:
+            sub = _extract(element, rest)
+            out.append(None if sub is _MISSING else sub)
+        return out
+    if isinstance(obj, dict) and head in obj:
+        sub = _extract(obj[head], rest)
+        if sub is _MISSING:
+            return _MISSING
+        return {head: sub}
+    return _MISSING
+
+
+def _merge(a: Any, b: Any) -> Any:  # noqa: ANN401 — arbitrary JSON
+    """Deep-merge two pruned substructures (later allow-list paths fold in)."""
+    if isinstance(a, dict) and isinstance(b, dict):
+        merged = dict(a)
+        for key, value in b.items():
+            merged[key] = _merge(merged[key], value) if key in merged else value
+        return merged
+    if isinstance(a, list) and isinstance(b, list):
+        return [
+            _merge(a[i], b[i]) if i < len(a) and i < len(b) else (a[i] if i < len(a) else b[i])
+            for i in range(max(len(a), len(b)))
+        ]
+    # Disjoint allow-list paths should not collide on a scalar; if they do,
+    # the most-recent extraction wins deterministically.
+    return b
+
+
+def project(obj: Any, keep: list[str]) -> Any:  # noqa: ANN401 — arbitrary JSON
+    """Project *obj* down to the allow-listed *keep* paths (lossless subset).
+
+    Args:
+        obj: The decoded JSON payload (``dict`` / ``list`` / scalar).
+        keep: Allow-listed paths in :func:`parse_path` grammar.
+
+    Returns:
+        A new structure containing only the allow-listed paths, preserving the
+        original nesting.  Paths that do not resolve are skipped.  Returns an
+        empty ``dict`` when nothing matches.
+    """
+    result: Any = _MISSING
+    for path in keep:
+        extracted = _extract(obj, parse_path(path))
+        if extracted is _MISSING:
+            continue
+        result = extracted if result is _MISSING else _merge(result, extracted)
+    return {} if result is _MISSING else result
+
+
+@dataclass
+class StructuredFirewall:
+    """A non-summarising firewall strategy: keep allow-listed JSON paths inline.
+
+    Pass an instance to the single-call
+    :func:`~contextweaver.context.firewall_api.compact_tool_result` facade or to
+    :meth:`ContextManager.ingest_tool_result` / ``ingest_mcp_result`` (via the
+    ``firewall=`` argument) to select deterministic field projection instead of
+    text summarisation.  The full payload is still offloaded to the artifact
+    store so dropped fields stay retrievable through ``drilldown``.
+
+    Attributes:
+        keep: Allow-listed paths (e.g.
+            ``["result.response.invoices[].amount", "result.response.total"]``).
+            Must be non-empty.
+        max_fact_chars: Upper bound on the total characters of the derived fact
+            list (forwarded to :class:`StructuredExtractor`).
+    """
+
+    keep: list[str] = field(default_factory=list)
+    max_fact_chars: int = 500
+
+    def __post_init__(self) -> None:
+        """Validate the allow-list is non-empty (security-grade: fail loud)."""
+        if not self.keep:
+            raise ConfigError(
+                "StructuredFirewall requires a non-empty keep allow-list; "
+                "an empty allow-list would drop the entire payload from the prompt"
+            )
+        for path in self.keep:
+            parse_path(path)  # validate grammar eagerly
+
+    def compact(self, data: Any) -> tuple[Any, list[str]]:  # noqa: ANN401 — arbitrary JSON
+        """Project *data* and derive a deterministic fact list.
+
+        Args:
+            data: The decoded JSON payload to project.
+
+        Returns:
+            A ``(projected, facts)`` tuple — *projected* is the lossless inline
+            subset; *facts* are structured facts derived from it.
+        """
+        projected = project(data, self.keep)
+        facts = StructuredExtractor(max_chars=self.max_fact_chars).extract(
+            json.dumps(projected, sort_keys=True), {}
+        )
+        return projected, facts

--- a/src/contextweaver/tokens.py
+++ b/src/contextweaver/tokens.py
@@ -1,0 +1,89 @@
+"""Built-in token counting for contextweaver (issue #405).
+
+Token counting is core to a *context* library, yet callers previously had to
+bring and wire their own ``tiktoken`` to measure before/after savings — a
+footgun (a missing import surfaced only when the firewall fired, then got
+swallowed by a broad ``except``).  This module owns the dependency: it exposes
+a first-class counter so callers never import ``tiktoken`` directly, and the
+firewall/``BuildStats`` numbers are computed through the *same* counter so
+reported savings match what callers measure.
+
+``tiktoken`` is already a **core** runtime dependency (see ``pyproject.toml``),
+so :func:`count` resolves an exact tokenizer by default and never hard-fails on
+import.  In offline / air-gapped environments :class:`TiktokenEstimator`
+transparently degrades to the character heuristic, so token counting always
+returns a value.  The no-op ``contextweaver[tokenizers]`` extra documents this
+contract for callers who prefer to pin the tokenizer explicitly.
+
+Example::
+
+    from contextweaver import tokens
+
+    tokens.count("hello world")                # exact (cl100k_base) when available
+    tokens.count("¡hola!", model="gpt-4o")     # model-specific tokenizer
+    counter = tokens.get_token_counter()       # reuse a cached TokenEstimator
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from contextweaver.protocols import (
+    CharDivFourEstimator,
+    TiktokenEstimator,
+    TokenEstimator,
+)
+
+#: Public alias — a token counter is exactly a
+#: :class:`~contextweaver.protocols.TokenEstimator` (``estimate(text) -> int``).
+#: Exposed under the friendlier "counter" name so callers reaching for token
+#: counting do not have to discover the "estimator" vocabulary first.
+TokenCounter = TokenEstimator
+
+#: Default tiktoken encoding used when no model is specified.  ``cl100k_base``
+#: backs GPT-3.5/4-class models and is a sensible cross-model default; pass an
+#: explicit ``model`` to :func:`count` / :func:`get_token_counter` for a
+#: model-specific tokenizer.
+DEFAULT_ENCODING: str = "cl100k_base"
+
+
+@lru_cache(maxsize=16)
+def get_token_counter(model: str | None = None) -> TokenEstimator:
+    """Return a cached :class:`TokenCounter` for *model*.
+
+    Args:
+        model: A model name (e.g. ``"gpt-4o"``) or a raw tiktoken encoding name
+            (e.g. ``"cl100k_base"``).  ``None`` uses :data:`DEFAULT_ENCODING`.
+
+    Returns:
+        A :class:`~contextweaver.protocols.TokenEstimator`.  The result is
+        memoised per *model* so repeated calls reuse the loaded encoding.  In
+        offline environments the underlying :class:`TiktokenEstimator` falls
+        back to the character heuristic; callers always get a usable counter.
+    """
+    return TiktokenEstimator(model or DEFAULT_ENCODING)
+
+
+def count(text: str, *, model: str | None = None) -> int:
+    """Return the token count for *text* using the built-in counter.
+
+    Args:
+        text: The text to measure.
+        model: Optional model / encoding name (see :func:`get_token_counter`).
+            ``None`` uses the default tiktoken encoding.
+
+    Returns:
+        The estimated token count.  Exact when the tiktoken encoding is
+        available; an approximation (``len(text) // 4``) when offline.
+    """
+    return get_token_counter(model).estimate(text)
+
+
+def heuristic_counter() -> TokenEstimator:
+    """Return the dependency-free character-heuristic counter.
+
+    Useful when a caller explicitly wants the ``len(text) // 4`` approximation
+    (e.g. byte-deterministic counts that never touch the tiktoken cache) rather
+    than the tokenizer-backed default.
+    """
+    return CharDivFourEstimator()

--- a/tests/fixtures/golden/route_prompt/basic.json
+++ b/tests/fixtures/golden/route_prompt/basic.json
@@ -54,6 +54,7 @@
       "dependency_closures": 0,
       "dropped_count": 0,
       "dropped_reasons": {},
+      "firewall_events": [],
       "header_footer_tokens": 81,
       "included_count": 1,
       "tokens_per_section": {

--- a/tests/test_firewall_api.py
+++ b/tests/test_firewall_api.py
@@ -125,6 +125,14 @@ def test_structured_strategy_requires_keep() -> None:
         compact_tool_result(_BIG, strategy="structured")
 
 
+def test_structured_strategy_on_non_json_raises_instead_of_downgrading() -> None:
+    # An explicit structured request on free-form text must fail loud rather
+    # than silently degrade to a text summary (projection needs JSON).
+    free_text = "lorem ipsum " * 500
+    with pytest.raises(ConfigError):
+        compact_tool_result(free_text, strategy="structured", keep=["a.b"])
+
+
 # ---------------------------------------------------------------------------
 # Review hardening (PR #420): unique handles, JSON-serialisability, empty keep
 # ---------------------------------------------------------------------------

--- a/tests/test_firewall_api.py
+++ b/tests/test_firewall_api.py
@@ -1,0 +1,165 @@
+"""Tests for the single-call firewall facade (issues #399, #402, #403, #404, #405, #406)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from contextweaver import compact_tool_result, firewalled_tool_result
+from contextweaver.context.firewall_api import CW_SIDECAR_KEY, CompactResult
+from contextweaver.exceptions import ConfigError, DeterminismError
+from contextweaver.store.artifacts import InMemoryArtifactStore
+
+_BIG = {"invoices": [{"invoiceNumber": f"A-{i}", "amount": i, "status": "due"} for i in range(200)]}
+
+
+class _FakeLlmSummarizer:
+    """Stand-in LLM summariser flagged via the ``is_llm`` provenance marker."""
+
+    is_llm = True
+
+    def summarize(self, raw: str, metadata: dict) -> str:
+        return "LLM SUMMARY"
+
+
+# ---------------------------------------------------------------------------
+# #403 — schema-preserving pass-through
+# ---------------------------------------------------------------------------
+
+
+def test_passthrough_preserves_dict_shape_with_sidecar() -> None:
+    data = {"response": {"x": 1, "y": 2}}
+    out = compact_tool_result(data, threshold_chars=2000)
+    assert out.firewalled is False
+    # Caller fields are byte-identical; only a namespaced sidecar is added.
+    assert out.payload["response"] == {"x": 1, "y": 2}
+    assert out.payload[CW_SIDECAR_KEY]["firewalled"] is False
+    assert out.payload[CW_SIDECAR_KEY]["strategy"] == "passthrough"
+    # Original input dict is not mutated.
+    assert CW_SIDECAR_KEY not in data
+
+
+def test_passthrough_does_not_mutate_input() -> None:
+    data = {"a": 1}
+    compact_tool_result(data, threshold_chars=2000)
+    assert data == {"a": 1}
+
+
+def test_passthrough_list_returned_unchanged() -> None:
+    data = [1, 2, 3]
+    out = compact_tool_result(data, threshold_chars=2000)
+    assert out.firewalled is False
+    assert out.payload == [1, 2, 3]
+    assert out.payload is data
+
+
+def test_explicit_passthrough_strategy_never_offloads_even_when_large() -> None:
+    out = compact_tool_result(_BIG, strategy="passthrough")
+    assert out.firewalled is False
+    assert out.stats.triggered is False
+    assert out.payload["invoices"] == _BIG["invoices"]
+
+
+# ---------------------------------------------------------------------------
+# #399 — single-call firewall + #402 stats
+# ---------------------------------------------------------------------------
+
+
+def test_text_strategy_offloads_and_reports_stats() -> None:
+    store = InMemoryArtifactStore()
+    out = compact_tool_result(_BIG, threshold_chars=100, strategy="text", artifact_store=store)
+    assert out.firewalled is True
+    assert out.summary is not None
+    assert "_cw_summary" in out.payload
+    assert out.payload["_cw_artifact_ref"] == out.artifact_ref
+    # #402: stats answer "triggered?" and "how much saved?"
+    assert out.stats.triggered is True
+    assert out.stats.strategy == "summary"
+    assert out.stats.original_chars > out.stats.summary_chars
+    assert out.stats.chars_saved > 0
+    assert out.stats.tokens_saved >= 0
+    # Raw payload retained out-of-band.
+    assert store.exists(out.artifact_ref)
+
+
+def test_compact_result_to_dict_round_trips_stats() -> None:
+    out = compact_tool_result(_BIG, threshold_chars=100, strategy="text")
+    d = out.to_dict()
+    assert d["firewalled"] is True
+    assert d["stats"]["strategy"] == "summary"
+    assert isinstance(out, CompactResult)
+
+
+def test_firewalled_tool_result_is_alias() -> None:
+    assert firewalled_tool_result is compact_tool_result
+
+
+# ---------------------------------------------------------------------------
+# #406 — structured (lossless) firewall via the facade
+# ---------------------------------------------------------------------------
+
+
+def test_structured_strategy_projects_and_keeps_raw_retrievable() -> None:
+    store = InMemoryArtifactStore()
+    out = compact_tool_result(
+        _BIG,
+        threshold_chars=100,
+        strategy="structured",
+        keep=["invoices[].invoiceNumber", "invoices[].amount"],
+        artifact_store=store,
+    )
+    assert out.firewalled is True
+    assert out.stats.strategy == "structured"
+    assert out.stats.summarized_by_llm is False
+    # Allow-listed fields are inline; `status` is dropped from the prompt view.
+    first = out.payload["invoices"][0]
+    assert set(first) == {"invoiceNumber", "amount"}
+    # Dropped fields remain retrievable via drilldown on the stored raw payload.
+    raw = json.loads(store.get(out.artifact_ref).decode("utf-8"))
+    assert raw["invoices"][0]["status"] == "due"
+
+
+def test_structured_strategy_requires_keep() -> None:
+    with pytest.raises(ConfigError):
+        compact_tool_result(_BIG, strategy="structured")
+
+
+# ---------------------------------------------------------------------------
+# #404 — determinism guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_default_raises_on_llm_summarizer() -> None:
+    with pytest.raises(DeterminismError):
+        compact_tool_result(
+            _BIG, threshold_chars=100, strategy="text", summarizer=_FakeLlmSummarizer()
+        )
+
+
+def test_non_deterministic_allows_llm_summarizer() -> None:
+    out = compact_tool_result(
+        _BIG,
+        threshold_chars=100,
+        strategy="text",
+        summarizer=_FakeLlmSummarizer(),
+        deterministic=False,
+    )
+    assert out.stats.summarized_by_llm is True
+    assert out.stats.strategy == "llm_summary"
+    assert out.payload["_cw_summary"] == "LLM SUMMARY"
+
+
+def test_structured_is_model_free_under_deterministic() -> None:
+    # An LLM summariser is supplied, but the structured path never calls it,
+    # so deterministic=True must NOT raise.
+    out = compact_tool_result(
+        _BIG,
+        threshold_chars=100,
+        strategy="structured",
+        keep=["invoices[].amount"],
+        summarizer=_FakeLlmSummarizer(),
+        deterministic=True,
+    )
+    assert out.stats.strategy == "structured"
+    assert out.stats.summarized_by_llm is False

--- a/tests/test_firewall_api.py
+++ b/tests/test_firewall_api.py
@@ -126,6 +126,47 @@ def test_structured_strategy_requires_keep() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Review hardening (PR #420): unique handles, JSON-serialisability, empty keep
+# ---------------------------------------------------------------------------
+
+
+def test_same_length_payloads_get_distinct_handles_in_shared_store() -> None:
+    # Two different payloads of the *same* serialised length must not collide
+    # on the artifact handle when a store is reused across calls.
+    store = InMemoryArtifactStore()
+    a = {"k": "A" * 5000}
+    b = {"k": "B" * 5000}
+    out_a = compact_tool_result(a, threshold_chars=100, strategy="text", artifact_store=store)
+    out_b = compact_tool_result(b, threshold_chars=100, strategy="text", artifact_store=store)
+    assert out_a.artifact_ref != out_b.artifact_ref
+    assert "A" * 5000 in store.get(out_a.artifact_ref).decode("utf-8")
+    assert "B" * 5000 in store.get(out_b.artifact_ref).decode("utf-8")
+
+
+def test_handle_is_deterministic_for_identical_payloads() -> None:
+    payload = {"k": "Z" * 5000}
+    h1 = compact_tool_result(payload, threshold_chars=100, strategy="text").artifact_ref
+    h2 = compact_tool_result(payload, threshold_chars=100, strategy="text").artifact_ref
+    assert h1 == h2
+
+
+def test_non_json_serialisable_input_raises_config_error() -> None:
+    with pytest.raises(ConfigError):
+        compact_tool_result({"bad": {1, 2, 3}}, threshold_chars=0)
+
+
+def test_empty_keep_does_not_select_structured_or_swallow_error() -> None:
+    # An empty allow-list means "no structured projection" — the call must fall
+    # through to a clean summary (status ok, facts extracted), not a swallowed
+    # ConfigError that downgrades to a partial summary.
+    out = compact_tool_result(
+        {"status": "ok", "count": 5}, threshold_chars=0, strategy="auto", keep=[]
+    )
+    assert out.firewalled is True
+    assert out.stats.strategy == "summary"
+
+
+# ---------------------------------------------------------------------------
 # #404 — determinism guarantee
 # ---------------------------------------------------------------------------
 

--- a/tests/test_firewall_stats.py
+++ b/tests/test_firewall_stats.py
@@ -77,6 +77,17 @@ def test_apply_firewall_structured_strategy_via_keep() -> None:
     assert env.summary == '{"a": {"keep": 1}}'
 
 
+def test_apply_firewall_empty_keep_falls_through_to_summary() -> None:
+    # keep=[] must NOT select the structured strategy (which would raise inside
+    # the projection and get swallowed into a partial summary).
+    item = ContextItem(id="rk", kind=ItemKind.tool_result, text="status: ok\ncount: 5")
+    _, env = apply_firewall(item, InMemoryArtifactStore(), keep=[])
+    assert env is not None and env.firewall_stats is not None
+    assert env.firewall_stats.strategy == "summary"
+    assert env.status == "ok"
+    assert len(env.facts) >= 1
+
+
 def test_apply_firewall_deterministic_raises_on_llm() -> None:
     item = ContextItem(id="r3", kind=ItemKind.tool_result, text="some output")
     with pytest.raises(DeterminismError):

--- a/tests/test_firewall_stats.py
+++ b/tests/test_firewall_stats.py
@@ -1,0 +1,179 @@
+"""Tests for FirewallStats + BuildStats/firewall integration (#402, #404, #406)."""
+
+from __future__ import annotations
+
+import pytest
+
+from contextweaver import BuildStats, ContextManager, FirewallStats
+from contextweaver.context.firewall import apply_firewall
+from contextweaver.exceptions import DeterminismError
+from contextweaver.store.artifacts import InMemoryArtifactStore
+from contextweaver.types import ContextItem, ItemKind, Phase
+
+
+class _FakeLlmSummarizer:
+    is_llm = True
+
+    def summarize(self, raw: str, metadata: dict) -> str:
+        return "LLM SUMMARY"
+
+
+# ---------------------------------------------------------------------------
+# FirewallStats dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_firewall_stats_round_trips() -> None:
+    fs = FirewallStats(
+        triggered=True,
+        strategy="structured",
+        threshold_chars=2000,
+        original_chars=7304,
+        original_tokens=2549,
+        summary_chars=186,
+        summary_tokens=47,
+        artifact_ref="artifact:tr_invoices",
+        summarized_by_llm=False,
+    )
+    assert FirewallStats.from_dict(fs.to_dict()) == fs
+
+
+def test_firewall_stats_savings_properties_clamp_at_zero() -> None:
+    fs = FirewallStats(
+        triggered=True,
+        strategy="summary",
+        original_chars=100,
+        original_tokens=25,
+        summary_chars=10,
+        summary_tokens=3,
+    )
+    assert fs.chars_saved == 90
+    assert fs.tokens_saved == 22
+    # Pass-through (summary == original) never reports negative savings.
+    noop = FirewallStats(triggered=False, strategy="passthrough", original_chars=5, summary_chars=5)
+    assert noop.chars_saved == 0
+
+
+# ---------------------------------------------------------------------------
+# apply_firewall now emits FirewallStats (#402) and honours determinism (#404)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_firewall_emits_firewall_stats() -> None:
+    item = ContextItem(id="r1", kind=ItemKind.tool_result, text="x" * 5000)
+    env = apply_firewall(item, InMemoryArtifactStore(), threshold_chars=2000)[1]
+    assert env is not None and env.firewall_stats is not None
+    assert env.firewall_stats.triggered is True
+    assert env.firewall_stats.strategy == "summary"
+    assert env.firewall_stats.threshold_chars == 2000
+    assert env.firewall_stats.original_chars == 5000
+
+
+def test_apply_firewall_structured_strategy_via_keep() -> None:
+    item = ContextItem(id="r2", kind=ItemKind.tool_result, text='{"a": {"keep": 1, "drop": 2}}')
+    _, env = apply_firewall(item, InMemoryArtifactStore(), keep=["a.keep"])
+    assert env is not None and env.firewall_stats is not None
+    assert env.firewall_stats.strategy == "structured"
+    assert env.summary == '{"a": {"keep": 1}}'
+
+
+def test_apply_firewall_deterministic_raises_on_llm() -> None:
+    item = ContextItem(id="r3", kind=ItemKind.tool_result, text="some output")
+    with pytest.raises(DeterminismError):
+        apply_firewall(
+            item, InMemoryArtifactStore(), summarizer=_FakeLlmSummarizer(), deterministic=True
+        )
+
+
+def test_apply_firewall_deterministic_allows_structured_with_llm_present() -> None:
+    item = ContextItem(id="r4", kind=ItemKind.tool_result, text='{"keep": 1, "drop": 2}')
+    _, env = apply_firewall(
+        item,
+        InMemoryArtifactStore(),
+        summarizer=_FakeLlmSummarizer(),
+        deterministic=True,
+        keep=["keep"],
+    )
+    assert env is not None and env.firewall_stats is not None
+    assert env.firewall_stats.strategy == "structured"
+
+
+# ---------------------------------------------------------------------------
+# BuildStats.firewall_summary aggregation (#402)
+# ---------------------------------------------------------------------------
+
+
+def test_build_stats_firewall_summary_empty() -> None:
+    summary = BuildStats().firewall_summary()
+    assert summary.triggered is False
+    assert summary.strategy == "noop"
+
+
+def test_build_stats_firewall_summary_aggregates() -> None:
+    stats = BuildStats(
+        firewall_events=[
+            FirewallStats(triggered=True, strategy="summary", original_chars=100, summary_chars=10),
+            FirewallStats(triggered=True, strategy="summary", original_chars=200, summary_chars=20),
+        ]
+    )
+    summary = stats.firewall_summary()
+    assert summary.triggered is True
+    assert summary.strategy == "summary"
+    assert summary.original_chars == 300
+    assert summary.summary_chars == 30
+
+
+def test_build_stats_firewall_summary_mixed_strategies() -> None:
+    stats = BuildStats(
+        firewall_events=[
+            FirewallStats(triggered=True, strategy="summary"),
+            FirewallStats(triggered=True, strategy="structured"),
+        ]
+    )
+    assert stats.firewall_summary().strategy == "mixed"
+
+
+def test_build_stats_round_trips_firewall_events() -> None:
+    stats = BuildStats(
+        firewall_events=[FirewallStats(triggered=True, strategy="structured", original_chars=9)]
+    )
+    restored = BuildStats.from_dict(stats.to_dict())
+    assert restored.firewall_events == stats.firewall_events
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: ContextManager build surfaces firewall_events (#402)
+# ---------------------------------------------------------------------------
+
+
+def test_manager_build_populates_firewall_events() -> None:
+    # A raw tool_result ingested without pre-firewalling is firewalled *during*
+    # the build, so its FirewallStats surfaces on BuildStats.firewall_events.
+    mgr = ContextManager()
+    mgr.ingest_sync(ContextItem(id="result:tc1", kind=ItemKind.tool_result, text="x" * 5000))
+    pack = mgr.build_sync(phase=Phase.interpret, query="summarise the dump")
+    assert len(pack.stats.firewall_events) == 1
+    assert pack.stats.firewall_summary().triggered is True
+
+
+def test_manager_deterministic_build_raises_on_llm_summarizer() -> None:
+    mgr = ContextManager(summarizer=_FakeLlmSummarizer(), deterministic=True)
+    mgr.ingest_sync(ContextItem(id="result:tc1", kind=ItemKind.tool_result, text="x" * 5000))
+    with pytest.raises(DeterminismError):
+        mgr.build_sync(phase=Phase.interpret, query="summarise")
+
+
+def test_manager_structured_ingest_uses_projection() -> None:
+    from contextweaver.summarize.structured import StructuredFirewall
+
+    mgr = ContextManager()
+    _item, env = mgr.ingest_tool_result_sync(
+        "tc1",
+        '{"keep": 1, "drop": ' + '"' + "x" * 5000 + '"}',
+        media_type="application/json",
+        firewall_threshold=100,
+        firewall=StructuredFirewall(keep=["keep"]),
+    )
+    assert env.firewall_stats is not None
+    assert env.firewall_stats.strategy == "structured"
+    assert env.summary == '{"keep": 1}'

--- a/tests/test_structured_firewall.py
+++ b/tests/test_structured_firewall.py
@@ -1,0 +1,96 @@
+"""Tests for the structured (lossless) firewall projection (issue #406)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from contextweaver.exceptions import ConfigError
+from contextweaver.summarize.structured import StructuredFirewall, parse_path, project
+
+_INVOICES = {
+    "result": {
+        "response": {
+            "invoices": [
+                {"invoiceNumber": "A-1", "amount": 100, "status": "paid", "notes": "x" * 500},
+                {"invoiceNumber": "A-2", "amount": 200, "status": "due", "notes": "y" * 500},
+            ],
+            "total": 300,
+            "secret": "do-not-leak",
+        }
+    }
+}
+
+
+def test_parse_path_splits_keys_and_list_marker() -> None:
+    assert parse_path("result.response.invoices[].amount") == [
+        "result",
+        "response",
+        "invoices",
+        "[]",
+        "amount",
+    ]
+
+
+def test_parse_path_rejects_empty() -> None:
+    with pytest.raises(ConfigError):
+        parse_path("   ")
+
+
+def test_project_keeps_only_allow_listed_paths() -> None:
+    projected = project(
+        _INVOICES,
+        [
+            "result.response.invoices[].invoiceNumber",
+            "result.response.invoices[].amount",
+            "result.response.invoices[].status",
+            "result.response.total",
+        ],
+    )
+    assert projected == {
+        "result": {
+            "response": {
+                "invoices": [
+                    {"invoiceNumber": "A-1", "amount": 100, "status": "paid"},
+                    {"invoiceNumber": "A-2", "amount": 200, "status": "due"},
+                ],
+                "total": 300,
+            }
+        }
+    }
+    # The bulky `notes` and the sensitive `secret` are dropped from the inline.
+    assert "do-not-leak" not in json.dumps(projected)
+    assert "notes" not in json.dumps(projected)
+
+
+def test_project_skips_unresolved_paths() -> None:
+    assert project({"a": 1}, ["b.c", "a"]) == {"a": 1}
+
+
+def test_project_no_matches_returns_empty_dict() -> None:
+    assert project({"a": 1}, ["x.y.z"]) == {}
+
+
+def test_project_is_deterministic() -> None:
+    keep = ["result.response.invoices[].amount", "result.response.total"]
+    assert json.dumps(project(_INVOICES, keep), sort_keys=True) == json.dumps(
+        project(_INVOICES, keep), sort_keys=True
+    )
+
+
+def test_structured_firewall_requires_non_empty_keep() -> None:
+    with pytest.raises(ConfigError):
+        StructuredFirewall(keep=[])
+
+
+def test_structured_firewall_validates_paths_eagerly() -> None:
+    with pytest.raises(ConfigError):
+        StructuredFirewall(keep=[""])
+
+
+def test_structured_firewall_compact_returns_projection_and_facts() -> None:
+    fw = StructuredFirewall(keep=["result.response.total"])
+    projected, facts = fw.compact(_INVOICES)
+    assert projected == {"result": {"response": {"total": 300}}}
+    assert isinstance(facts, list)

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,0 +1,48 @@
+"""Tests for the built-in token counter (issue #405)."""
+
+from __future__ import annotations
+
+from contextweaver import tokens
+from contextweaver.protocols import CharDivFourEstimator, TokenEstimator
+
+
+def test_count_returns_non_negative_int() -> None:
+    assert isinstance(tokens.count("hello world"), int)
+    assert tokens.count("hello world") >= 0
+
+
+def test_count_empty_string_is_zero() -> None:
+    assert tokens.count("") == 0
+
+
+def test_count_is_monotonic_in_length() -> None:
+    short = tokens.count("one two")
+    long = tokens.count("one two three four five six seven eight nine ten")
+    assert long > short
+
+
+def test_count_matches_its_counter() -> None:
+    # count() must agree with the counter get_token_counter() hands out, so the
+    # firewall/BuildStats numbers match what callers measure (#405).
+    text = "the quick brown fox jumps over the lazy dog"
+    assert tokens.count(text) == tokens.get_token_counter().estimate(text)
+
+
+def test_get_token_counter_is_cached() -> None:
+    assert tokens.get_token_counter() is tokens.get_token_counter()
+    assert tokens.get_token_counter("gpt-4o") is tokens.get_token_counter("gpt-4o")
+
+
+def test_get_token_counter_is_a_token_estimator() -> None:
+    assert isinstance(tokens.get_token_counter(), TokenEstimator)
+
+
+def test_heuristic_counter_is_dependency_free_and_exact() -> None:
+    counter = tokens.heuristic_counter()
+    assert isinstance(counter, CharDivFourEstimator)
+    # The heuristic is exactly len // 4 — a byte-deterministic, offline count.
+    assert counter.estimate("x" * 40) == 10
+
+
+def test_token_counter_alias_is_token_estimator() -> None:
+    assert tokens.TokenCounter is TokenEstimator


### PR DESCRIPTION
## Summary

Implements the **context-firewall productization** cluster identified during issue triage as one coherent PR. The six issues compose into a single surface over the stage-4 firewall: a one-call facade selects a deterministic strategy (structured projection or rule-based summary), preserves the caller's payload shape under threshold, counts tokens with a built-in counter, and exposes first-class, auditable stats.

Closes #399
Closes #402
Closes #403
Closes #404
Closes #405
Closes #406

## Changes

- **#405 — `contextweaver.tokens`** (new `src/contextweaver/tokens.py`): public `count()` / `get_token_counter()` / `heuristic_counter()` and `TokenCounter` alias. Owns the `tiktoken` dependency (already core) so callers never wire it directly; degrades to the char heuristic offline. Firewall/`FirewallStats` numbers use this same counter. No-op `[tokenizers]` extra documents the contract.
- **#406 — structured (lossless) firewall** (new `src/contextweaver/summarize/structured.py`): `parse_path` / `project` + `StructuredFirewall(keep=[...])`. Keeps an allow-list of JSON paths inline, offloads the full payload (retrievable via `drilldown`), no LLM. Selectable via the facade and `ingest_tool_result(..., firewall=StructuredFirewall(...))`.
- **#402 — `FirewallStats`** (`envelope.py`): `triggered`, `strategy`, original/summary chars+tokens (`chars_saved`/`tokens_saved`), `artifact_ref`, `summarized_by_llm`. On `ResultEnvelope.firewall_stats`; aggregated on `BuildStats.firewall_events` + `BuildStats.firewall_summary()`.
- **#404 — determinism guarantee**: `ContextManager(deterministic=True)` and `compact_tool_result(deterministic=...)` fail closed with new `DeterminismError` rather than passing data through an LLM-backed summariser (`is_llm` marker on `LlmSummarizer`/`LlmExtractor`). `strategy`/`summarized_by_llm` make the path auditable.
- **#403 — schema-preserving pass-through** (`firewall_api.py`): under-threshold payloads returned shape-unchanged with a reserved namespaced `_cw` sidecar (dicts) / byte-identical (lists/strings) — never an in-place rewrite.
- **#399 — single-call facade** (new `src/contextweaver/context/firewall_api.py`): `compact_tool_result` / `firewalled_tool_result` → `CompactResult`, composing all of the above.

Plus: regenerated `build_stats` / `result_envelope` JSON schemas, updated `AGENTS.md` module map + key types, `docs/context_firewall.md`, and `CHANGELOG.md`.

## How verified

- `make ci` — **EXIT 0**: `ruff check` (All checks passed), `mypy` (Success, 122 files), `pytest` (**1969 passed, 30 skipped, 1 xfailed**), `schemas-check` (up to date), `make example`, `make demo`.
- 45 new tests across `test_tokens.py`, `test_structured_firewall.py`, `test_firewall_api.py`, `test_firewall_stats.py` (passthrough byte-equality, structured projection + retrievable drilldown, `DeterminismError` fail-closed, structured-is-model-free-under-deterministic, `FirewallStats` round-trip + aggregation, end-to-end `ContextManager` build).

## Checklist

- [x] Tests added or updated for every new/changed public function
- [x] `make ci` passes locally (fmt + lint + type + test + schemas-check + example + demo)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docstrings added for all new public APIs (Google-style)
- [x] Every modified module stays ≤ 300 lines (`_manager_ingest.py` trimmed back to exactly 300; `envelope.py` is on the documented exempt list)
- [x] Related issues linked in the summary above
- [x] Agent-facing docs updated (`AGENTS.md` module map + key types, `docs/context_firewall.md`)

## Notes for reviewers

- **Backward compatible by default.** `apply_firewall(item, store)` with no new args is byte-identical to before — the 18 pre-existing `test_firewall.py` cases pass unchanged. New behaviour is opt-in (`deterministic=True`, `keep=...`, the facade). One golden fixture gained the always-on `firewall_events: []` field.
- **Security-grade code.** Firewall defaults stay conservative; `deterministic` only ever *adds* a fail-closed guard, never weakens redaction/summarisation. `keep` triggers structured projection only when the payload is JSON.
- **Build-time `firewall_events`** captures items firewalled *during* the build; items pre-firewalled at ingest carry their `FirewallStats` on the returned envelope instead (the #190 idempotency guard prevents double-firing).
- Mode B per the task: `compact_tool_result` returns a richer `CompactResult` (with `.payload` and `.to_dict()`) rather than the bare dict sketched in #399 — happy to revert to a plain dict if preferred.

## Reproducibility (scoring / context-pipeline changes)

No routing/scoring math changed. The firewall now records token counts via the built-in counter, but item `token_estimate` (which drives selection) is unchanged (`len(summary)//4`), so budget/selection behaviour is identical. CI will post the sticky benchmark-delta comment.

---
_Generated by [Claude Code](https://claude.ai/code/session_018wyefhkaV7DjvZYCdcmG8n)_