### PR TITLE
chore(release): 0.14.1 + MCP Registry listing & OIDC publish (#348)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Publish to PyPI and MCP Registry
 
 on:
   release:
@@ -29,3 +29,34 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # Required for MCP Registry GitHub OIDC authentication
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server.json (retry while PyPI metadata propagates)
+        run: |
+          for attempt in 1 2 3 4 5 6; do
+            if ./mcp-publisher publish; then
+              echo "Published to the MCP Registry."
+              exit 0
+            fi
+            echo "Attempt $attempt failed (PyPI metadata may still be propagating); retrying in 30s..."
+            sleep 30
+          done
+          echo "::error::mcp-publisher publish failed after 6 attempts." >&2
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-06-11
+
 ### Added
 
+- **MCP Registry listing + PyPI ownership marker (#348).** Adds a
+  registry-publishable `server.json` describing the gateway as a
+  `uvx contextweaver mcp serve --config <gateway.yaml>` stdio server (linking
+  to the gateway quickstart, not the raw API docs), an
+  `mcp-name: io.github.dgenio/contextweaver` marker in the README for PyPI
+  ownership verification, and a release-triggered GitHub Actions job that
+  publishes to the official MCP Registry via GitHub OIDC (no interactive
+  login required).
 - **Trustworthy diagnostics across context builds and the MCP gateway
   (#370, #378, #398, #414, #459).** `BuildStats.dropped_items` attributes
   every excluded item to `sensitivity`, `dedup`, `kind_limit`, or `budget`;

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # contextweaver
 
+<!-- mcp-name: io.github.dgenio/contextweaver -->
+
 [![CI](https://github.com/dgenio/contextweaver/actions/workflows/ci.yml/badge.svg)](https://github.com/dgenio/contextweaver/actions/workflows/ci.yml)
 [![PyPI version](https://img.shields.io/pypi/v/contextweaver.svg)](https://pypi.org/project/contextweaver/)
 [![Python versions](https://img.shields.io/pypi/pyversions/contextweaver.svg)](https://pypi.org/project/contextweaver/)
@@ -617,7 +619,7 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 
 ### 6. Roadmap & Community
 
-Current package version: **0.14.0**.
+Current package version: **0.14.1**.
 
 Recent milestones:
 
@@ -649,7 +651,7 @@ Recent milestones:
 
 | Approach | Tool routing | History compaction | Sensitivity firewall | Deterministic | MCP-native |
 |---|---|---|---|---|---|
-| **contextweaver** (this repo, [v0.14.0](https://pypi.org/project/contextweaver/0.14.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42-84 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
+| **contextweaver** (this repo, [v0.14.1](https://pypi.org/project/contextweaver/0.14.1/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42-84 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
 | **Naïve concat-everything** | ❌ No router · prompt carries every tool schema | ❌ No compaction · prompt grows with turn count | ❌ Raw outputs in the prompt | ⚠️ Only if the upstream LLM is | ⚠️ Compatible but no shaping |
 | **LangGraph memory** ([0.6.x](https://github.com/langchain-ai/langgraph/releases)) | ❌ Out of scope — LangGraph routes state, not tools | ⚠️ Optional via `ConversationSummaryMemory` (LLM-based, non-deterministic) [^lg-mem] | ❌ Not provided | ⚠️ Workflow yes; memory summarizer no | ⚠️ Possible via custom adapter, not first-class |
 | **LlamaIndex retrievers** ([0.11.x](https://github.com/run-llama/llama_index/releases)) | ⚠️ Tool retrieval via `ObjectIndex` is unranked similarity, no bounded routing | ⚠️ `ChatMemoryBuffer` token-bounded · no phase awareness [^li-mem] | ❌ Not provided · large outputs flow through verbatim | ⚠️ Retriever yes; summarizer no | ⚠️ Possible via custom tool wrapper |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -32,6 +32,8 @@
 
 # contextweaver
 
+<!-- mcp-name: io.github.dgenio/contextweaver -->
+
 [![CI](https://github.com/dgenio/contextweaver/actions/workflows/ci.yml/badge.svg)](https://github.com/dgenio/contextweaver/actions/workflows/ci.yml)
 [![PyPI version](https://img.shields.io/pypi/v/contextweaver.svg)](https://pypi.org/project/contextweaver/)
 [![Python versions](https://img.shields.io/pypi/pyversions/contextweaver.svg)](https://pypi.org/project/contextweaver/)
@@ -649,7 +651,7 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 
 ### 6. Roadmap & Community
 
-Current package version: **0.14.0**.
+Current package version: **0.14.1**.
 
 Recent milestones:
 
@@ -681,7 +683,7 @@ Recent milestones:
 
 | Approach | Tool routing | History compaction | Sensitivity firewall | Deterministic | MCP-native |
 |---|---|---|---|---|---|
-| **contextweaver** (this repo, [v0.14.0](https://pypi.org/project/contextweaver/0.14.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42-84 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
+| **contextweaver** (this repo, [v0.14.1](https://pypi.org/project/contextweaver/0.14.1/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42-84 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
 | **Naïve concat-everything** | ❌ No router · prompt carries every tool schema | ❌ No compaction · prompt grows with turn count | ❌ Raw outputs in the prompt | ⚠️ Only if the upstream LLM is | ⚠️ Compatible but no shaping |
 | **LangGraph memory** ([0.6.x](https://github.com/langchain-ai/langgraph/releases)) | ❌ Out of scope — LangGraph routes state, not tools | ⚠️ Optional via `ConversationSummaryMemory` (LLM-based, non-deterministic) [^lg-mem] | ❌ Not provided | ⚠️ Workflow yes; memory summarizer no | ⚠️ Possible via custom adapter, not first-class |
 | **LlamaIndex retrievers** ([0.11.x](https://github.com/run-llama/llama_index/releases)) | ⚠️ Tool retrieval via `ObjectIndex` is unranked similarity, no bounded routing | ⚠️ `ChatMemoryBuffer` token-bounded · no phase awareness [^li-mem] | ❌ Not provided · large outputs flow through verbatim | ⚠️ Retriever yes; summarizer no | ⚠️ Possible via custom tool wrapper |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "contextweaver"
-version = "0.14.0"
+version = "0.14.1"
 description = "Context firewall + tool router for MCP and tool-heavy AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.dgenio/contextweaver",
+  "title": "contextweaver",
+  "description": "MCP gateway: bounded tool shortlists + artifact-backed result firewall. Deterministic, no model.",
+  "websiteUrl": "https://dgenio.github.io/contextweaver/recipes/",
+  "repository": {
+    "url": "https://github.com/dgenio/contextweaver",
+    "source": "github"
+  },
+  "version": "0.14.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "contextweaver",
+      "version": "0.14.1",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        },
+        {
+          "type": "positional",
+          "value": "serve"
+        },
+        {
+          "type": "named",
+          "name": "--config",
+          "description": "Path to a gateway config (YAML/JSON) declaring the upstream tool catalog and serve options (mode, top_k, beam_width). See the gateway quickstart at https://dgenio.github.io/contextweaver/recipes/.",
+          "format": "filepath",
+          "isRequired": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Prepares the **0.14.1** release that completes the MCP Registry half of #348, and **automates registry publishing so no interactive login is ever needed**.

## What this does

- **`server.json`** — registry-publishable manifest. Describes the gateway as a `uvx contextweaver mcp serve --config <gateway.yaml>` stdio server and points `websiteUrl` at the **gateway quickstart** (not raw API docs), satisfying the issue's "link to quickstart" criterion. Schema-validated against the official `2025-12-11` server schema.
- **README `mcp-name` marker** — `<!-- mcp-name: io.github.dgenio/contextweaver -->`. This is how the MCP Registry verifies PyPI package ownership (it reads the marker from the published PyPI long-description).
- **Version bump 0.14.0 → 0.14.1** — `pyproject.toml` + the two README version references the `make readme-version-check` gate enforces. `llms-full.txt` regenerated.
- **OIDC MCP-Registry publish job** — new `publish-mcp-registry` job in `publish.yml`, gated on `needs: publish`. It authenticates with `mcp-publisher login github-oidc` (GitHub OIDC, **no secret, no device-code login**) and runs `mcp-publisher publish` with a retry loop to absorb PyPI propagation lag. After this merges, **cutting a GitHub Release publishes to PyPI _and_ the MCP Registry automatically.**

## Why a patch release

Current `main` already includes #563 (diagnostics), which sits in `[Unreleased]`. Cutting `0.14.1` from `main` bundles diagnostics + this registry listing — both reviewed/merged work.

## Release sequence (after merge)

1. Merge this PR to `main`.
2. Tag + create the `v0.14.1` GitHub Release → `publish.yml` publishes to PyPI (with the marker in the README), then the `publish-mcp-registry` job publishes `server.json` via OIDC.

## Validation run locally

- `python scripts/check_readme_version.py` → in sync (0.14.1)
- `python scripts/gen_llms.py --check` → no drift
- `server.json` → schema validation PASS
- `publish.yml` → YAML parses; `publish-mcp-registry` correctly `needs: publish`

Closes #348 once the release ships.
