### PR TITLE
feat(diagnostics): make context and gateway diagnostics trustworthy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,9 @@ It prepares context and routes tools but never calls models or executes tools.
 | Path | Responsibility |
 |---|---|
 | `types.py` | Core dataclasses and enums: `SelectableItem`, `ContextItem`, `Phase`, `ItemKind`, `Sensitivity` |
-| `envelope.py` | Result types: `ResultEnvelope`, `BuildStats`, `ContextPack`, `ChoiceCard`, `HydrationResult`, `RoutingDecision` |
+| `envelope.py` | Result types: `ResultEnvelope`, `BuildStats`, `DroppedItem`, `ContextPack`, `ChoiceCard`, `HydrationResult`, `RoutingDecision` |
+| `diagnostics.py` | Versioned, payload-safe gateway events and sinks (`DiagnosticEvent`, `DiagnosticSink`, JSONL/in-memory sinks) plus deterministic aggregate reports (issues #370/#378). |
+| `inspection.py` | Pure JSON/Markdown report construction for offline context, routing, and artifact inspection without raw payload content (issue #398). |
 | `config.py` | Configuration: `ContextBudget`, `ContextPolicy`, `ScoringConfig` |
 | `profiles.py` | Routing and profile config: `Mode`, `RoutingConfig`, `ProfileConfig`, named presets |
 | `protocols.py` | Protocol interfaces: `TokenEstimator`, `EventHook`, `Summarizer`, `Extractor`, `RedactionHook`, `MemorySource`, `Labeler`, `Retriever`, `Reranker`, `ClusteringEngine`, `RoutingScoreProvider` (store protocols re-exported from `store/protocols.py`) |
@@ -74,6 +76,7 @@ It prepares context and routes tools but never calls models or executes tools.
 | `adapters/smolagents.py` | Hugging Face smolagents `Tool` ↔ `SelectableItem` and `MultiStepAgent.memory.steps` → `ContextItem`s (`smolagents_tool_to_selectable`, `smolagents_tools_to_catalog`, `load_smolagents_catalog`, `from_smolagents_agent`, issue #274) |
 | `adapters/agno.py` | Agno (formerly Phidata) `Function` / `Toolkit` ↔ `SelectableItem` and `AgentSession` → `ContextItem`s (`agno_tool_to_selectable`, `agno_tools_to_catalog`, `load_agno_catalog`, `from_agno_session`, issue #275) |
 | `adapters/proxy_runtime.py` | `ProxyRuntime` shared core + `ExposureMode` enum + `UpstreamCall` Protocol (issue #29) |
+| `adapters/gateway_diagnostics.py` / `gateway_catalog_diagnostics.py` | Sanitized `ProxyRuntime` instrumentation plus exact gateway/proxy static-schema exposure calculations: catalog, browse/hydrate/execute/view events, savings, artifact-view usage, and latency (issues #370/#378). |
 | `adapters/mcp_gateway.py` | Two-tool gateway dispatch (`tool_browse` + `tool_execute` + `tool_view`, issues #28 / #34) |
 | `adapters/mcp_proxy.py` | Transparent proxy dispatch (stripped `tools/list` + `tool_hydrate` + `tool_execute`, issue #13) |
 | `adapters/mcp_upstream.py` | Concrete `UpstreamCall` adapters (`StubUpstream`, `McpClientUpstream`, `MultiplexUpstream`) |
@@ -92,8 +95,8 @@ It prepares context and routes tools but never calls models or executes tools.
 | `extras/memory/langmem.py` | `LangMemEpisodicStore` + `LangMemFactStore` — wrap any LangGraph `BaseStore` scoped by a `namespace` tuple; canonical ID is the store key, value is the dataclass `to_dict()` payload (direct, lossless KV). `search` delegates to `BaseStore.search`. Gated behind the `[langmem]` extra (issue #195). |
 | `eval/` | Evaluation harness (issue #12): `EvalCase` / `EvalDataset` (gold datasets), `evaluate_routing` → `RoutingEvalReport` (top-k recall, MRR, confidence gap, beam steps), `evaluate_context` → `ContextEvalReport` (budget utilisation + token savings vs naive concat). Pure-stdlib, deterministic; backs the `eval` CLI subcommand. |
 | `eval/metrics.py` | Canonical rank-based routing metrics — `recall_at_k` (classic fractional recall@k), `precision_at_k`, `reciprocal_rank` (issue #354). Single source of truth imported by both `eval/routing.py` and `benchmarks/benchmark.py` so the harness and the benchmark script can no longer define the same names with different semantics. |
-| `__main__.py` | CLI: 10 subcommands (`demo`, `build`, `route`, `print-tree`, `init`, `ingest`, `replay`, `stats`, `budget-check`, `eval`) plus the `mcp` Typer sub-app (`mcp serve`, [experimental] stdio MCP gateway/proxy entrypoint; issues #243/#246). Typer + Rich (both core deps as of v0.5, issue #221). |
-| `_mcp_cli.py` | Backs the `mcp` Typer sub-app mounted from `__main__.py`. Hosts `mcp serve` (stdio MCP gateway or transparent proxy) and the catalog loader that accepts native contextweaver, raw MCP `tools/list`, and `{tools:[...]}` snapshot shapes. `mcp serve --config FILE` loads catalog + serve options from one JSON/YAML file (zero-Python drop-in launch, issue #346); relative catalog paths resolve from the config file's directory and explicit CLI flags win. Marked `[experimental]` in `--help` for v0.9. Uses `typer.echo(..., err=True)` for stderr output (library-code `print()` is forbidden). |
+| `__main__.py` | CLI: 11 subcommands (`demo`, `build`, `route`, `print-tree`, `init`, `ingest`, `replay`, `stats`, `inspect`, `budget-check`, `eval`) plus the `mcp` Typer sub-app. `inspect` renders payload-safe context/routing/artifact JSON or Markdown (issue #398). |
+| `_mcp_cli.py` | Backs the `mcp` Typer sub-app. Hosts `mcp serve`, `mcp inspect`, and `mcp stats`; accepts native contextweaver, raw MCP `tools/list`, and `{tools:[...]}` catalog shapes. `mcp serve --diagnostics FILE` appends sanitized JSONL and `--quiet` suppresses lifecycle stderr; both are config-file keys. The packaged serve path remains a static catalog + stub upstream. |
 | `data/` | Packaged data files shipped inside the wheel via `[tool.setuptools.package-data]`. Exposes `gateway_catalog_path()` (resolves `mcp_gateway_catalog.yaml` to a concrete `Path` for both editable installs and zipped wheels — falls back to a persistent cache under `tempfile.gettempdir()/contextweaver/` for zipimport). Issue #264. |
 | `examples/recipes/` | MCP-client integration recipes: installed-CLI configs for Claude Desktop, Claude Code, GitHub Copilot, and Cursor plus `gateway_config.yaml`; `serve_gateway.py` remains a legacy/custom-runtime launcher (issues #278, #279, #346, #371, #429, #437). |
 
@@ -127,7 +130,7 @@ For full pipeline descriptions and design rationale, see [docs/agent-context/arc
 | `ContextItem` | Event log entry with `parent_id` for dependency closure |
 | `ResultEnvelope` | Processed tool output: summary + facts + artifacts + views |
 | `ContextPack` | Rendered prompt + stats from a context build |
-| `BuildStats` | What was kept, dropped, and why — diagnostic output of every build. Carries `firewall_events: list[FirewallStats]` + `firewall_summary()` (issue #402) |
+| `BuildStats` | What was kept, dropped, and why. `total_candidates` is pre-sensitivity; `dropped_items` attributes every exclusion; completed builds satisfy included + dropped = total. Carries `firewall_events` + `firewall_summary()` (issues #402/#414/#459). |
 | `FirewallStats` | Per-firewall diagnostics: `triggered`, `strategy`, original/summary chars+tokens, `artifact_ref`, `summarized_by_llm` (issues #402 / #404) |
 | `CompactResult` | Output of the single-call `compact_tool_result` facade: `firewalled`, `payload`, `summary`, `facts`, `artifact_ref`, `stats` (issue #399) |
 | `StructuredFirewall` | Non-summarising firewall strategy — keep an allow-list of JSON paths inline, offload the rest (issue #406) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Trustworthy diagnostics across context builds and the MCP gateway
+  (#370, #378, #398, #414, #459).** `BuildStats.dropped_items` attributes
+  every excluded item to `sensitivity`, `dedup`, `kind_limit`, or `budget`;
+  the production context pipeline now fires exclusion and budget lifecycle
+  hooks. New versioned `DiagnosticEvent` / `DiagnosticSink` APIs include
+  thread-safe in-memory and append-only JSONL sinks. `ProxyRuntime` emits
+  sanitized catalog, browse, hydrate, execute, and artifact-view events with
+  counts, token/schema savings, failures, and latency. Operators can use
+  `contextweaver mcp inspect`, `contextweaver mcp stats`, and
+  `contextweaver inspect` for JSON or Markdown reports without exposing raw
+  queries, argument values, result text, prompt text, or artifact bytes.
 - **Single-call firewall facade — `compact_tool_result()` /
   `firewalled_tool_result()` (#399).** Shrink one large tool result before it
   enters the prompt without standing up a `ContextManager`. Returns a
@@ -53,6 +64,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`BuildStats` accounting now has one pipeline owner (#459).**
+  `total_candidates` is measured after dependency closure and before
+  sensitivity filtering; `dropped_count` includes every later exclusion, so
+  completed builds satisfy `included_count + dropped_count ==
+  total_candidates`. The report schema is version 2.
 - **CI now exercises every committed generated-artifact drift check
   (#389–#393).** `llms.txt` / `llms-full.txt`, recorded demo casts, and the
   gateway scorecard are gating checks on the Python 3.12 matrix cell; the

--- a/README.md
+++ b/README.md
@@ -682,6 +682,10 @@ contextweaver route --graph g.json --catalog c.json --query "send email"
 contextweaver print-tree --graph g.json
 contextweaver ingest --events session.jsonl --out session.json
 contextweaver replay --session session.json --phase answer
+contextweaver inspect --session session.json --format markdown
+contextweaver mcp inspect --catalog c.json --format json
+contextweaver mcp serve --catalog c.json --diagnostics gateway.jsonl --quiet
+contextweaver mcp stats --events gateway.jsonl
 ```
 
 ## Examples
@@ -729,7 +733,9 @@ Provide a custom `Summarizer` to control how the summary is generated.
 
 **Q: How do I debug what was kept or dropped?**
 Inspect `pack.stats` (a `BuildStats` object) after every `build_sync()` / `build()` call:
-`included_count`, `dropped_count`, `dropped_reasons`, `dedup_removed`.
+`included_count`, `dropped_count`, `dropped_reasons`, `dropped_items`,
+`dedup_removed`. Completed builds satisfy
+`included_count + dropped_count == total_candidates`.
 
 **Q: Does this work with [framework X]?**
 Yes, contextweaver is framework-agnostic — it compiles context; you send `pack.prompt`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,6 +49,8 @@ term itself, see Atlan's
 |---|---|
 | `types.py` | Core dataclasses and enums (`SelectableItem`, `ContextItem`, `Phase`, `ItemKind`) |
 | `envelope.py` | Result types (`ResultEnvelope`, `BuildStats`, `ContextPack`, `ChoiceCard`, `HydrationResult`) |
+| `diagnostics.py` | Versioned gateway event schema, JSONL/in-memory sinks, aggregate reports |
+| `inspection.py` | Payload-safe offline context/routing/artifact reports |
 | `config.py` | Configuration dataclasses (`ContextBudget`, `ContextPolicy`, `ScoringConfig`) |
 | `protocols.py` | Protocol interfaces (`TokenEstimator`, `EventHook`, `Summarizer`, …) |
 | `exceptions.py` | Custom exception hierarchy |
@@ -59,7 +61,7 @@ term itself, see Atlan's
 | `context/` | Full context compilation pipeline |
 | `routing/` | Catalog, DAG builder, beam-search router, card renderer |
 | `adapters/` | MCP, FastMCP, and A2A protocol adapters |
-| `__main__.py` | CLI entry point (7 subcommands) |
+| `__main__.py` | CLI entry point (`inspect` includes context/routing/artifact diagnostics) |
 
 ## Context Engine pipeline
 
@@ -83,6 +85,12 @@ the event log. The pipeline has eight stages:
    into the token budget for the current phase.
 8. **render_context** — assemble the final prompt string, grouped by
    section (facts, history, tool results), with `BuildStats` metadata.
+
+The pipeline owns `BuildStats` construction after selection. Candidate totals
+are captured before sensitivity filtering, while sensitivity, deduplication,
+kind-limit, and budget exclusions are attributed per item. This preserves the
+invariant `included_count + dropped_count == total_candidates` and keeps
+lifecycle hooks aligned with the returned statistics.
 
 ## Routing Engine pipeline
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -98,8 +98,12 @@ what happened:
 - How many candidates were generated.
 - How many were included, dropped, or deduplicated.
 - Token usage per section.
-- Which items were dropped and why.
+- Which items were dropped and why (`dropped_items` carries item ID + reason).
 - Dependency closures applied.
+
+`total_candidates` is measured after dependency closure and before sensitivity
+filtering. Every later exclusion is counted, so completed builds satisfy
+`included_count + dropped_count == total_candidates`.
 
 ## Choice Graph
 

--- a/docs/daily_driver.md
+++ b/docs/daily_driver.md
@@ -51,6 +51,26 @@ pip install contextweaver
 contextweaver mcp serve --config /path/to/gateway.yaml --dry-run
 ```
 
+Enable local, payload-safe diagnostics in a directory that already exists:
+
+```bash
+contextweaver mcp serve \
+  --config /path/to/gateway.yaml \
+  --diagnostics /path/to/logs/contextweaver.jsonl \
+  --quiet
+```
+
+Inspect the static catalog before launch and aggregate the event stream later:
+
+```bash
+contextweaver mcp inspect --catalog /path/to/catalog.yaml
+contextweaver mcp stats --events /path/to/logs/contextweaver.jsonl
+```
+
+The packaged CLI still represents one configured static catalog source. Its
+catalog report groups tools by namespace; it does not claim live health for
+multiple upstream MCP processes.
+
 `pipx run contextweaver ...` is another isolated option. The first `uvx` or
 `pipx run` launch resolves a temporary environment and is slower than later
 runs. Pin a deployment when reproducibility matters:
@@ -129,7 +149,9 @@ When a route or prompt looks wrong, inspect these in order:
    score gaps, filters, and ambiguity. Use `debug=True` when you need the
    expansion trace.
 3. **Build statistics.** Check `included_count`, `dropped_count`,
-   `dropped_reasons`, `dedup_removed`, and token usage in `BuildStats`.
+   `dropped_reasons`, per-item `dropped_items`, `dedup_removed`, and token
+   usage in `BuildStats`. For an ingested session, run
+   `contextweaver inspect --session session.json`.
 4. **Artifact reference.** Confirm the handle exists before calling
    `tool_view`, then request a bounded `head`, `lines`, `rows`, or `json_keys`
    selector.
@@ -137,8 +159,11 @@ When a route or prompt looks wrong, inspect these in order:
    inspect phase budgets, the firewall threshold, sensitivity policy, and
    scoring/retrieval backend. These are Python runtime settings, not fields in
    the current `mcp serve` YAML.
-6. **Telemetry.** When the `[otel]` extra is enabled, inspect the context-build,
-   firewall, and routing spans. Raw prompt content remains off by default.
+6. **Telemetry.** Use `mcp serve --diagnostics FILE` for local JSONL counts,
+   savings, failures, artifact-view usage, and latency. The built-in stream
+   records IDs, sizes, argument key names, and error codes, but not queries,
+   argument values, result text, prompt text, or artifact bytes. When the
+   `[otel]` extra is enabled, inspect context-build, firewall, and routing spans.
 
 Do not respond to a poor route by immediately increasing every budget or
 returning whole artifacts. Better descriptions, a sharper browse query, and a

--- a/docs/schemas/v0/build_stats.schema.json
+++ b/docs/schemas/v0/build_stats.schema.json
@@ -1,5 +1,22 @@
 {
   "$defs": {
+    "DroppedItem": {
+      "additionalProperties": false,
+      "description": "Lightweight attribution for one item excluded from a context build.",
+      "properties": {
+        "item_id": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "item_id",
+        "reason"
+      ],
+      "type": "object"
+    },
     "FirewallStats": {
       "additionalProperties": false,
       "description": "First-class diagnostics for a single context-firewall decision (issue #402).",
@@ -59,6 +76,12 @@
     },
     "dropped_count": {
       "type": "integer"
+    },
+    "dropped_items": {
+      "items": {
+        "$ref": "#/$defs/DroppedItem"
+      },
+      "type": "array"
     },
     "dropped_reasons": {
       "additionalProperties": {

--- a/docs/security_model.md
+++ b/docs/security_model.md
@@ -54,6 +54,8 @@ filesystem or caller-supplied stores.
 - Routing queries, candidate identifiers, scores, and build statistics.
 - OpenTelemetry attributes and metrics when the optional integration is
   enabled.
+- Local gateway JSONL diagnostics when `mcp serve --diagnostics FILE` is
+  enabled.
 
 MCP annotations such as `readOnlyHint` are untrusted metadata. They may improve
 presentation or routing, but must not grant permission or bypass approval.
@@ -77,6 +79,12 @@ The default OpenTelemetry emission excludes raw queries, full tool
 descriptions, schemas, and prompt content. Enabling
 `otel_emit_experimental=True` can add sensitive content and should be limited
 to a trusted, access-controlled backend.
+
+The built-in gateway JSONL stream excludes query text, argument values, result
+text, prompt text, and artifact bytes. It does include canonical tool and
+artifact handles, namespaces, argument key names, sizes, timings, and error
+codes. Treat those identifiers as operationally sensitive and restrict file
+permissions and retention accordingly.
 
 ## Trust boundaries
 
@@ -159,6 +167,9 @@ contextweaver does not:
   artifact stores.
 - Leave experimental OTel content emission disabled unless the exporter is
   trusted for the data class involved.
+- Store gateway JSONL diagnostics in an access-controlled path and define a
+  retention policy; use `--quiet` only to suppress lifecycle stderr, not as a
+  substitute for diagnostics access control.
 - Review tool descriptions and results as untrusted input; do not rely on
   `readOnlyHint`, `destructiveHint`, or similar annotations as policy.
 - Pin the contextweaver version in managed deployments and review release notes

--- a/examples/recipes/gateway_config.yaml
+++ b/examples/recipes/gateway_config.yaml
@@ -33,5 +33,12 @@ beam_width: 3
 # Byte-stable browse prefix for prompt-cache hits.
 cache_stable: false
 
+# Optional append-only, payload-safe diagnostic event stream. Parent directory
+# must already exist. Uncomment for operator counts, savings, and latency:
+# diagnostics: ./logs/contextweaver.jsonl
+
+# Suppress lifecycle messages on stderr (stdout remains reserved for MCP).
+quiet: false
+
 # MCP server display name advertised on init.
 name: contextweaver

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -714,6 +714,10 @@ contextweaver route --graph g.json --catalog c.json --query "send email"
 contextweaver print-tree --graph g.json
 contextweaver ingest --events session.jsonl --out session.json
 contextweaver replay --session session.json --phase answer
+contextweaver inspect --session session.json --format markdown
+contextweaver mcp inspect --catalog c.json --format json
+contextweaver mcp serve --catalog c.json --diagnostics gateway.jsonl --quiet
+contextweaver mcp stats --events gateway.jsonl
 ```
 
 ## Examples
@@ -761,7 +765,9 @@ Provide a custom `Summarizer` to control how the summary is generated.
 
 **Q: How do I debug what was kept or dropped?**
 Inspect `pack.stats` (a `BuildStats` object) after every `build_sync()` / `build()` call:
-`included_count`, `dropped_count`, `dropped_reasons`, `dedup_removed`.
+`included_count`, `dropped_count`, `dropped_reasons`, `dropped_items`,
+`dedup_removed`. Completed builds satisfy
+`included_count + dropped_count == total_candidates`.
 
 **Q: Does this work with [framework X]?**
 Yes, contextweaver is framework-agnostic — it compiles context; you send `pack.prompt`
@@ -895,6 +901,8 @@ term itself, see Atlan's
 |---|---|
 | `types.py` | Core dataclasses and enums (`SelectableItem`, `ContextItem`, `Phase`, `ItemKind`) |
 | `envelope.py` | Result types (`ResultEnvelope`, `BuildStats`, `ContextPack`, `ChoiceCard`, `HydrationResult`) |
+| `diagnostics.py` | Versioned gateway event schema, JSONL/in-memory sinks, aggregate reports |
+| `inspection.py` | Payload-safe offline context/routing/artifact reports |
 | `config.py` | Configuration dataclasses (`ContextBudget`, `ContextPolicy`, `ScoringConfig`) |
 | `protocols.py` | Protocol interfaces (`TokenEstimator`, `EventHook`, `Summarizer`, …) |
 | `exceptions.py` | Custom exception hierarchy |
@@ -905,7 +913,7 @@ term itself, see Atlan's
 | `context/` | Full context compilation pipeline |
 | `routing/` | Catalog, DAG builder, beam-search router, card renderer |
 | `adapters/` | MCP, FastMCP, and A2A protocol adapters |
-| `__main__.py` | CLI entry point (7 subcommands) |
+| `__main__.py` | CLI entry point (`inspect` includes context/routing/artifact diagnostics) |
 
 ## Context Engine pipeline
 
@@ -929,6 +937,12 @@ the event log. The pipeline has eight stages:
    into the token budget for the current phase.
 8. **render_context** — assemble the final prompt string, grouped by
    section (facts, history, tool results), with `BuildStats` metadata.
+
+The pipeline owns `BuildStats` construction after selection. Candidate totals
+are captured before sensitivity filtering, while sensitivity, deduplication,
+kind-limit, and budget exclusions are attributed per item. This preserves the
+invariant `included_count + dropped_count == total_candidates` and keeps
+lifecycle hooks aligned with the returned statistics.
 
 ## Routing Engine pipeline
 
@@ -1078,8 +1092,12 @@ what happened:
 - How many candidates were generated.
 - How many were included, dropped, or deduplicated.
 - Token usage per section.
-- Which items were dropped and why.
+- Which items were dropped and why (`dropped_items` carries item ID + reason).
 - Dependency closures applied.
+
+`total_candidates` is measured after dependency closure and before sensitivity
+filtering. Every later exclusion is counted, so completed builds satisfy
+`included_count + dropped_count == total_candidates`.
 
 ## Choice Graph
 
@@ -1611,6 +1629,26 @@ pip install contextweaver
 contextweaver mcp serve --config /path/to/gateway.yaml --dry-run
 ```
 
+Enable local, payload-safe diagnostics in a directory that already exists:
+
+```bash
+contextweaver mcp serve \
+  --config /path/to/gateway.yaml \
+  --diagnostics /path/to/logs/contextweaver.jsonl \
+  --quiet
+```
+
+Inspect the static catalog before launch and aggregate the event stream later:
+
+```bash
+contextweaver mcp inspect --catalog /path/to/catalog.yaml
+contextweaver mcp stats --events /path/to/logs/contextweaver.jsonl
+```
+
+The packaged CLI still represents one configured static catalog source. Its
+catalog report groups tools by namespace; it does not claim live health for
+multiple upstream MCP processes.
+
 `pipx run contextweaver ...` is another isolated option. The first `uvx` or
 `pipx run` launch resolves a temporary environment and is slower than later
 runs. Pin a deployment when reproducibility matters:
@@ -1689,7 +1727,9 @@ When a route or prompt looks wrong, inspect these in order:
    score gaps, filters, and ambiguity. Use `debug=True` when you need the
    expansion trace.
 3. **Build statistics.** Check `included_count`, `dropped_count`,
-   `dropped_reasons`, `dedup_removed`, and token usage in `BuildStats`.
+   `dropped_reasons`, per-item `dropped_items`, `dedup_removed`, and token
+   usage in `BuildStats`. For an ingested session, run
+   `contextweaver inspect --session session.json`.
 4. **Artifact reference.** Confirm the handle exists before calling
    `tool_view`, then request a bounded `head`, `lines`, `rows`, or `json_keys`
    selector.
@@ -1697,8 +1737,11 @@ When a route or prompt looks wrong, inspect these in order:
    inspect phase budgets, the firewall threshold, sensitivity policy, and
    scoring/retrieval backend. These are Python runtime settings, not fields in
    the current `mcp serve` YAML.
-6. **Telemetry.** When the `[otel]` extra is enabled, inspect the context-build,
-   firewall, and routing spans. Raw prompt content remains off by default.
+6. **Telemetry.** Use `mcp serve --diagnostics FILE` for local JSONL counts,
+   savings, failures, artifact-view usage, and latency. The built-in stream
+   records IDs, sizes, argument key names, and error codes, but not queries,
+   argument values, result text, prompt text, or artifact bytes. When the
+   `[otel]` extra is enabled, inspect context-build, firewall, and routing spans.
 
 Do not respond to a poor route by immediately increasing every budget or
 returning whole artifacts. Better descriptions, a sharper browse query, and a
@@ -1775,6 +1818,8 @@ filesystem or caller-supplied stores.
 - Routing queries, candidate identifiers, scores, and build statistics.
 - OpenTelemetry attributes and metrics when the optional integration is
   enabled.
+- Local gateway JSONL diagnostics when `mcp serve --diagnostics FILE` is
+  enabled.
 
 MCP annotations such as `readOnlyHint` are untrusted metadata. They may improve
 presentation or routing, but must not grant permission or bypass approval.
@@ -1798,6 +1843,12 @@ The default OpenTelemetry emission excludes raw queries, full tool
 descriptions, schemas, and prompt content. Enabling
 `otel_emit_experimental=True` can add sensitive content and should be limited
 to a trusted, access-controlled backend.
+
+The built-in gateway JSONL stream excludes query text, argument values, result
+text, prompt text, and artifact bytes. It does include canonical tool and
+artifact handles, namespaces, argument key names, sizes, timings, and error
+codes. Treat those identifiers as operationally sensitive and restrict file
+permissions and retention accordingly.
 
 ## Trust boundaries
 
@@ -1880,6 +1931,9 @@ contextweaver does not:
   artifact stores.
 - Leave experimental OTel content emission disabled unless the exporter is
   trusted for the data class involved.
+- Store gateway JSONL diagnostics in an access-controlled path and define a
+  retention policy; use `--quiet` only to suppress lifecycle stderr, not as a
+  substitute for diagnostics access control.
 - Review tool descriptions and results as untrusted input; do not rely on
   `readOnlyHint`, `destructiveHint`, or similar annotations as policy.
 - Pin the contextweaver version in managed deployments and review release notes

--- a/schemas/build_stats.schema.json
+++ b/schemas/build_stats.schema.json
@@ -1,5 +1,22 @@
 {
   "$defs": {
+    "DroppedItem": {
+      "additionalProperties": false,
+      "description": "Lightweight attribution for one item excluded from a context build.",
+      "properties": {
+        "item_id": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "item_id",
+        "reason"
+      ],
+      "type": "object"
+    },
     "FirewallStats": {
       "additionalProperties": false,
       "description": "First-class diagnostics for a single context-firewall decision (issue #402).",
@@ -59,6 +76,12 @@
     },
     "dropped_count": {
       "type": "integer"
+    },
+    "dropped_items": {
+      "items": {
+        "$ref": "#/$defs/DroppedItem"
+      },
+      "type": "array"
     },
     "dropped_reasons": {
       "additionalProperties": {

--- a/src/contextweaver/__init__.py
+++ b/src/contextweaver/__init__.py
@@ -20,7 +20,17 @@ Quick start::
 
 from __future__ import annotations
 
-from contextweaver import config, envelope, exceptions, profiles, protocols, tokens, types
+from contextweaver import (
+    config,
+    diagnostics,
+    envelope,
+    exceptions,
+    inspection,
+    profiles,
+    protocols,
+    tokens,
+    types,
+)
 from contextweaver._utils import BM25Scorer, FuzzyScorer, TfIdfScorer, jaccard
 from contextweaver._version import __version__  # noqa: F401
 from contextweaver.config import ContextBudget, ContextPolicy, ScoringConfig
@@ -52,10 +62,21 @@ from contextweaver.context.memory_source import (
 )
 from contextweaver.context.sensitivity import MaskRedactionHook, register_redaction_hook
 from contextweaver.context.views import ViewRegistry, drilldown_tool_spec, generate_views
+from contextweaver.diagnostics import (
+    DiagnosticEvent,
+    DiagnosticSink,
+    InMemoryDiagnosticSink,
+    JsonlDiagnosticSink,
+    NoOpDiagnosticSink,
+    load_diagnostic_events,
+    render_diagnostic_report,
+    summarize_diagnostics,
+)
 from contextweaver.envelope import (
     BuildStats,
     ChoiceCard,
     ContextPack,
+    DroppedItem,
     FirewallStats,
     HydrationResult,
     ResultEnvelope,
@@ -75,6 +96,7 @@ from contextweaver.exceptions import (
     RouteError,
     StoreClosedError,
 )
+from contextweaver.inspection import build_inspection_report, render_inspection_report
 from contextweaver.metrics import MetricsCollector, MetricsHook
 from contextweaver.profiles import Mode, ProfileConfig, RoutingConfig
 from contextweaver.protocols import (
@@ -155,8 +177,10 @@ from contextweaver.types import (
 __all__ = [
     # sub-modules
     "config",
+    "diagnostics",
     "envelope",
     "exceptions",
+    "inspection",
     "profiles",
     "protocols",
     "tokens",
@@ -172,6 +196,7 @@ __all__ = [
     "ChoiceCard",
     "ContextItem",
     "ContextPack",
+    "DroppedItem",
     "FirewallStats",
     "HydrationResult",
     "ItemKind",
@@ -182,6 +207,7 @@ __all__ = [
     "Sensitivity",
     "ToolCard",
     "ViewSpec",
+    "DiagnosticEvent",
     # config
     "ContextBudget",
     "ContextPolicy",
@@ -206,6 +232,7 @@ __all__ = [
     "RoutingScoreProvider",
     "Summarizer",
     "TokenEstimator",
+    "DiagnosticSink",
     # exceptions
     "ArtifactNotFoundError",
     "BudgetExceededError",
@@ -219,6 +246,15 @@ __all__ = [
     "PolicyViolationError",
     "RouteError",
     "StoreClosedError",
+    # diagnostics
+    "InMemoryDiagnosticSink",
+    "JsonlDiagnosticSink",
+    "NoOpDiagnosticSink",
+    "load_diagnostic_events",
+    "render_diagnostic_report",
+    "summarize_diagnostics",
+    "build_inspection_report",
+    "render_inspection_report",
     # stores
     "InMemoryArtifactStore",
     "InMemoryEpisodicStore",

--- a/src/contextweaver/__main__.py
+++ b/src/contextweaver/__main__.py
@@ -11,6 +11,7 @@ ingest      Ingest a JSONL session into a serialised session file.
 replay      Replay a session and build context for a given phase.
 stats       Render a human-readable :class:`BuildStats` diagnostic report
             from an ingested session (issue #106).
+inspect     Render a payload-safe context/routing/artifact report (issue #398).
 budget-check
             Assert an ingested session's rendered prompt stays under a
             token ceiling for CI regression checks (issue #276).
@@ -43,6 +44,8 @@ from contextweaver.config import ContextBudget
 from contextweaver.context.manager import ContextManager
 from contextweaver.eval.dataset import EvalDataset
 from contextweaver.eval.routing import evaluate_routing
+from contextweaver.exceptions import ContextWeaverError
+from contextweaver.inspection import build_inspection_report, render_inspection_report
 from contextweaver.routing.cards import make_choice_cards, render_cards_text
 from contextweaver.routing.catalog import generate_sample_catalog, load_catalog, load_catalog_json
 from contextweaver.routing.graph_io import load_graph, save_graph
@@ -79,6 +82,11 @@ class _PhaseChoice(str, Enum):
 class _StatsFormatChoice(str, Enum):
     rich = "rich"
     text = "text"
+
+
+class _InspectFormatChoice(str, Enum):
+    json = "json"
+    markdown = "markdown"
 
 
 class _DemoScenario(str, Enum):
@@ -447,6 +455,68 @@ def stats(
         print(pack.stats.report(format="text", phase=phase.value, budget=budget))
 
 
+@app.command("inspect")
+def inspect_cmd(
+    session: Annotated[Path, typer.Option(..., help="Path to the session JSON file.")],
+    phase: Annotated[
+        _PhaseChoice, typer.Option(help="Context phase to inspect.")
+    ] = _PhaseChoice.answer,
+    budget: Annotated[int, typer.Option(help="Token budget for the context build.")] = 4000,
+    format: Annotated[  # noqa: A002
+        _InspectFormatChoice, typer.Option("--format", help="Output format.")
+    ] = _InspectFormatChoice.markdown,
+    graph: Annotated[Path | None, typer.Option(help="Optional routing graph to inspect.")] = None,
+    catalog: Annotated[Path | None, typer.Option(help="Catalog paired with --graph.")] = None,
+    route_query: Annotated[
+        str | None, typer.Option("--route-query", help="Query used with --graph and --catalog.")
+    ] = None,
+) -> None:
+    """Inspect context decisions, optional routing, and artifact metadata."""
+    routing_requested = any(value is not None for value in (graph, catalog, route_query))
+    if routing_requested and (graph is None or catalog is None or route_query is None):
+        raise typer.BadParameter(
+            "--graph, --catalog, and --route-query must be supplied together",
+            param_hint="--graph",
+        )
+
+    manager = _restore_manager_from_session(str(session), budget)
+    pack, explanation = manager.build_sync(
+        phase=Phase(phase.value),
+        query="inspect",
+        budget_tokens=budget,
+        explain=True,
+    )
+    raw_session: dict[str, Any] = json.loads(session.read_text(encoding="utf-8"))
+    artifacts: list[dict[str, Any]] = []
+    for handle, metadata in raw_session.get("artifacts", {}).items():
+        item = dict(metadata) if isinstance(metadata, dict) else {}
+        item["handle"] = handle
+        artifacts.append(item)
+
+    routing: dict[str, Any] | None = None
+    if graph is not None and catalog is not None and route_query is not None:
+        graph_obj = load_graph(str(graph))
+        items = load_catalog(str(catalog))
+        graph_ids = set(graph_obj.items())
+        router = Router(
+            graph_obj,
+            items=[item for item in items if item.id in graph_ids],
+        )
+        routing = router.route(route_query).to_dict(include_items=False)
+
+    report = build_inspection_report(
+        pack,
+        explanation=explanation,
+        artifacts=artifacts,
+        routing=routing,
+        budget=budget,
+    )
+    if format == _InspectFormatChoice.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_inspection_report(report), end="")
+
+
 @app.command("budget-check")
 def budget_check(
     session: Annotated[Path, typer.Option(..., help="Path to the session JSON file.")],
@@ -607,7 +677,7 @@ def main() -> None:
     except json.JSONDecodeError as exc:
         print(f"Error: invalid JSON — {exc}", file=sys.stderr)
         sys.exit(1)
-    except (ValueError, PermissionError) as exc:
+    except (ContextWeaverError, ValueError, PermissionError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 

--- a/src/contextweaver/_mcp_cli.py
+++ b/src/contextweaver/_mcp_cli.py
@@ -38,10 +38,18 @@ from typing import Annotated, Any
 import typer
 import yaml
 
+from contextweaver.adapters.gateway_catalog_diagnostics import catalog_diagnostic_summary
 from contextweaver.adapters.mcp_gateway_server import McpGatewayServer
 from contextweaver.adapters.mcp_proxy_server import McpProxyServer
 from contextweaver.adapters.mcp_upstream import StubUpstream
 from contextweaver.adapters.proxy_runtime import ExposureMode, ProxyRuntime
+from contextweaver.diagnostics import (
+    DiagnosticSink,
+    JsonlDiagnosticSink,
+    load_diagnostic_events,
+    render_diagnostic_report,
+    summarize_diagnostics,
+)
 
 logger = logging.getLogger("contextweaver.mcp_cli")
 
@@ -49,6 +57,11 @@ logger = logging.getLogger("contextweaver.mcp_cli")
 class _ServeMode(str, Enum):
     gateway = "gateway"
     proxy = "proxy"
+
+
+class _ReportFormat(str, Enum):
+    json = "json"
+    markdown = "markdown"
 
 
 mcp_app = typer.Typer(
@@ -66,13 +79,23 @@ mcp_app = typer.Typer(
 
 
 _CONFIG_KEYS: frozenset[str] = frozenset(
-    {"catalog", "mode", "top_k", "beam_width", "cache_stable", "name", "version"}
+    {
+        "catalog",
+        "mode",
+        "top_k",
+        "beam_width",
+        "cache_stable",
+        "name",
+        "version",
+        "diagnostics",
+        "quiet",
+    }
 )
 _TRUE_STRINGS: frozenset[str] = frozenset({"true", "1", "yes", "on"})
 _FALSE_STRINGS: frozenset[str] = frozenset({"false", "0", "no", "off"})
 
 
-def _coerce_config_bool(value: object) -> bool:
+def _coerce_config_bool(key: str, value: object) -> bool:
     """Coerce a config value to ``bool``, accepting common string spellings.
 
     Plain ``bool(value)`` is wrong for config files: ``bool("false")`` is
@@ -86,9 +109,7 @@ def _coerce_config_bool(value: object) -> bool:
             return True
         if norm in _FALSE_STRINGS:
             return False
-    raise typer.BadParameter(
-        f"cache_stable must be a boolean, got {value!r}", param_hint="--config"
-    )
+    raise typer.BadParameter(f"{key} must be a boolean, got {value!r}", param_hint="--config")
 
 
 def _coerce_config_int(key: str, value: object) -> int:
@@ -109,10 +130,11 @@ def _load_serve_config(config_path: Path) -> dict[str, Any]:
 
     The config is a JSON/YAML mapping whose keys mirror the ``serve`` options:
     ``catalog`` (path, required), ``mode`` (``gateway`` | ``proxy``),
-    ``top_k``, ``beam_width``, ``cache_stable``, ``name``, ``version``. Explicit
-    CLI flags still win over config values; the file supplies everything else so
-    a drop-in proxy can be launched with ``mcp serve --config gateway.yaml``.
-    Relative catalog paths are resolved from the config file's directory.
+    ``top_k``, ``beam_width``, ``cache_stable``, ``name``, ``version``,
+    ``diagnostics``, and ``quiet``. Explicit CLI flags still win over config
+    values; the file supplies everything else so a drop-in proxy can be launched
+    with ``mcp serve --config gateway.yaml``. Relative catalog and diagnostics
+    paths are resolved from the config file's directory.
 
     Args:
         config_path: Filesystem path to the config file (``.json``/``.yaml``/``.yml``).
@@ -171,8 +193,14 @@ def _load_serve_config(config_path: Path) -> dict[str, Any]:
     for int_key in ("top_k", "beam_width"):
         if int_key in data:
             data[int_key] = _coerce_config_int(int_key, data[int_key])
-    if "cache_stable" in data:
-        data["cache_stable"] = _coerce_config_bool(data["cache_stable"])
+    for bool_key in ("cache_stable", "quiet"):
+        if bool_key in data:
+            data[bool_key] = _coerce_config_bool(bool_key, data[bool_key])
+    if "diagnostics" in data:
+        diagnostics_path = Path(str(data["diagnostics"])).expanduser()
+        if not diagnostics_path.is_absolute():
+            diagnostics_path = config_path.parent / diagnostics_path
+        data["diagnostics"] = str(diagnostics_path.resolve())
     return data
 
 
@@ -293,6 +321,7 @@ def _build_runtime(
     top_k: int,
     beam_width: int,
     cache_stable: bool,
+    diagnostic_sink: DiagnosticSink | None = None,
 ) -> ProxyRuntime:
     """Construct a :class:`ProxyRuntime` populated from *catalog_path*.
 
@@ -302,6 +331,7 @@ def _build_runtime(
         top_k: Maximum number of cards returned by ``tool_browse``.
         beam_width: Router beam width.
         cache_stable: Toggle cache-stable browse ordering.
+        diagnostic_sink: Optional structured event destination.
 
     Returns:
         A ready-to-serve :class:`ProxyRuntime`.
@@ -314,11 +344,72 @@ def _build_runtime(
         top_k=top_k,
         beam_width=beam_width,
         cache_stable=cache_stable,
+        diagnostic_sink=diagnostic_sink,
     )
     runtime.register_tool_defs_sync(tool_defs)
     # Reuse the helper so test code can introspect the resulting catalog
     # without re-parsing the file.
     return runtime
+
+
+@mcp_app.command("inspect")
+def inspect_catalog(
+    catalog: Annotated[
+        Path, typer.Option(..., "--catalog", help="Path to a JSON/YAML tool catalog.")
+    ],
+    mode: Annotated[
+        _ServeMode, typer.Option("--mode", help="Exposure mode used for savings estimates.")
+    ] = _ServeMode.gateway,
+    format: Annotated[  # noqa: A002
+        _ReportFormat, typer.Option("--format", help="Output format.")
+    ] = _ReportFormat.markdown,
+) -> None:
+    """Inspect catalog size, namespaces, and static schema savings."""
+    tool_defs = _load_tool_defs_from_catalog(catalog)
+    runtime = ProxyRuntime(
+        StubUpstream(tool_defs, handler=_stub_handler),
+        mode=ExposureMode.GATEWAY if mode == _ServeMode.gateway else ExposureMode.TRANSPARENT,
+    )
+    runtime.register_tool_defs_sync(tool_defs)
+    items = runtime.catalog.all()
+    raw_defs = {item.id: raw for item, raw in zip(items, tool_defs, strict=True)}
+    summary = catalog_diagnostic_summary(items, raw_defs, mode=mode.value)
+    summary["catalog"] = str(catalog)
+    summary["tool_ids"] = runtime.list_tool_ids()
+    if format == _ReportFormat.json:
+        typer.echo(json.dumps(summary, indent=2, sort_keys=True))
+        return
+    lines = [
+        "# MCP Catalog Inspection",
+        "",
+        f"- Catalog: `{catalog}`",
+        f"- Mode: {mode.value}",
+        f"- Upstream tools: {summary['tool_count']}",
+        f"- Exposed tools: {summary['exposed_tool_count']}",
+        f"- Full schema tokens: {summary['full_schema_tokens']}",
+        f"- Exposed schema tokens: {summary['exposed_schema_tokens']}",
+        f"- Schema tokens avoided: {summary['schema_tokens_avoided']}",
+        "",
+        "## Namespaces",
+    ]
+    for namespace, count_value in summary["namespace_counts"].items():
+        lines.append(f"- `{namespace or '(default)'}`: {count_value}")
+    typer.echo("\n".join(lines))
+
+
+@mcp_app.command("stats")
+def diagnostic_stats(
+    events: Annotated[Path, typer.Option(..., "--events", help="Diagnostic JSONL file.")],
+    format: Annotated[  # noqa: A002
+        _ReportFormat, typer.Option("--format", help="Output format.")
+    ] = _ReportFormat.markdown,
+) -> None:
+    """Aggregate gateway event counts, savings, failures, and latency."""
+    summary = summarize_diagnostics(load_diagnostic_events(events))
+    if format == _ReportFormat.json:
+        typer.echo(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        typer.echo(render_diagnostic_report(summary), nl=False)
 
 
 def _install_sigint_handler(loop: asyncio.AbstractEventLoop) -> None:
@@ -408,6 +499,20 @@ def serve(
             help="Validate catalog and print summary; do not bind stdio.",
         ),
     ] = False,
+    diagnostics: Annotated[
+        Path | None,
+        typer.Option(
+            "--diagnostics",
+            help="Append sanitized gateway events to this JSONL file.",
+        ),
+    ] = None,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet/--no-quiet",
+            help="Suppress lifecycle messages on stderr.",
+        ),
+    ] = False,
 ) -> None:
     """[experimental] Run contextweaver as an MCP server over stdio.
 
@@ -446,6 +551,10 @@ def serve(
             name = str(cfg["name"])
         if not _from_cli("version") and "version" in cfg:
             version = str(cfg["version"])
+        if not _from_cli("diagnostics") and "diagnostics" in cfg:
+            diagnostics = Path(str(cfg["diagnostics"]))
+        if not _from_cli("quiet") and "quiet" in cfg:
+            quiet = cfg["quiet"]
 
     if catalog is None:
         raise typer.BadParameter(
@@ -454,24 +563,29 @@ def serve(
         )
     resolved_mode = _ServeMode.gateway if gateway else _ServeMode.proxy if proxy else mode
 
+    diagnostic_sink = JsonlDiagnosticSink(diagnostics) if diagnostics is not None else None
     runtime = _build_runtime(
         catalog,
         mode=resolved_mode,
         top_k=top_k,
         beam_width=beam_width,
         cache_stable=cache_stable,
+        diagnostic_sink=diagnostic_sink,
     )
     tool_count = len(runtime.list_tool_ids())
 
-    typer.echo(
-        f"contextweaver mcp serve: mode={resolved_mode.value} "
-        f"catalog={catalog} tools={tool_count} top_k={top_k} "
-        f"beam_width={beam_width} cache_stable={cache_stable}",
-        err=True,
-    )
+    if not quiet:
+        typer.echo(
+            f"contextweaver mcp serve: mode={resolved_mode.value} "
+            f"catalog={catalog} tools={tool_count} top_k={top_k} "
+            f"beam_width={beam_width} cache_stable={cache_stable} "
+            f"diagnostics={diagnostics or 'off'}",
+            err=True,
+        )
 
     if dry_run:
-        typer.echo("dry-run: catalog validated; not binding stdio.", err=True)
+        if not quiet:
+            typer.echo("dry-run: catalog validated; not binding stdio.", err=True)
         raise typer.Exit(0)
 
     server: McpGatewayServer | McpProxyServer
@@ -492,7 +606,8 @@ def serve(
         _install_sigint_handler(loop)
         loop.run_until_complete(_serve())
     except (KeyboardInterrupt, asyncio.CancelledError):
-        typer.echo("contextweaver mcp serve: interrupted, shutting down.", err=True)
+        if not quiet:
+            typer.echo("contextweaver mcp serve: interrupted, shutting down.", err=True)
         raise typer.Exit(0) from None
     finally:
         loop.close()

--- a/src/contextweaver/adapters/gateway_catalog_diagnostics.py
+++ b/src/contextweaver/adapters/gateway_catalog_diagnostics.py
@@ -1,0 +1,85 @@
+"""Exact static-schema exposure measurements for MCP gateway modes."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from contextweaver.tokens import count
+from contextweaver.types import SelectableItem
+
+_GATEWAY_META_SCHEMAS: tuple[dict[str, Any], ...] = (
+    {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"},
+            "path": {"type": "string"},
+            "top_k": {"type": "integer", "minimum": 1, "maximum": 50},
+        },
+        "additionalProperties": False,
+    },
+    {
+        "type": "object",
+        "properties": {
+            "tool_id": {"type": "string"},
+            "args": {"type": "object"},
+        },
+        "required": ["tool_id", "args"],
+        "additionalProperties": False,
+    },
+    {
+        "type": "object",
+        "properties": {
+            "handle": {"type": "string"},
+            "selector": {"type": "object"},
+        },
+        "required": ["handle", "selector"],
+        "additionalProperties": False,
+    },
+)
+
+_PROXY_META_SCHEMAS: tuple[dict[str, Any], ...] = (
+    {
+        "type": "object",
+        "properties": {"tool_id": {"type": "string"}},
+        "required": ["tool_id"],
+        "additionalProperties": False,
+    },
+    _GATEWAY_META_SCHEMAS[1],
+)
+
+
+def _schema_tokens(schema: dict[str, Any]) -> int:
+    return count(json.dumps(schema, sort_keys=True, separators=(",", ":")))
+
+
+def catalog_diagnostic_summary(
+    items: list[SelectableItem],
+    raw_defs: dict[str, dict[str, Any]],
+    *,
+    mode: str,
+) -> dict[str, Any]:
+    """Return exact catalog exposure and static schema-savings measurements."""
+    namespace_counts: dict[str, int] = {}
+    full_schema_tokens = 0
+    for item in items:
+        namespace_counts[item.namespace] = namespace_counts.get(item.namespace, 0) + 1
+        full_schema_tokens += _schema_tokens(raw_defs.get(item.id, {}).get("inputSchema", {}))
+
+    if mode == "gateway":
+        exposed_count = len(_GATEWAY_META_SCHEMAS)
+        exposed_schema_tokens = sum(_schema_tokens(schema) for schema in _GATEWAY_META_SCHEMAS)
+    else:
+        exposed_count = len(items) + len(_PROXY_META_SCHEMAS)
+        exposed_schema_tokens = len(items) * _schema_tokens({"type": "object"})
+        exposed_schema_tokens += sum(_schema_tokens(schema) for schema in _PROXY_META_SCHEMAS)
+
+    return {
+        "mode": mode,
+        "tool_count": len(items),
+        "exposed_tool_count": exposed_count,
+        "namespace_counts": dict(sorted(namespace_counts.items())),
+        "full_schema_tokens": full_schema_tokens,
+        "exposed_schema_tokens": exposed_schema_tokens,
+        "schema_tokens_avoided": max(full_schema_tokens - exposed_schema_tokens, 0),
+    }

--- a/src/contextweaver/adapters/gateway_diagnostics.py
+++ b/src/contextweaver/adapters/gateway_diagnostics.py
@@ -1,0 +1,254 @@
+"""Gateway-specific instrumentation built on :mod:`contextweaver.diagnostics`."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+from uuid import uuid4
+
+from contextweaver.adapters.gateway_catalog_diagnostics import catalog_diagnostic_summary
+from contextweaver.adapters.gateway_error import GatewayError
+from contextweaver.diagnostics import DiagnosticEvent, DiagnosticSink, NoOpDiagnosticSink
+from contextweaver.envelope import ChoiceCard, FirewallStats, HydrationResult, ResultEnvelope
+from contextweaver.tokens import count
+from contextweaver.types import SelectableItem
+
+logger = logging.getLogger("contextweaver.adapters.gateway_diagnostics")
+
+
+class GatewayTelemetry:
+    """Emit sanitized diagnostics for one gateway runtime session."""
+
+    def __init__(
+        self,
+        sink: DiagnosticSink | None = None,
+        *,
+        session_id: str | None = None,
+    ) -> None:
+        """Create telemetry backed by *sink*."""
+        self._sink = sink or NoOpDiagnosticSink()
+        self.session_id = session_id or uuid4().hex
+
+    def emit(
+        self,
+        event: str,
+        *,
+        success: bool = True,
+        duration_ms: float | None = None,
+        tool_id: str | None = None,
+        namespace: str | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
+        """Emit one event without allowing diagnostics failures to break calls."""
+        try:
+            self._sink.emit(
+                DiagnosticEvent(
+                    event=event,
+                    success=success,
+                    duration_ms=round(duration_ms, 3) if duration_ms is not None else None,
+                    session_id=self.session_id,
+                    tool_id=tool_id,
+                    namespace=namespace,
+                    attributes=attributes or {},
+                )
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("diagnostic sink failed while emitting %s", event)
+
+    def catalog_registered(
+        self,
+        items: list[SelectableItem],
+        raw_defs: dict[str, dict[str, Any]],
+        *,
+        mode: str,
+    ) -> None:
+        """Record catalog size and static schema exposure."""
+        self.emit(
+            "catalog.loaded",
+            attributes=catalog_diagnostic_summary(items, raw_defs, mode=mode),
+        )
+
+    def browse_completed(
+        self,
+        result: list[ChoiceCard] | GatewayError,
+        *,
+        duration_ms: float,
+        query_chars: int,
+        path_depth: int,
+        raw_defs: dict[str, dict[str, Any]],
+    ) -> None:
+        """Record one browse result without recording query or path text."""
+        if isinstance(result, GatewayError):
+            self.emit(
+                "browse.failed",
+                success=False,
+                duration_ms=duration_ms,
+                attributes={
+                    "error_code": result.code,
+                    "query_chars": query_chars,
+                    "path_depth": path_depth,
+                },
+            )
+            return
+        real_cards = [card for card in result if card.id in raw_defs]
+        card_tokens = sum(
+            count(json.dumps(card.to_dict(), sort_keys=True, separators=(",", ":")))
+            for card in real_cards
+        )
+        schema_tokens = sum(
+            count(
+                json.dumps(
+                    raw_defs[card.id].get("inputSchema", {}),
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            )
+            for card in real_cards
+        )
+        self.emit(
+            "browse.completed",
+            duration_ms=duration_ms,
+            attributes={
+                "query_chars": query_chars,
+                "path_depth": path_depth,
+                "card_count": len(result),
+                "tool_ids": [card.id for card in real_cards],
+                "card_tokens": card_tokens,
+                "schema_tokens_avoided": max(schema_tokens - card_tokens, 0),
+            },
+        )
+
+    def hydrate_completed(
+        self,
+        tool_id: str,
+        result: HydrationResult | GatewayError,
+        *,
+        duration_ms: float,
+        namespace: str | None,
+    ) -> None:
+        """Record schema hydration."""
+        if isinstance(result, GatewayError):
+            self.emit(
+                "hydrate.failed",
+                success=False,
+                duration_ms=duration_ms,
+                tool_id=tool_id,
+                namespace=namespace,
+                attributes={"error_code": result.code},
+            )
+            return
+        self.emit(
+            "hydrate.completed",
+            duration_ms=duration_ms,
+            tool_id=tool_id,
+            namespace=namespace,
+            attributes={
+                "schema_tokens": count(
+                    json.dumps(result.args_schema, sort_keys=True, separators=(",", ":"))
+                )
+            },
+        )
+
+    def execute_failed(
+        self,
+        tool_id: str,
+        error: GatewayError,
+        *,
+        duration_ms: float,
+        namespace: str | None,
+        arg_keys: list[str],
+    ) -> None:
+        """Record a failed execution."""
+        self.emit(
+            "execute.failed",
+            success=False,
+            duration_ms=duration_ms,
+            tool_id=tool_id,
+            namespace=namespace,
+            attributes={"error_code": error.code, "arg_keys": arg_keys},
+        )
+
+    def execute_completed(
+        self,
+        tool_id: str,
+        envelope: ResultEnvelope,
+        *,
+        duration_ms: float,
+        namespace: str | None,
+        arg_keys: list[str],
+        full_text: str,
+        binary_bytes: int,
+    ) -> None:
+        """Attach firewall stats and record compact-result savings."""
+        original_tokens = count(full_text)
+        compact_tokens = count(envelope.summary)
+        artifact_ref = next(
+            (ref.handle for ref in envelope.artifacts if ref.handle.startswith("text:")),
+            envelope.artifacts[0].handle if envelope.artifacts else None,
+        )
+        triggered = len(full_text) > len(envelope.summary)
+        envelope.firewall_stats = FirewallStats(
+            triggered=triggered,
+            strategy="summary" if triggered else "passthrough",
+            original_chars=len(full_text),
+            original_tokens=original_tokens,
+            summary_chars=len(envelope.summary),
+            summary_tokens=compact_tokens,
+            artifact_ref=artifact_ref if triggered else None,
+        )
+        self.emit(
+            "execute.completed",
+            success=envelope.status != "error",
+            duration_ms=duration_ms,
+            tool_id=tool_id,
+            namespace=namespace,
+            attributes={
+                "status": envelope.status,
+                "arg_keys": arg_keys,
+                "raw_chars": len(full_text),
+                "raw_tokens": original_tokens,
+                "compact_chars": len(envelope.summary),
+                "compact_tokens": compact_tokens,
+                "tokens_saved": max(original_tokens - compact_tokens, 0),
+                "artifact_count": len(envelope.artifacts),
+                "artifact_bytes": binary_bytes
+                + sum(
+                    ref.size_bytes for ref in envelope.artifacts if ref.handle.startswith("text:")
+                ),
+                "artifact_refs": [ref.handle for ref in envelope.artifacts],
+                "firewall_triggered": triggered,
+            },
+        )
+
+    def view_completed(
+        self,
+        handle: str,
+        selector_type: str,
+        result: str | GatewayError,
+        *,
+        duration_ms: float,
+    ) -> None:
+        """Record artifact drill-down usage without recording returned content."""
+        if isinstance(result, GatewayError):
+            self.emit(
+                "view.failed",
+                success=False,
+                duration_ms=duration_ms,
+                attributes={
+                    "artifact_ref": handle,
+                    "selector_type": selector_type,
+                    "error_code": result.code,
+                },
+            )
+            return
+        self.emit(
+            "view.completed",
+            duration_ms=duration_ms,
+            attributes={
+                "artifact_ref": handle,
+                "selector_type": selector_type,
+                "result_chars": len(result),
+                "result_tokens": count(result),
+            },
+        )

--- a/src/contextweaver/adapters/gateway_diagnostics.py
+++ b/src/contextweaver/adapters/gateway_diagnostics.py
@@ -30,6 +30,11 @@ class GatewayTelemetry:
         self._sink = sink or NoOpDiagnosticSink()
         self.session_id = session_id or uuid4().hex
 
+    @property
+    def enabled(self) -> bool:
+        """Whether diagnostics emission is active for this session."""
+        return not isinstance(self._sink, NoOpDiagnosticSink)
+
     def emit(
         self,
         event: str,
@@ -64,6 +69,8 @@ class GatewayTelemetry:
         mode: str,
     ) -> None:
         """Record catalog size and static schema exposure."""
+        if not self.enabled:
+            return
         self.emit(
             "catalog.loaded",
             attributes=catalog_diagnostic_summary(items, raw_defs, mode=mode),
@@ -79,6 +86,8 @@ class GatewayTelemetry:
         raw_defs: dict[str, dict[str, Any]],
     ) -> None:
         """Record one browse result without recording query or path text."""
+        if not self.enabled:
+            return
         if isinstance(result, GatewayError):
             self.emit(
                 "browse.failed",
@@ -128,6 +137,8 @@ class GatewayTelemetry:
         namespace: str | None,
     ) -> None:
         """Record schema hydration."""
+        if not self.enabled:
+            return
         if isinstance(result, GatewayError):
             self.emit(
                 "hydrate.failed",
@@ -160,6 +171,8 @@ class GatewayTelemetry:
         arg_keys: list[str],
     ) -> None:
         """Record a failed execution."""
+        if not self.enabled:
+            return
         self.emit(
             "execute.failed",
             success=False,
@@ -197,6 +210,8 @@ class GatewayTelemetry:
             summary_tokens=compact_tokens,
             artifact_ref=artifact_ref if triggered else None,
         )
+        if not self.enabled:
+            return
         self.emit(
             "execute.completed",
             success=envelope.status != "error",
@@ -230,6 +245,8 @@ class GatewayTelemetry:
         duration_ms: float,
     ) -> None:
         """Record artifact drill-down usage without recording returned content."""
+        if not self.enabled:
+            return
         if isinstance(result, GatewayError):
             self.emit(
                 "view.failed",

--- a/src/contextweaver/adapters/proxy_runtime.py
+++ b/src/contextweaver/adapters/proxy_runtime.py
@@ -37,14 +37,17 @@ import hashlib
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
+from time import perf_counter
 from typing import Any, Protocol, runtime_checkable
 
 import jsonschema
 import jsonschema.exceptions
 
+from contextweaver.adapters.gateway_diagnostics import GatewayTelemetry
 from contextweaver.adapters.gateway_error import GatewayError
 from contextweaver.adapters.mcp import mcp_result_to_envelope, mcp_tool_to_selectable
 from contextweaver.context.manager import ContextManager
+from contextweaver.diagnostics import DiagnosticSink
 from contextweaver.envelope import ChoiceCard, HydrationResult, ResultEnvelope
 from contextweaver.exceptions import (
     ArtifactNotFoundError,
@@ -148,6 +151,10 @@ class ProxyRuntime:
             downstream consumers can still rank after the fact —
             **the first emitted card is not guaranteed to be the
             highest-ranked card when this flag is on**.
+        diagnostic_sink: Optional destination for sanitized catalog, browse,
+            hydrate, execute, and artifact-view events.
+        session_id: Optional stable identifier attached to diagnostic events.
+            A random identifier is generated when omitted.
     """
 
     def __init__(
@@ -160,6 +167,8 @@ class ProxyRuntime:
         beam_width: int = 3,
         top_k: int = 10,
         cache_stable: bool = False,
+        diagnostic_sink: DiagnosticSink | None = None,
+        session_id: str | None = None,
     ) -> None:
         self._upstream = upstream
         self._mode = mode
@@ -181,6 +190,7 @@ class ProxyRuntime:
         self._router: Router | None = None
         self._upstream_names = _UpstreamNameIndex()
         self._raw_tool_defs: dict[str, dict[str, Any]] = {}
+        self._telemetry = GatewayTelemetry(diagnostic_sink, session_id=session_id)
 
     # ------------------------------------------------------------------
     # Properties
@@ -214,6 +224,11 @@ class ProxyRuntime:
         :class:`frozenset` so callers cannot mutate runtime state through it.
         """
         return frozenset(self._browsed_tool_ids)
+
+    @property
+    def diagnostic_session_id(self) -> str:
+        """Return the identifier attached to this runtime's diagnostic events."""
+        return self._telemetry.session_id
 
     # ------------------------------------------------------------------
     # Catalog management
@@ -264,6 +279,7 @@ class ProxyRuntime:
         else:
             self._graph = None
             self._router = None
+        self._telemetry.catalog_registered(items, raw_defs, mode=self._mode.value)
         logger.debug("proxy_runtime: registered %d tools", len(items))
         return len(items)
 
@@ -299,15 +315,25 @@ class ProxyRuntime:
             :class:`GatewayError` describing why the request was
             rejected.
         """
+        started = perf_counter()
         if (query is None) == (path is None):
-            return GatewayError(
+            result: list[ChoiceCard] | GatewayError = GatewayError(
                 code="ARGS_INVALID",
                 message="tool_browse requires exactly one of 'query' or 'path'.",
             )
-        if query is not None:
-            return self._browse_by_query(query, top_k=top_k)
-        assert path is not None  # narrowed by the XOR check above
-        return self._browse_by_path(path)
+        elif query is not None:
+            result = self._browse_by_query(query, top_k=top_k)
+        else:
+            assert path is not None  # narrowed by the XOR check above
+            result = self._browse_by_path(path)
+        self._telemetry.browse_completed(
+            result,
+            duration_ms=(perf_counter() - started) * 1000,
+            query_chars=len(query) if query is not None else 0,
+            path_depth=len([part for part in (path or "").split("/") if part]),
+            raw_defs=self._raw_tool_defs,
+        )
+        return result
 
     def _browse_by_query(self, query: str, *, top_k: int | None) -> list[ChoiceCard] | GatewayError:
         if self._router is None or not self._catalog.all():
@@ -375,16 +401,26 @@ class ProxyRuntime:
             A :class:`HydrationResult` or :class:`GatewayError` with code
             ``HYDRATE_FAILED`` when *tool_id* is unknown.
         """
+        started = perf_counter()
+        namespace: str | None = None
+        result: HydrationResult | GatewayError
         try:
             result = self._catalog.hydrate(tool_id)
+            namespace = result.item.namespace
         except ItemNotFoundError as exc:
-            return GatewayError(
+            result = GatewayError(
                 code="HYDRATE_FAILED",
                 message=str(exc),
                 path=tool_id,
             )
-        if self._cache_stable:
+        if self._cache_stable and not isinstance(result, GatewayError):
             self._browsed_tool_ids.add(tool_id)
+        self._telemetry.hydrate_completed(
+            tool_id,
+            result,
+            duration_ms=(perf_counter() - started) * 1000,
+            namespace=namespace,
+        )
         return result
 
     # ------------------------------------------------------------------
@@ -469,31 +505,59 @@ class ProxyRuntime:
             ``ARGS_INVALID`` per §4.4; transport / protocol failures map
             to ``UPSTREAM_ERROR``.
         """
+        started = perf_counter()
+        arg_keys = sorted(args)
+        namespace: str | None = None
         try:
             hydrated = self._catalog.hydrate(tool_id)
+            namespace = hydrated.item.namespace
         except ItemNotFoundError as exc:
-            return GatewayError(
+            error = GatewayError(
                 code="HYDRATE_FAILED",
                 message=str(exc),
                 path=tool_id,
             )
+            self._telemetry.execute_failed(
+                tool_id,
+                error,
+                duration_ms=(perf_counter() - started) * 1000,
+                namespace=namespace,
+                arg_keys=arg_keys,
+            )
+            return error
         validation_error = _validate_args(args, hydrated.args_schema)
         if validation_error is not None:
-            return GatewayError(
+            error = GatewayError(
                 code="ARGS_INVALID",
                 message=validation_error.message,
                 path=tool_id,
                 details={"path": list(validation_error.path)},
             )
+            self._telemetry.execute_failed(
+                tool_id,
+                error,
+                duration_ms=(perf_counter() - started) * 1000,
+                namespace=namespace,
+                arg_keys=arg_keys,
+            )
+            return error
         upstream_name = self._upstream_names.by_tool_id.get(tool_id, hydrated.item.name)
         try:
             raw = await self._upstream.call_tool(upstream_name, args)
         except Exception as exc:  # noqa: BLE001
-            return GatewayError(
+            error = GatewayError(
                 code="UPSTREAM_ERROR",
                 message=f"upstream call failed: {exc}",
                 path=tool_id,
             )
+            self._telemetry.execute_failed(
+                tool_id,
+                error,
+                duration_ms=(perf_counter() - started) * 1000,
+                namespace=namespace,
+                arg_keys=arg_keys,
+            )
+            return error
         envelope, binaries, full_text = mcp_result_to_envelope(raw, upstream_name)
         # Persist binaries on the session's artifact store so subsequent
         # tool_view calls can drill in.  Text content larger than the
@@ -503,7 +567,7 @@ class ProxyRuntime:
         for handle, (data, mime, label) in binaries.items():
             if not artifact_store.exists(handle):
                 artifact_store.put(handle=handle, content=data, media_type=mime, label=label)
-        if full_text and not envelope.artifacts:
+        if full_text:
             content_bytes = full_text.encode("utf-8")
             text_hash = hashlib.sha256(content_bytes).hexdigest()[:16]
             text_handle = f"text:{tool_id}:{text_hash}"
@@ -520,6 +584,15 @@ class ProxyRuntime:
         envelope.provenance.setdefault("tool_id", tool_id)
         if self._cache_stable:
             self._browsed_tool_ids.add(tool_id)
+        self._telemetry.execute_completed(
+            tool_id,
+            envelope,
+            duration_ms=(perf_counter() - started) * 1000,
+            namespace=namespace,
+            arg_keys=arg_keys,
+            full_text=full_text,
+            binary_bytes=sum(len(data) for data, _mime, _label in binaries.values()),
+        )
         return envelope
 
     # ------------------------------------------------------------------
@@ -533,15 +606,23 @@ class ProxyRuntime:
         code ``VIEW_FAILED`` if the handle is unknown or the selector is
         invalid.
         """
+        started = perf_counter()
         store: InMemoryArtifactStore = self._context_manager.artifact_store  # type: ignore[assignment]
         try:
-            return store.drilldown(handle, selector)
+            result: str | GatewayError = store.drilldown(handle, selector)
         except (ArtifactNotFoundError, ContextWeaverError) as exc:
-            return GatewayError(
+            result = GatewayError(
                 code="VIEW_FAILED",
                 message=str(exc),
                 path=handle,
             )
+        self._telemetry.view_completed(
+            handle,
+            str(selector.get("type", "")),
+            result,
+            duration_ms=(perf_counter() - started) * 1000,
+        )
+        return result
 
     # ------------------------------------------------------------------
     # Proxy-only: stripped tools/list (§4.1)

--- a/src/contextweaver/context/build.py
+++ b/src/contextweaver/context/build.py
@@ -27,7 +27,7 @@ from contextweaver.context.prompt import render_context
 from contextweaver.context.scoring import score_candidates
 from contextweaver.context.selection import select_and_pack
 from contextweaver.context.sensitivity import apply_sensitivity_filter
-from contextweaver.envelope import ContextPack
+from contextweaver.envelope import BuildStats, ContextPack, DroppedItem
 from contextweaver.types import Phase
 
 if TYPE_CHECKING:
@@ -79,16 +79,23 @@ def run_build_pipeline(
     if explain:
         pre_closure_ids = {c.id for c in candidates}
     candidates, closures = resolve_dependency_closure(candidates, manager._event_log)
+    total_candidates = len(candidates)
     closure_added_ids = {c.id for c in candidates} - pre_closure_ids if explain else set()
 
     # 3. Sensitivity filter
+    pre_sensitivity = list(candidates)
     if explain:
-        pre_sens_ids = {(c.id, c.kind.value, c.sensitivity.value) for c in candidates}
+        pre_sens_ids = {(c.id, c.kind.value, c.sensitivity.value) for c in pre_sensitivity}
     candidates, sensitivity_drops = apply_sensitivity_filter(candidates, manager._policy)
+    post_sensitivity_ids = {item.id for item in candidates}
+    sensitivity_dropped_items = [
+        item for item in pre_sensitivity if item.id not in post_sensitivity_ids
+    ]
     if explain:
-        post_sens_ids = {c.id for c in candidates}
         sensitivity_dropped_records: list[tuple[str, str, str]] = sorted(
-            (cid, kind, sens) for (cid, kind, sens) in pre_sens_ids if cid not in post_sens_ids
+            (cid, kind, sens)
+            for (cid, kind, sens) in pre_sens_ids
+            if cid not in post_sensitivity_ids
         )
     else:
         sensitivity_dropped_records = []
@@ -107,15 +114,20 @@ def run_build_pipeline(
     scored = score_candidates(candidates, query, _tags, manager._scoring)
 
     # 6. Dedup
+    pre_dedup_scored = list(scored)
     if explain:
         pre_dedup_view: list[tuple[str, str, str, float]] = [
-            (item.id, item.kind.value, item.sensitivity.value, score) for score, item in scored
+            (item.id, item.kind.value, item.sensitivity.value, score)
+            for score, item in pre_dedup_scored
         ]
     scored, dedup_removed = deduplicate_candidates(
         scored, similarity_threshold=manager._scoring.dedup_threshold
     )
+    post_dedup_ids = {item.id for _score, item in scored}
+    dedup_dropped_items = [
+        item for _score, item in pre_dedup_scored if item.id not in post_dedup_ids
+    ]
     if explain:
-        post_dedup_ids = {item.id for _score, item in scored}
         dedup_dropped_records: list[tuple[str, str, str, float]] = [
             (iid, kind, sens, sc)
             for (iid, kind, sens, sc) in pre_dedup_view
@@ -133,24 +145,52 @@ def run_build_pipeline(
     adjusted = _adjust_budget_for_header(effective_budget, phase, hf_tokens)
 
     # 7. Select (budget already accounts for header/footer overhead)
-    selected, stats = select_and_pack(scored, phase, adjusted, manager._policy, manager._estimator)
-    stats.dedup_removed = dedup_removed
-    stats.dependency_closures = closures
-    stats.header_footer_tokens = hf_tokens
+    selection = select_and_pack(scored, phase, adjusted, manager._policy, manager._estimator)
+    selected = selection.selected
+    dropped_records = [
+        *(DroppedItem(item.id, "sensitivity") for item in sensitivity_dropped_items),
+        *(DroppedItem(item.id, "dedup") for item in dedup_dropped_items),
+        *(DroppedItem(item.id, reason) for item, reason in selection.dropped),
+    ]
+    dropped_reasons: dict[str, int] = {}
+    for record in dropped_records:
+        dropped_reasons[record.reason] = dropped_reasons.get(record.reason, 0) + 1
+    stats = BuildStats(
+        tokens_per_section=selection.tokens_per_section,
+        total_candidates=total_candidates,
+        included_count=len(selected),
+        dropped_count=len(dropped_records),
+        dropped_reasons=dropped_reasons,
+        dropped_items=dropped_records,
+        dedup_removed=dedup_removed,
+        dependency_closures=closures,
+        header_footer_tokens=hf_tokens,
+    )
     # Surface per-item firewall diagnostics (issue #402): one FirewallStats per
     # offloaded tool result.  Read ``stats.firewall_summary()`` for the roll-up.
     stats.firewall_events = [
         env.firewall_stats for env in envelopes if env.firewall_stats is not None
     ]
-    if sensitivity_drops > 0:
-        # Account for items dropped by sensitivity filtering in both the
-        # total candidate count and the drop breakdown so that
-        # dropped_count + included_count <= total_candidates remains true.
-        stats.total_candidates += sensitivity_drops
-        stats.dropped_count += sensitivity_drops
-        stats.dropped_reasons["sensitivity"] = (
-            stats.dropped_reasons.get("sensitivity", 0) + sensitivity_drops
-        )
+    if sensitivity_dropped_items:
+        manager._hook.on_items_excluded(sensitivity_dropped_items, "sensitivity")
+    if dedup_dropped_items:
+        manager._hook.on_items_excluded(dedup_dropped_items, "dedup")
+    for reason in ("kind_limit", "budget"):
+        excluded = [item for item, drop_reason in selection.dropped if drop_reason == reason]
+        if excluded:
+            manager._hook.on_items_excluded(excluded, reason)
+    active_budget = effective_budget.for_phase(phase)
+    if hf_tokens > active_budget:
+        manager._hook.on_budget_exceeded(hf_tokens, active_budget)
+    elif selection.budget_overruns:
+        requested, limit = max(selection.budget_overruns)
+        manager._hook.on_budget_exceeded(requested, limit)
+
+    assert stats.included_count + stats.dropped_count == stats.total_candidates, (
+        "context build accounting invariant failed: "
+        f"included={stats.included_count} dropped={stats.dropped_count} "
+        f"total={stats.total_candidates}"
+    )
 
     # 8. Render
     prompt = render_context(selected, header=full_header, footer=footer)

--- a/src/contextweaver/context/explanation.py
+++ b/src/contextweaver/context/explanation.py
@@ -64,9 +64,7 @@ class CandidateExplanation:
             (``None`` for candidates dropped before scoring).
         included: ``True`` when the candidate landed in the final pack.
         drop_reason: One of ``"sensitivity"``, ``"dedup"``,
-            ``"selection"``, ``""`` (kept).  ``"selection"`` is a
-            coarse bucket covering both per-kind-limit and budget
-            drops (the breakdown lives on :class:`BuildStats`).
+            ``"kind_limit"``, ``"budget"``, or ``""`` (kept).
             Empty when ``included`` is ``True``.
         dependency_closure: ``True`` when the candidate was pulled in
             by the dependency-closure stage rather than the phase
@@ -117,8 +115,8 @@ class ContextBuildExplanation:
         version: Schema version (currently :data:`EXPLANATION_VERSION`).
         phase: The :attr:`Phase` the build targeted.
         query: The query string passed to :meth:`ContextManager.build`.
-        total_candidates: Number of candidates entering the scoring
-            stage (i.e. after sensitivity + firewall).
+        total_candidates: Number of candidates after dependency closure
+            and before sensitivity filtering.
         included_count: Number of items in the final pack.
         dropped_count: Number of candidates not included.
         dropped_reasons: Aggregate counts per drop reason — mirrors the
@@ -282,6 +280,7 @@ def build_explanation(
 
     # Build the score lookup for the remaining survivors (post-dedup).
     score_by_id: dict[str, float] = {item.id: score for score, item in scored}
+    drop_reason_by_id = {item.item_id: item.reason for item in stats.dropped_items}
 
     # 3) Every scored item — included or dropped by selection.
     for _score, item in scored:
@@ -290,13 +289,7 @@ def build_explanation(
         included = item.id in selected_ids
         reason = ""
         if not included:
-            # Selection drops items for two reasons: per-kind limit or
-            # token budget.  We cannot distinguish them per-item from
-            # the public surface — both share the same dropped_reasons
-            # bucket in BuildStats — so we report "selection" as a
-            # single coarse bucket here and leave the breakdown to
-            # ``stats.dropped_reasons``.
-            reason = "selection"
+            reason = drop_reason_by_id.get(item.id, "selection")
         candidates.append(
             CandidateExplanation(
                 item_id=item.id,

--- a/src/contextweaver/context/explanation.py
+++ b/src/contextweaver/context/explanation.py
@@ -63,9 +63,10 @@ class CandidateExplanation:
         score: The relevance score assigned by ``score_candidates``
             (``None`` for candidates dropped before scoring).
         included: ``True`` when the candidate landed in the final pack.
-        drop_reason: One of ``"sensitivity"``, ``"dedup"``,
-            ``"kind_limit"``, ``"budget"``, or ``""`` (kept).
-            Empty when ``included`` is ``True``.
+        drop_reason: Empty when ``included`` is ``True``. Otherwise the
+            recorded exclusion reason, typically ``"sensitivity"``,
+            ``"dedup"``, ``"kind_limit"``, or ``"budget"``. Older payloads
+            can also surface the legacy fallback ``"selection"``.
         dependency_closure: ``True`` when the candidate was pulled in
             by the dependency-closure stage rather than the phase
             filter — i.e. it scored lower than the cutoff but the

--- a/src/contextweaver/context/explanation.py
+++ b/src/contextweaver/context/explanation.py
@@ -64,9 +64,10 @@ class CandidateExplanation:
             (``None`` for candidates dropped before scoring).
         included: ``True`` when the candidate landed in the final pack.
         drop_reason: Empty when ``included`` is ``True``. Otherwise the
-            recorded exclusion reason, typically ``"sensitivity"``,
-            ``"dedup"``, ``"kind_limit"``, or ``"budget"``. Older payloads
-            can also surface the legacy fallback ``"selection"``.
+            recorded exclusion reason. Common values include
+            ``"sensitivity"``, ``"dedup"``, ``"kind_limit"``, and
+            ``"budget"``; older payloads can also surface the
+            legacy-only fallback ``"selection"``.
         dependency_closure: ``True`` when the candidate was pulled in
             by the dependency-closure stage rather than the phase
             filter — i.e. it scored lower than the cutoff but the

--- a/src/contextweaver/context/selection.py
+++ b/src/contextweaver/context/selection.py
@@ -7,13 +7,23 @@ configured token budget for the current phase.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 
 from contextweaver.config import ContextBudget, ContextPolicy
-from contextweaver.envelope import BuildStats
 from contextweaver.protocols import TokenEstimator
 from contextweaver.types import ContextItem, Phase
 
 logger = logging.getLogger("contextweaver.context")
+
+
+@dataclass
+class _SelectionOutcome:
+    """Raw selection-stage outcome consumed by the build pipeline."""
+
+    selected: list[ContextItem] = field(default_factory=list)
+    dropped: list[tuple[ContextItem, str]] = field(default_factory=list)
+    tokens_per_section: dict[str, int] = field(default_factory=dict)
+    budget_overruns: list[tuple[int, int]] = field(default_factory=list)
 
 
 def select_and_pack(
@@ -22,7 +32,7 @@ def select_and_pack(
     budget: ContextBudget,
     policy: ContextPolicy,
     estimator: TokenEstimator,
-) -> tuple[list[ContextItem], BuildStats]:
+) -> _SelectionOutcome:
     """Select items up to the phase budget, enforcing per-kind limits.
 
     Iterates through *scored* in descending order and greedily includes items
@@ -36,7 +46,8 @@ def select_and_pack(
         estimator: Token estimator for items whose ``token_estimate`` is zero.
 
     Returns:
-        A 2-tuple ``(selected_items, stats)``.
+        The raw selection outcome. The enclosing build pipeline owns final
+        :class:`~contextweaver.envelope.BuildStats` construction.
     """
     token_limit = budget.for_phase(phase)
     max_per_kind = policy.max_items_per_kind
@@ -44,7 +55,8 @@ def select_and_pack(
     selected: list[ContextItem] = []
     tokens_used = 0
     kind_counts: dict[str, int] = {}
-    dropped_reasons: dict[str, int] = {}
+    dropped: list[tuple[ContextItem, str]] = []
+    budget_overruns: list[tuple[int, int]] = []
 
     for _, item in scored:
         kind_key = item.kind.value
@@ -52,7 +64,7 @@ def select_and_pack(
         # Per-kind limit
         kind_limit = max_per_kind.get(item.kind, 50)
         if kind_counts.get(kind_key, 0) >= kind_limit:
-            dropped_reasons["kind_limit"] = dropped_reasons.get("kind_limit", 0) + 1
+            dropped.append((item, "kind_limit"))
             continue
 
         # Token estimate
@@ -60,7 +72,8 @@ def select_and_pack(
 
         # Budget check
         if tokens_used + token_count > token_limit:
-            dropped_reasons["budget"] = dropped_reasons.get("budget", 0) + 1
+            dropped.append((item, "budget"))
+            budget_overruns.append((tokens_used + token_count, token_limit))
             continue
 
         selected.append(item)
@@ -74,23 +87,20 @@ def select_and_pack(
         t = item.token_estimate or estimator.estimate(item.text)
         tokens_per_section[k] = tokens_per_section.get(k, 0) + t
 
-    total_candidates = len(scored)
-    included = len(selected)
-    dropped = total_candidates - included
-
-    stats = BuildStats(
-        tokens_per_section=tokens_per_section,
-        total_candidates=total_candidates,
-        included_count=included,
-        dropped_count=dropped,
-        dropped_reasons=dropped_reasons,
-    )
+    dropped_reasons: dict[str, int] = {}
+    for _item, reason in dropped:
+        dropped_reasons[reason] = dropped_reasons.get(reason, 0) + 1
     logger.debug(
         "select_and_pack: included=%d, dropped=%d, tokens=%d/%d, reasons=%s",
-        included,
-        dropped,
+        len(selected),
+        len(dropped),
         tokens_used,
         token_limit,
         dropped_reasons,
     )
-    return selected, stats
+    return _SelectionOutcome(
+        selected=selected,
+        dropped=dropped,
+        tokens_per_section=tokens_per_section,
+        budget_overruns=budget_overruns,
+    )

--- a/src/contextweaver/diagnostics.py
+++ b/src/contextweaver/diagnostics.py
@@ -1,0 +1,252 @@
+"""Structured, privacy-conscious diagnostics for gateway operations.
+
+The gateway emits versioned :class:`DiagnosticEvent` records to an injected
+:class:`DiagnosticSink`. The built-in :class:`JsonlDiagnosticSink` provides an
+append-only local event log; :func:`summarize_diagnostics` turns that stream
+into operator-facing counts, savings, latency percentiles, and drill-down IDs.
+
+Events intentionally carry metadata only. Runtime instrumentation records
+identifiers, sizes, timings, argument key names, and error codes, never query
+text, argument values, result text, or artifact bytes.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from contextweaver.exceptions import ConfigError
+
+DIAGNOSTIC_EVENT_VERSION: int = 1
+DIAGNOSTIC_REPORT_VERSION: int = 1
+
+
+def utc_timestamp() -> str:
+    """Return the current UTC timestamp in ISO-8601 form."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class DiagnosticEvent:
+    """One structured gateway diagnostic event.
+
+    Attributes:
+        event: Stable event name such as ``"browse.completed"``.
+        timestamp: UTC ISO-8601 timestamp.
+        success: Whether the operation succeeded.
+        duration_ms: Operation latency in milliseconds, when applicable.
+        session_id: Runtime session identifier.
+        tool_id: Canonical tool identifier, when applicable.
+        namespace: Tool namespace, when applicable.
+        attributes: JSON-compatible metadata. Callers must not place payload
+            content or argument values here.
+        version: Event schema version.
+    """
+
+    event: str
+    timestamp: str = field(default_factory=utc_timestamp)
+    success: bool = True
+    duration_ms: float | None = None
+    session_id: str = ""
+    tool_id: str | None = None
+    namespace: str | None = None
+    attributes: dict[str, Any] = field(default_factory=dict)
+    version: int = DIAGNOSTIC_EVENT_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-compatible dict."""
+        return {
+            "version": self.version,
+            "event": self.event,
+            "timestamp": self.timestamp,
+            "success": self.success,
+            "duration_ms": self.duration_ms,
+            "session_id": self.session_id,
+            "tool_id": self.tool_id,
+            "namespace": self.namespace,
+            "attributes": dict(self.attributes),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DiagnosticEvent:
+        """Deserialise from a JSON-compatible dict."""
+        duration = data.get("duration_ms")
+        return cls(
+            version=int(data.get("version", DIAGNOSTIC_EVENT_VERSION)),
+            event=str(data["event"]),
+            timestamp=str(data.get("timestamp", "")),
+            success=bool(data.get("success", True)),
+            duration_ms=float(duration) if duration is not None else None,
+            session_id=str(data.get("session_id", "")),
+            tool_id=str(data["tool_id"]) if data.get("tool_id") is not None else None,
+            namespace=str(data["namespace"]) if data.get("namespace") is not None else None,
+            attributes=dict(data.get("attributes", {})),
+        )
+
+
+@runtime_checkable
+class DiagnosticSink(Protocol):
+    """Destination for structured diagnostic events."""
+
+    def emit(self, event: DiagnosticEvent) -> None:
+        """Persist or export *event*."""
+        ...
+
+
+class NoOpDiagnosticSink:
+    """Default sink that discards events."""
+
+    def emit(self, event: DiagnosticEvent) -> None:
+        """Discard *event*."""
+        _ = event
+
+
+class InMemoryDiagnosticSink:
+    """Thread-safe sink retaining events for tests and embedded dashboards."""
+
+    def __init__(self) -> None:
+        """Create an empty sink."""
+        self._lock = threading.Lock()
+        self._events: list[DiagnosticEvent] = []
+
+    def emit(self, event: DiagnosticEvent) -> None:
+        """Append *event*."""
+        with self._lock:
+            self._events.append(event)
+
+    def events(self) -> list[DiagnosticEvent]:
+        """Return a snapshot of retained events."""
+        with self._lock:
+            return list(self._events)
+
+
+class JsonlDiagnosticSink:
+    """Append diagnostic events to a UTF-8 JSONL file."""
+
+    def __init__(self, path: str | Path) -> None:
+        """Create a sink writing to *path*."""
+        self.path = Path(path)
+        if not self.path.parent.exists():
+            raise ConfigError(f"diagnostics directory does not exist: {self.path.parent}")
+        self._lock = threading.Lock()
+
+    def emit(self, event: DiagnosticEvent) -> None:
+        """Append one canonical JSON line."""
+        line = json.dumps(event.to_dict(), sort_keys=True, separators=(",", ":"))
+        with self._lock, self.path.open("a", encoding="utf-8", newline="\n") as stream:
+            stream.write(line + "\n")
+
+
+def load_diagnostic_events(path: str | Path) -> list[DiagnosticEvent]:
+    """Load a diagnostic JSONL stream.
+
+    Raises:
+        ConfigError: If a non-empty line is not a valid event object.
+    """
+    source = Path(path)
+    events: list[DiagnosticEvent] = []
+    try:
+        lines = source.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        raise ConfigError(f"cannot read diagnostics file {source}: {exc}") from exc
+    for lineno, line in enumerate(lines, 1):
+        if not line.strip():
+            continue
+        try:
+            raw = json.loads(line)
+            if not isinstance(raw, dict):
+                raise TypeError("event must be a JSON object")
+            events.append(DiagnosticEvent.from_dict(raw))
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise ConfigError(f"{source}:{lineno}: invalid diagnostic event: {exc}") from exc
+    return events
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    index = max(0, min(len(ordered) - 1, int(percentile * len(ordered) + 0.999999) - 1))
+    return round(ordered[index], 3)
+
+
+def summarize_diagnostics(events: list[DiagnosticEvent]) -> dict[str, Any]:
+    """Aggregate diagnostic events into a deterministic gateway report."""
+    names: dict[str, int] = {}
+    namespaces: dict[str, int] = {}
+    durations: list[float] = []
+    failures = 0
+    raw_tokens = 0
+    compact_tokens = 0
+    schema_tokens_avoided = 0
+    artifact_views = 0
+    tool_ids: set[str] = set()
+    sessions: set[str] = set()
+
+    for item in events:
+        names[item.event] = names.get(item.event, 0) + 1
+        if not item.success:
+            failures += 1
+        if item.duration_ms is not None:
+            durations.append(item.duration_ms)
+        if item.session_id:
+            sessions.add(item.session_id)
+        if item.tool_id:
+            tool_ids.add(item.tool_id)
+        if item.namespace:
+            namespaces[item.namespace] = namespaces.get(item.namespace, 0) + 1
+        raw_tokens += int(item.attributes.get("raw_tokens", 0))
+        compact_tokens += int(item.attributes.get("compact_tokens", 0))
+        schema_tokens_avoided += int(item.attributes.get("schema_tokens_avoided", 0))
+        if item.event == "view.completed":
+            artifact_views += 1
+
+    return {
+        "version": DIAGNOSTIC_REPORT_VERSION,
+        "event_count": len(events),
+        "session_count": len(sessions),
+        "failure_count": failures,
+        "events_by_name": dict(sorted(names.items())),
+        "unique_tool_count": len(tool_ids),
+        "namespaces": dict(sorted(namespaces.items())),
+        "artifact_view_count": artifact_views,
+        "raw_tokens": raw_tokens,
+        "compact_tokens": compact_tokens,
+        "tokens_saved": max(raw_tokens - compact_tokens, 0),
+        "schema_tokens_avoided": schema_tokens_avoided,
+        "latency_ms": {
+            "count": len(durations),
+            "p50": _percentile(durations, 0.50),
+            "p95": _percentile(durations, 0.95),
+            "max": round(max(durations), 3) if durations else 0.0,
+        },
+    }
+
+
+def render_diagnostic_report(summary: dict[str, Any]) -> str:
+    """Render a grep-friendly Markdown report from a summary payload."""
+    latency = summary.get("latency_ms", {})
+    lines = [
+        "# Gateway Diagnostics",
+        "",
+        f"- Events: {summary.get('event_count', 0)}",
+        f"- Sessions: {summary.get('session_count', 0)}",
+        f"- Failures: {summary.get('failure_count', 0)}",
+        f"- Unique tools: {summary.get('unique_tool_count', 0)}",
+        f"- Artifact views: {summary.get('artifact_view_count', 0)}",
+        f"- Result tokens: {summary.get('raw_tokens', 0)} raw -> "
+        f"{summary.get('compact_tokens', 0)} compact "
+        f"({summary.get('tokens_saved', 0)} saved)",
+        f"- Schema tokens avoided: {summary.get('schema_tokens_avoided', 0)}",
+        f"- Latency: p50={latency.get('p50', 0)}ms "
+        f"p95={latency.get('p95', 0)}ms max={latency.get('max', 0)}ms",
+        "",
+        "## Events",
+    ]
+    for name, count in summary.get("events_by_name", {}).items():
+        lines.append(f"- `{name}`: {count}")
+    return "\n".join(lines) + "\n"

--- a/src/contextweaver/envelope.py
+++ b/src/contextweaver/envelope.py
@@ -17,9 +17,10 @@ from typing import Any, Literal
 
 from contextweaver.types import ArtifactRef, Phase, SelectableItem, ViewSpec
 
-#: Schema version for :meth:`BuildStats.report_dict` payloads.  Bumped on
-#: backwards-incompatible field changes.
-BUILD_STATS_REPORT_VERSION: int = 1
+#: Schema version for :meth:`BuildStats.report_dict` payloads.  Version 2
+#: adds per-item drop attribution and gives candidate counts one consistent
+#: pre-sensitivity meaning (issues #414 / #459).
+BUILD_STATS_REPORT_VERSION: int = 2
 
 #: Canonical firewall strategy labels recorded on :class:`FirewallStats`
 #: (issues #402 / #404 / #406).
@@ -164,14 +165,47 @@ class ResultEnvelope:
 
 
 @dataclass
+class DroppedItem:
+    """Lightweight attribution for one item excluded from a context build.
+
+    Attributes:
+        item_id: The excluded :class:`~contextweaver.types.ContextItem` id.
+        reason: The pipeline stage reason: ``"sensitivity"``, ``"dedup"``,
+            ``"kind_limit"``, or ``"budget"``.
+    """
+
+    item_id: str
+    reason: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialise to a JSON-compatible dict."""
+        return {"item_id": self.item_id, "reason": self.reason}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DroppedItem:
+        """Deserialise from a JSON-compatible dict."""
+        return cls(item_id=str(data["item_id"]), reason=str(data["reason"]))
+
+
+@dataclass
 class BuildStats:
-    """Diagnostic statistics produced by a context build pass."""
+    """Diagnostic statistics produced by a context build pass.
+
+    ``total_candidates`` is the number of phase candidates after dependency
+    closure and before sensitivity filtering. ``included_count`` is the final
+    number rendered into the prompt. ``dropped_count`` includes every later
+    exclusion (sensitivity, deduplication, kind limit, and token budget), so a
+    completed build satisfies ``included_count + dropped_count ==
+    total_candidates``. ``dropped_items`` carries the matching lightweight
+    per-item attribution without requiring ``explain=True``.
+    """
 
     tokens_per_section: dict[str, int] = field(default_factory=dict)
     total_candidates: int = 0
     included_count: int = 0
     dropped_count: int = 0
     dropped_reasons: dict[str, int] = field(default_factory=dict)
+    dropped_items: list[DroppedItem] = field(default_factory=list)
     dedup_removed: int = 0
     dependency_closures: int = 0
     header_footer_tokens: int = 0
@@ -233,6 +267,7 @@ class BuildStats:
             "included_count": self.included_count,
             "dropped_count": self.dropped_count,
             "dropped_reasons": dict(self.dropped_reasons),
+            "dropped_items": [item.to_dict() for item in self.dropped_items],
             "dedup_removed": self.dedup_removed,
             "dependency_closures": self.dependency_closures,
             "header_footer_tokens": self.header_footer_tokens,
@@ -248,6 +283,7 @@ class BuildStats:
             included_count=int(data.get("included_count", 0)),
             dropped_count=int(data.get("dropped_count", 0)),
             dropped_reasons=dict(data.get("dropped_reasons", {})),
+            dropped_items=[DroppedItem.from_dict(item) for item in data.get("dropped_items", [])],
             dedup_removed=int(data.get("dedup_removed", 0)),
             dependency_closures=int(data.get("dependency_closures", 0)),
             header_footer_tokens=int(data.get("header_footer_tokens", 0)),
@@ -328,7 +364,7 @@ def _build_stats_report_dict(
             )
 
     return {
-        "version": 1,
+        "version": BUILD_STATS_REPORT_VERSION,
         "phase": phase,
         "budget": budget,
         "prompt_tokens": prompt_tokens,
@@ -341,6 +377,7 @@ def _build_stats_report_dict(
             "dependency_closures": stats.dependency_closures,
         },
         "dropped_reasons": dict(reasons),
+        "dropped_items": [item.to_dict() for item in stats.dropped_items],
         "recommendations": recommendations,
     }
 

--- a/src/contextweaver/envelope.py
+++ b/src/contextweaver/envelope.py
@@ -170,10 +170,11 @@ class DroppedItem:
 
     Attributes:
         item_id: The excluded :class:`~contextweaver.types.ContextItem` id.
-        reason: The recorded exclusion reason. Common values include
-            ``"sensitivity"``, ``"dedup"``, ``"kind_limit"``, and
-            ``"budget"``, but callers may also persist policy- or
-            integration-specific reasons such as ``"policy"``.
+        reason: The recorded exclusion reason. Built-in values commonly
+            include ``"sensitivity"``, ``"dedup"``, ``"kind_limit"``,
+            and ``"budget"``, but the set is not exhaustive: callers may
+            also persist policy- or integration-specific reasons such as
+            ``"policy"``.
     """
 
     item_id: str

--- a/src/contextweaver/envelope.py
+++ b/src/contextweaver/envelope.py
@@ -170,8 +170,10 @@ class DroppedItem:
 
     Attributes:
         item_id: The excluded :class:`~contextweaver.types.ContextItem` id.
-        reason: The pipeline stage reason: ``"sensitivity"``, ``"dedup"``,
-            ``"kind_limit"``, or ``"budget"``.
+        reason: The recorded exclusion reason. Common values include
+            ``"sensitivity"``, ``"dedup"``, ``"kind_limit"``, and
+            ``"budget"``, but callers may also persist policy- or
+            integration-specific reasons such as ``"policy"``.
     """
 
     item_id: str

--- a/src/contextweaver/inspection.py
+++ b/src/contextweaver/inspection.py
@@ -1,0 +1,99 @@
+"""Offline diagnostic report construction for context builds and routes."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from contextweaver.context.explanation import ContextBuildExplanation
+    from contextweaver.envelope import ContextPack
+
+INSPECTION_REPORT_VERSION: int = 1
+
+
+def build_inspection_report(
+    pack: ContextPack,
+    *,
+    explanation: ContextBuildExplanation | None = None,
+    artifacts: Iterable[dict[str, Any]] = (),
+    routing: dict[str, Any] | None = None,
+    budget: int | None = None,
+) -> dict[str, Any]:
+    """Build a payload-safe context/routing/artifact diagnostic report.
+
+    Raw prompt text, event text, queries, argument values, and artifact bytes
+    are intentionally excluded. Candidate and artifact identifiers remain so
+    operators can drill down through their own stores.
+    """
+    candidates: list[dict[str, Any]] = []
+    if explanation is not None:
+        candidates = [
+            {
+                "item_id": item.item_id,
+                "kind": item.kind,
+                "sensitivity": item.sensitivity,
+                "score": round(item.score, 4) if item.score is not None else None,
+                "included": item.included,
+                "drop_reason": item.drop_reason,
+                "dependency_closure": item.dependency_closure,
+            }
+            for item in explanation.candidates
+        ]
+    return {
+        "version": INSPECTION_REPORT_VERSION,
+        "phase": pack.phase.value,
+        "build": pack.stats.report_dict(phase=pack.phase.value, budget=budget),
+        "candidates": candidates,
+        "artifacts": sorted(
+            (dict(item) for item in artifacts),
+            key=lambda item: str(item.get("handle", "")),
+        ),
+        "routing": routing,
+    }
+
+
+def render_inspection_report(report: dict[str, Any]) -> str:
+    """Render an inspection payload as deterministic Markdown."""
+    build = report["build"]
+    candidates = build["candidates"]
+    lines = [
+        "# Context Inspection",
+        "",
+        f"- Phase: {report.get('phase', '')}",
+        f"- Prompt tokens: {build.get('prompt_tokens', 0)}",
+        f"- Candidates: {candidates.get('total', 0)} total, "
+        f"{candidates.get('included', 0)} included, "
+        f"{candidates.get('dropped', 0)} dropped",
+        "",
+        "## Drops",
+    ]
+    dropped_items = build.get("dropped_items", [])
+    if dropped_items:
+        for item in dropped_items:
+            lines.append(f"- `{item['item_id']}`: {item['reason']}")
+    else:
+        lines.append("- None")
+
+    lines.extend(["", "## Artifacts"])
+    artifacts = report.get("artifacts", [])
+    if artifacts:
+        for item in artifacts:
+            lines.append(
+                f"- `{item.get('handle', '')}`: {item.get('media_type', '')}, "
+                f"{item.get('size_bytes', 0)} bytes"
+            )
+    else:
+        lines.append("- None")
+
+    routing = report.get("routing")
+    lines.extend(["", "## Routing"])
+    if routing:
+        ids = routing.get("candidate_ids", [])
+        lines.append(f"- Candidates: {len(ids)}")
+        for item_id, score in zip(ids, routing.get("scores", []), strict=False):
+            lines.append(f"- `{item_id}`: {score}")
+    else:
+        lines.append("- Not requested")
+    return "\n".join(lines) + "\n"

--- a/tests/fixtures/context_explain/basic_build.json
+++ b/tests/fixtures/context_explain/basic_build.json
@@ -67,14 +67,15 @@
   ],
   "dedup_removed": 1,
   "dependency_closures": 0,
-  "dropped_count": 1,
+  "dropped_count": 2,
   "dropped_reasons": {
+    "dedup": 1,
     "sensitivity": 1
   },
   "included_count": 5,
   "phase": "answer",
   "query": "weather",
   "sensitivity_drops": 1,
-  "total_candidates": 6,
+  "total_candidates": 7,
   "version": 1
 }

--- a/tests/fixtures/golden/route_prompt/basic.json
+++ b/tests/fixtures/golden/route_prompt/basic.json
@@ -53,6 +53,7 @@
       "dedup_removed": 0,
       "dependency_closures": 0,
       "dropped_count": 0,
+      "dropped_items": [],
       "dropped_reasons": {},
       "firewall_events": [],
       "header_footer_tokens": 81,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -382,6 +382,56 @@ def test_stats_subcommand_rich_format(tmp_path: Path) -> None:
 
 
 # ------------------------------------------------------------------
+# inspect (issue #398)
+# ------------------------------------------------------------------
+
+
+def test_inspect_subcommand_emits_payload_safe_json(tmp_path: Path) -> None:
+    jsonl_path = _write_session_jsonl(tmp_path)
+    ingested_path = tmp_path / "ingested.json"
+    _run("ingest", "--events", str(jsonl_path), "--out", str(ingested_path))
+
+    result = _run(
+        "inspect",
+        "--session",
+        str(ingested_path),
+        "--budget",
+        "1000",
+        "--format",
+        "json",
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["version"] == 1
+    assert payload["build"]["candidates"]["total"] > 0
+    assert "prompt" not in payload
+    assert "text" not in payload
+
+
+def test_inspect_subcommand_markdown_lists_drop_reasons(tmp_path: Path) -> None:
+    jsonl_path = tmp_path / "events.jsonl"
+    jsonl_path.write_text(
+        '{"id":"big","type":"user_turn","text":"large","token_estimate":500}\n',
+        encoding="utf-8",
+    )
+    ingested_path = tmp_path / "ingested.json"
+    _run("ingest", "--events", str(jsonl_path), "--out", str(ingested_path))
+
+    result = _run(
+        "inspect",
+        "--session",
+        str(ingested_path),
+        "--budget",
+        "10",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Context Inspection" in result.stdout
+    assert "`big`: budget" in result.stdout
+
+
+# ------------------------------------------------------------------
 # budget-check (issue #276)
 # ------------------------------------------------------------------
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -6,6 +6,9 @@ import json
 from pathlib import Path
 from typing import Any
 
+from pytest import MonkeyPatch
+
+import contextweaver.adapters.gateway_diagnostics as gateway_diagnostics
 from contextweaver.adapters.gateway_catalog_diagnostics import catalog_diagnostic_summary
 from contextweaver.adapters.mcp import mcp_tool_to_selectable
 from contextweaver.adapters.mcp_gateway import make_gateway_meta_tools
@@ -20,7 +23,7 @@ from contextweaver.diagnostics import (
     render_diagnostic_report,
     summarize_diagnostics,
 )
-from contextweaver.envelope import ResultEnvelope
+from contextweaver.envelope import ChoiceCard, ResultEnvelope
 from contextweaver.tokens import count
 
 
@@ -108,6 +111,38 @@ def test_catalog_summary_matches_exposed_meta_tool_schemas() -> None:
         for tool in make_proxy_meta_tools(runtime)
     )
     assert proxy["exposed_schema_tokens"] == proxy_expected
+
+
+def test_gateway_telemetry_skips_catalog_summary_when_disabled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    telemetry = gateway_diagnostics.GatewayTelemetry()
+
+    def fail(*args: object, **kwargs: object) -> dict[str, object]:
+        raise AssertionError("catalog summary should be skipped when diagnostics are disabled")
+
+    monkeypatch.setattr(gateway_diagnostics, "catalog_diagnostic_summary", fail)
+
+    telemetry.catalog_registered([], {}, mode="gateway")
+
+
+def test_gateway_telemetry_skips_browse_token_work_when_disabled(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    telemetry = gateway_diagnostics.GatewayTelemetry()
+
+    def fail(*args: object, **kwargs: object) -> int:
+        raise AssertionError("token counting should be skipped when diagnostics are disabled")
+
+    monkeypatch.setattr(gateway_diagnostics, "count", fail)
+
+    telemetry.browse_completed(
+        [ChoiceCard(id="github.create_issue", name="create_issue", description="Create")],
+        duration_ms=1.0,
+        query_chars=5,
+        path_depth=0,
+        raw_defs={"github.create_issue": {"inputSchema": {"type": "object"}}},
+    )
 
 
 async def test_proxy_runtime_emits_sanitized_operation_events() -> None:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,162 @@
+"""Tests for structured gateway diagnostics (issues #370 / #378)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from contextweaver.adapters.gateway_catalog_diagnostics import catalog_diagnostic_summary
+from contextweaver.adapters.mcp import mcp_tool_to_selectable
+from contextweaver.adapters.mcp_gateway import make_gateway_meta_tools
+from contextweaver.adapters.mcp_proxy import make_proxy_meta_tools
+from contextweaver.adapters.mcp_upstream import StubUpstream
+from contextweaver.adapters.proxy_runtime import ProxyRuntime
+from contextweaver.diagnostics import (
+    DiagnosticEvent,
+    InMemoryDiagnosticSink,
+    JsonlDiagnosticSink,
+    load_diagnostic_events,
+    render_diagnostic_report,
+    summarize_diagnostics,
+)
+from contextweaver.envelope import ResultEnvelope
+from contextweaver.tokens import count
+
+
+def _tool_defs() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "github.create_issue",
+            "description": "Create an issue.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"title": {"type": "string"}, "body": {"type": "string"}},
+                "required": ["title"],
+            },
+        }
+    ]
+
+
+def test_jsonl_sink_round_trips_events(tmp_path: Path) -> None:
+    path = tmp_path / "diagnostics.jsonl"
+    sink = JsonlDiagnosticSink(path)
+    sink.emit(
+        DiagnosticEvent(
+            event="browse.completed",
+            session_id="s1",
+            duration_ms=12.5,
+            attributes={"card_count": 2},
+        )
+    )
+
+    events = load_diagnostic_events(path)
+
+    assert len(events) == 1
+    assert events[0].event == "browse.completed"
+    assert events[0].attributes == {"card_count": 2}
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert raw["version"] == 1
+
+
+def test_summary_reports_savings_failures_views_and_latency() -> None:
+    events = [
+        DiagnosticEvent(
+            event="execute.completed",
+            session_id="s1",
+            tool_id="github:create",
+            namespace="github",
+            duration_ms=10,
+            attributes={"raw_tokens": 100, "compact_tokens": 20},
+        ),
+        DiagnosticEvent(
+            event="execute.failed",
+            session_id="s1",
+            success=False,
+            duration_ms=100,
+        ),
+        DiagnosticEvent(event="view.completed", session_id="s2", duration_ms=20),
+    ]
+
+    summary = summarize_diagnostics(events)
+
+    assert summary["event_count"] == 3
+    assert summary["session_count"] == 2
+    assert summary["failure_count"] == 1
+    assert summary["tokens_saved"] == 80
+    assert summary["artifact_view_count"] == 1
+    assert summary["latency_ms"] == {"count": 3, "p50": 20, "p95": 100, "max": 100}
+    assert "Gateway Diagnostics" in render_diagnostic_report(summary)
+
+
+def test_catalog_summary_matches_exposed_meta_tool_schemas() -> None:
+    raw = _tool_defs()[0]
+    item = mcp_tool_to_selectable(raw)
+    runtime = ProxyRuntime(StubUpstream([raw]))
+    runtime.register_tool_defs_sync([raw])
+
+    gateway = catalog_diagnostic_summary([item], {item.id: raw}, mode="gateway")
+    gateway_expected = sum(
+        count(json.dumps(tool["inputSchema"], sort_keys=True, separators=(",", ":")))
+        for tool in make_gateway_meta_tools(runtime)
+    )
+    assert gateway["exposed_schema_tokens"] == gateway_expected
+
+    proxy = catalog_diagnostic_summary([item], {item.id: raw}, mode="transparent")
+    proxy_expected = count('{"type":"object"}') + sum(
+        count(json.dumps(tool["inputSchema"], sort_keys=True, separators=(",", ":")))
+        for tool in make_proxy_meta_tools(runtime)
+    )
+    assert proxy["exposed_schema_tokens"] == proxy_expected
+
+
+async def test_proxy_runtime_emits_sanitized_operation_events() -> None:
+    async def handler(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        _ = name, args
+        return {"content": [{"type": "text", "text": "x" * 800}], "isError": False}
+
+    sink = InMemoryDiagnosticSink()
+    runtime = ProxyRuntime(
+        StubUpstream(_tool_defs(), handler=handler),
+        diagnostic_sink=sink,
+        session_id="session-test",
+    )
+    runtime.register_tool_defs_sync(_tool_defs())
+    tool_id = runtime.list_tool_ids()[0]
+    runtime.browse(query="secret query")
+    runtime.hydrate(tool_id)
+    result = await runtime.execute(tool_id, {"title": "private title", "body": "private body"})
+    assert isinstance(result, ResultEnvelope)
+    handle = result.artifacts[0].handle
+    runtime.view(handle, {"type": "head", "chars": 10})
+
+    events = sink.events()
+    assert [event.event for event in events] == [
+        "catalog.loaded",
+        "browse.completed",
+        "hydrate.completed",
+        "execute.completed",
+        "view.completed",
+    ]
+    execute_event = next(event for event in events if event.event == "execute.completed")
+    assert execute_event.attributes["arg_keys"] == ["body", "title"]
+    encoded = json.dumps([event.to_dict() for event in events])
+    assert "secret query" not in encoded
+    assert "private title" not in encoded
+    assert "private body" not in encoded
+    assert execute_event.attributes["raw_tokens"] > execute_event.attributes["compact_tokens"]
+    assert result.firewall_stats is not None
+    assert result.firewall_stats.triggered is True
+
+
+async def test_proxy_runtime_emits_failure_event() -> None:
+    sink = InMemoryDiagnosticSink()
+    runtime = ProxyRuntime(StubUpstream(_tool_defs()), diagnostic_sink=sink)
+    runtime.register_tool_defs_sync(_tool_defs())
+
+    await runtime.execute(runtime.list_tool_ids()[0], {})
+
+    failure = sink.events()[-1]
+    assert failure.event == "execute.failed"
+    assert failure.success is False
+    assert failure.attributes["error_code"] == "ARGS_INVALID"

--- a/tests/test_envelope.py
+++ b/tests/test_envelope.py
@@ -7,9 +7,11 @@ from datetime import datetime, timezone
 import pytest
 
 from contextweaver.envelope import (
+    BUILD_STATS_REPORT_VERSION,
     BuildStats,
     ChoiceCard,
     ContextPack,
+    DroppedItem,
     ResultEnvelope,
     RoutingDecision,
 )
@@ -71,6 +73,7 @@ def test_build_stats_defaults() -> None:
     assert bs.included_count == 0
     assert bs.dropped_count == 0
     assert bs.dropped_reasons == {}
+    assert bs.dropped_items == []
     assert bs.dedup_removed == 0
     assert bs.dependency_closures == 0
     assert bs.header_footer_tokens == 0
@@ -83,6 +86,10 @@ def test_build_stats_roundtrip() -> None:
         included_count=30,
         dropped_count=20,
         dropped_reasons={"budget": 15, "policy": 5},
+        dropped_items=[
+            DroppedItem(item_id="budget-item", reason="budget"),
+            DroppedItem(item_id="policy-item", reason="policy"),
+        ],
         dedup_removed=3,
         dependency_closures=2,
         header_footer_tokens=42,
@@ -94,6 +101,10 @@ def test_build_stats_roundtrip() -> None:
     assert restored.included_count == 30
     assert restored.dropped_count == 20
     assert restored.dropped_reasons == {"budget": 15, "policy": 5}
+    assert restored.dropped_items == [
+        DroppedItem(item_id="budget-item", reason="budget"),
+        DroppedItem(item_id="policy-item", reason="policy"),
+    ]
     assert restored.dedup_removed == 3
     assert restored.dependency_closures == 2
     assert restored.header_footer_tokens == 42
@@ -215,7 +226,7 @@ def test_build_stats_report_rich_has_markup() -> None:
 
 def test_build_stats_report_dict_versioned() -> None:
     payload = _sample_stats().report_dict(phase="answer", budget=4000)
-    assert payload["version"] == 1
+    assert payload["version"] == BUILD_STATS_REPORT_VERSION
     assert payload["phase"] == "answer"
     assert payload["budget"] == 4000
     assert payload["prompt_tokens"] == 180 + 1200 + 1800 + 320
@@ -228,6 +239,7 @@ def test_build_stats_report_dict_versioned() -> None:
     }
     # dropped_reasons sorted deterministically
     assert list(payload["dropped_reasons"].keys()) == ["budget_exceeded", "dedup", "sensitivity"]
+    assert payload["dropped_items"] == []
 
 
 def test_build_stats_report_dict_empty_recommendations_without_budget() -> None:

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -6,6 +6,7 @@ import json
 
 import pytest
 
+from contextweaver.config import ContextBudget, ContextPolicy
 from contextweaver.context.manager import ContextManager
 from contextweaver.exceptions import ContextWeaverError, ItemNotFoundError
 from contextweaver.routing.catalog import Catalog
@@ -21,6 +22,7 @@ from contextweaver.types import (
     Phase,
     ResultEnvelope,
     SelectableItem,
+    Sensitivity,
 )
 
 
@@ -29,6 +31,29 @@ def _make_log(*texts: str) -> InMemoryEventLog:
     for i, text in enumerate(texts):
         log.append(ContextItem(id=f"item-{i}", kind=ItemKind.user_turn, text=text))
     return log
+
+
+class _RecordingHook:
+    """Capture build lifecycle callbacks for production-pipeline tests."""
+
+    def __init__(self) -> None:
+        self.excluded: list[tuple[list[str], str]] = []
+        self.budget_events: list[tuple[int, int]] = []
+
+    def on_context_built(self, pack: ContextPack) -> None:
+        _ = pack
+
+    def on_firewall_triggered(self, item: ContextItem, reason: str) -> None:
+        _ = item, reason
+
+    def on_items_excluded(self, items: list[ContextItem], reason: str) -> None:
+        self.excluded.append(([item.id for item in items], reason))
+
+    def on_budget_exceeded(self, requested: int, budget: int) -> None:
+        self.budget_events.append((requested, budget))
+
+    def on_route_completed(self, tool_ids: list[str]) -> None:
+        _ = tool_ids
 
 
 @pytest.mark.asyncio
@@ -62,6 +87,49 @@ async def test_build_stats_populated() -> None:
     mgr = ContextManager(event_log=log)
     pack = await mgr.build(phase=Phase.answer)
     assert pack.stats.total_candidates == 3
+
+
+def test_build_stats_attribute_every_drop_and_fire_hooks() -> None:
+    log = InMemoryEventLog()
+    log.append(ContextItem(id="keep", kind=ItemKind.user_turn, text="keep", token_estimate=20))
+    log.append(ContextItem(id="dup-a", kind=ItemKind.doc_snippet, text="same text"))
+    log.append(ContextItem(id="dup-b", kind=ItemKind.doc_snippet, text="same text"))
+    log.append(ContextItem(id="kind-limit", kind=ItemKind.doc_snippet, text="different text"))
+    log.append(
+        ContextItem(
+            id="secret",
+            kind=ItemKind.memory_fact,
+            text="secret",
+            sensitivity=Sensitivity.confidential,
+        )
+    )
+    log.append(ContextItem(id="budget", kind=ItemKind.agent_msg, text="large", token_estimate=100))
+    policy = ContextPolicy()
+    policy.max_items_per_kind[ItemKind.doc_snippet] = 1
+    hook = _RecordingHook()
+    mgr = ContextManager(
+        event_log=log,
+        budget=ContextBudget(answer=40),
+        policy=policy,
+        hook=hook,
+    )
+
+    pack = mgr.build_sync(phase=Phase.answer, query="keep")
+
+    assert pack.stats.included_count + pack.stats.dropped_count == pack.stats.total_candidates
+    assert pack.stats.total_candidates == 6
+    dropped = {item.item_id: item.reason for item in pack.stats.dropped_items}
+    assert dropped["secret"] == "sensitivity"
+    assert dropped["budget"] == "budget"
+    assert sorted(dropped.values()) == ["budget", "dedup", "kind_limit", "sensitivity"]
+    assert pack.stats.dropped_reasons == {
+        "budget": 1,
+        "dedup": 1,
+        "kind_limit": 1,
+        "sensitivity": 1,
+    }
+    assert sorted(reason for _ids, reason in hook.excluded) == sorted(pack.stats.dropped_reasons)
+    assert len(hook.budget_events) == 1
 
 
 def test_build_sync() -> None:

--- a/tests/test_mcp_serve_cli.py
+++ b/tests/test_mcp_serve_cli.py
@@ -8,6 +8,7 @@ the flag-parsing rules (mutual exclusion of ``--gateway``/``--proxy``).
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -72,6 +73,8 @@ def test_mcp_help_lists_serve_subcommand() -> None:
     out = _strip_ansi(result.stdout)
     assert "serve" in out
     assert "MCP server entrypoints" in out or "MCP" in out
+    assert "inspect" in out
+    assert "stats" in out
 
 
 def test_mcp_serve_help_shows_required_catalog_flag() -> None:
@@ -85,6 +88,8 @@ def test_mcp_serve_help_shows_required_catalog_flag() -> None:
     assert "--gateway" in out
     assert "--proxy" in out
     assert "--dry-run" in out
+    assert "--diagnostics" in out
+    assert "--quiet" in out
 
 
 # ------------------------------------------------------------------
@@ -126,6 +131,27 @@ def test_serve_dry_run_proxy_mode_with_packaged_catalog() -> None:
     )
     assert result.returncode == 0
     assert "mode=proxy" in result.stderr + result.stdout
+
+
+def test_serve_dry_run_writes_catalog_diagnostic_event(tmp_path: Path) -> None:
+    events = tmp_path / "gateway.jsonl"
+    result = _run(
+        "mcp",
+        "serve",
+        "--catalog",
+        str(gateway_catalog_path()),
+        "--diagnostics",
+        str(events),
+        "--dry-run",
+        "--quiet",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    assert result.stderr == ""
+    payload = json.loads(events.read_text(encoding="utf-8"))
+    assert payload["event"] == "catalog.loaded"
+    assert payload["attributes"]["tool_count"] == 60
 
 
 def test_serve_gateway_flag_shortcut() -> None:
@@ -301,6 +327,17 @@ def test_load_serve_config_coerces_quoted_bool(tmp_path: Path) -> None:
     assert _load_serve_config(cfg)["cache_stable"] is True
 
 
+def test_load_serve_config_resolves_diagnostics_and_quiet(tmp_path: Path) -> None:
+    cfg = tmp_path / "gateway.yaml"
+    cfg.write_text(
+        "catalog: catalog.json\ndiagnostics: logs/events.jsonl\nquiet: true\n",
+        encoding="utf-8",
+    )
+    loaded = _load_serve_config(cfg)
+    assert loaded["diagnostics"] == str((tmp_path / "logs" / "events.jsonl").resolve())
+    assert loaded["quiet"] is True
+
+
 def test_load_serve_config_rejects_bad_types(tmp_path: Path) -> None:
     cfg = tmp_path / "c.yaml"
     cfg.write_text("catalog: x.json\ntop_k: not-a-number\n", encoding="utf-8")
@@ -400,3 +437,42 @@ def test_build_runtime_proxy_mode_registers_all_tools() -> None:
     )
     assert runtime.mode == ExposureMode.TRANSPARENT
     assert len(runtime.list_tool_ids()) == 60
+
+
+def test_mcp_inspect_reports_catalog_savings_json() -> None:
+    result = _run(
+        "mcp",
+        "inspect",
+        "--catalog",
+        str(gateway_catalog_path()),
+        "--format",
+        "json",
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["tool_count"] == 60
+    assert payload["exposed_tool_count"] == 3
+    assert payload["schema_tokens_avoided"] > 0
+
+
+def test_mcp_stats_aggregates_jsonl(tmp_path: Path) -> None:
+    events = tmp_path / "events.jsonl"
+    events.write_text(
+        json.dumps(
+            {
+                "event": "execute.completed",
+                "timestamp": "2026-06-11T00:00:00+00:00",
+                "session_id": "s1",
+                "success": True,
+                "duration_ms": 12,
+                "attributes": {"raw_tokens": 100, "compact_tokens": 25},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = _run("mcp", "stats", "--events", str(events), "--format", "json")
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["event_count"] == 1
+    assert payload["tokens_saved"] == 75

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -17,10 +17,10 @@ def test_select_within_budget() -> None:
     policy = ContextPolicy()
     estimator = CharDivFourEstimator()
     scored = [(1.0 - i * 0.1, _item(f"i{i}", tokens=100)) for i in range(3)]
-    selected, stats = select_and_pack(scored, Phase.answer, budget, policy, estimator)
-    total_tokens = sum(item.token_estimate for item in selected)
+    outcome = select_and_pack(scored, Phase.answer, budget, policy, estimator)
+    total_tokens = sum(item.token_estimate for item in outcome.selected)
     assert total_tokens <= 500
-    assert stats.included_count == len(selected)
+    assert outcome.dropped == []
 
 
 def test_select_respects_kind_limit() -> None:
@@ -29,17 +29,18 @@ def test_select_respects_kind_limit() -> None:
     policy.max_items_per_kind[ItemKind.user_turn] = 2
     estimator = CharDivFourEstimator()
     scored = [(1.0, _item(f"i{i}", ItemKind.user_turn, tokens=10)) for i in range(5)]
-    selected, stats = select_and_pack(scored, Phase.answer, budget, policy, estimator)
-    user_turns = [s for s in selected if s.kind == ItemKind.user_turn]
+    outcome = select_and_pack(scored, Phase.answer, budget, policy, estimator)
+    user_turns = [s for s in outcome.selected if s.kind == ItemKind.user_turn]
     assert len(user_turns) == 2
-    assert stats.dropped_reasons.get("kind_limit", 0) >= 3
+    assert [reason for _item, reason in outcome.dropped] == ["kind_limit"] * 3
 
 
-def test_build_stats_populated() -> None:
-    budget = ContextBudget(answer=1000)
+def test_select_reports_exact_budget_drops_and_overrun() -> None:
+    budget = ContextBudget(answer=150)
     policy = ContextPolicy()
     estimator = CharDivFourEstimator()
     scored = [(1.0, _item("i1", tokens=100)), (0.5, _item("i2", tokens=100))]
-    _, stats = select_and_pack(scored, Phase.answer, budget, policy, estimator)
-    assert stats.total_candidates == 2
-    assert stats.included_count + stats.dropped_count == 2
+    outcome = select_and_pack(scored, Phase.answer, budget, policy, estimator)
+    assert [item.id for item in outcome.selected] == ["i1"]
+    assert [(item.id, reason) for item, reason in outcome.dropped] == [("i2", "budget")]
+    assert outcome.budget_overruns == [(200, 150)]


### PR DESCRIPTION
## Summary

Make context and gateway diagnostics trustworthy end to end: attribute every dropped context item, fire production lifecycle hooks, emit payload-safe gateway telemetry, aggregate operator statistics, and expose CLI inspect/report commands.

Fixes #414
Fixes #459
Fixes #370
Fixes #378
Fixes #398

## Changes

- Added `DroppedItem` attribution to `BuildStats`, bumped the report schema to version 2, and enforced `included + dropped == total` across sensitivity, deduplication, kind-limit, and budget exclusions.
- Fired exclusion and budget lifecycle hooks from the production context pipeline and reused the exact drop reasons in build explanations.
- Added versioned diagnostic events, in-memory and JSONL sinks, deterministic aggregation, latency distributions, token/schema savings, namespace counts, failures, and Markdown rendering.
- Instrumented gateway/proxy catalog, browse, hydrate, execute, and view operations without recording query text, argument values, result text, prompts, or artifact bytes.
- Added `contextweaver inspect`, `contextweaver mcp inspect`, `contextweaver mcp stats`, and `mcp serve --diagnostics/--quiet`, including config-file support.
- Updated schemas, fixtures, tests, changelog, architecture/concept/security/operator docs, recipe config, and generated `llms-full.txt`.

## Checklist

- [x] Tests added or updated for every new/changed public function
- [x] `make ci` passes locally (fmt + lint + type + test + schemas-check + example + demo) - equivalent repo commands were run individually on Windows because GNU Make is unavailable
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docstrings added for all new public APIs (Google-style)
- [x] Every modified module stays ≤ 300 lines (N/A for pre-existing `proxy_runtime.py`, which was 586 lines before this PR; new instrumentation is decomposed into 85- and 254-line helpers, and `_mcp_cli.py` is a documented exemption)
- [x] Related issue linked in the summary above
- [x] Agent-facing docs updated if pipeline, API, or conventions changed

## Notes for reviewers

### How verified

- `.venv\Scripts\python.exe -m ruff format --check src tests examples scripts` - 293 files already formatted
- `.venv\Scripts\python.exe -m ruff check src tests examples scripts` - all checks passed
- `.venv\Scripts\python.exe -m mypy src` - success, 126 source files
- `.venv\Scripts\python.exe -m pytest --basetemp C:\Users\dandrsantos\AppData\Local\Temp\contextweaver-pytest-escalated-20260611 --cov=contextweaver --cov-report=term-missing -q` - 1,955 passed, 67 skipped, 1 xfailed; 81% coverage
- Schema, demo-cast, scorecard, gateway-scorecard, README-version, context-rot, and llms generated-file checks passed
- All 29 example/reference-architecture commands and the default CLI demo passed
- `mkdocs build --clean` passed with existing warnings only
- `git diff --cached --check` passed

### Behavior evidence

The production accounting regression now reports six candidates as two included and four dropped, with one exact attribution for each of sensitivity, deduplication, kind-limit, and budget, plus one budget lifecycle event. Previously pre-selection exclusions were omitted from totals and production callbacks were not fired.

### Tradeoffs / risks

- This intentionally changes the low-level selection outcome and `BuildStats` report schema to version 2; backward compatibility was not retained for this owner-authorized combined change.
- JSONL events omit payload content but retain operational identifiers, namespaces, argument key names, sizes, timings, errors, and artifact references; the security guide treats the files as sensitive operational data.
- The packaged `mcp inspect` path analyzes the configured static catalog and the existing stub runtime; it does not contact an upstream MCP server.
- Diagnostic sink failures are logged and never fail gateway calls.

### Scope

The diff is limited to the shared context-accounting model, gateway telemetry/reporting, CLI surfaces, tests, generated schemas, and required documentation for issues #414, #459, #370, #378, and #398. No dependencies were added.

## Reproducibility (scoring / context-pipeline changes)

This changes accounting and observability, not candidate scores or selection decisions. The deterministic context regression and generated scorecard checks passed; the benchmark matrix was not regenerated, and CI can provide the sticky benchmark delta.