### PR TITLE
feat(mcp): add gateway Dockerfile; serve advertises package version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,52 @@
+# Keep the Docker build context small and reproducible. The image only needs
+# pyproject.toml, README.md, LICENSE, and src/ to build + run the gateway.
+
+# Version control & CI
+.git/
+.github/
+.gitignore
+
+# Multiple full repo clones — must never enter the build context
+.claude/
+
+# Editors / IDEs
+.vscode/
+.idea/
+
+# Build / packaging artifacts
+build/
+dist/
+site/
+*.egg-info/
+src/*.egg-info/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Python caches & coverage
+__pycache__/
+*.py[cod]
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+coverage.xml
+
+# Not needed to build or run the gateway
+tests/
+docs/
+benchmarks/
+examples/
+notebooks/
+drafts/
+scripts/
+schemas/
+llms.txt
+llms-full.txt
+
+# The image builds these itself
+Dockerfile
+.dockerignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Dockerfile for the MCP gateway.** A top-level `Dockerfile` (+ `.dockerignore`)
+  boots `contextweaver mcp serve --gateway` over stdio against the packaged
+  reference catalog, so an MCP client or automated scanner (e.g. Glama) can
+  build, start, and introspect the gateway with no extra configuration. The
+  image build validates the catalog with `--dry-run`.
+
+### Changed
+
+- **`contextweaver mcp serve` advertises the installed package version.**
+  `--version` now defaults to the contextweaver package version (was `None`)
+  when neither the flag nor the config file sets it, and the resolved version
+  is shown in the serve lifecycle line.
+
 ## [0.14.1] - 2026-06-11
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+#
+# contextweaver — MCP Context Gateway (stdio) image.
+#
+# Boots contextweaver in *gateway* mode over stdio: an MCP client / inspector
+# sees a bounded set of meta-tools (tool_browse / tool_execute / tool_view)
+# instead of a full upstream tool catalog, plus an artifact-backed result
+# firewall. The image is self-contained — it fronts the packaged 60-tool
+# reference catalog, so it starts and answers MCP `initialize` + `tools/list`
+# with no external configuration. That is exactly what an automated scanner
+# (e.g. Glama) needs to introspect and score the server.
+#
+#   Build:  docker build -t contextweaver-gateway .
+#   Run:    docker run --rm -i contextweaver-gateway        # speak MCP over stdio
+#
+# To front your own upstream catalog instead of the bundled reference one,
+# mount it and append a --catalog override (the last --catalog wins):
+#   docker run --rm -i -v "$PWD/catalog.json:/app/catalog.json" \
+#       contextweaver-gateway --catalog /app/catalog.json
+
+FROM python:3.12-slim
+
+# stdio MCP transport must not buffer; keep the image quiet and reproducible.
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+# Install contextweaver from source — matches the repo being scanned and needs
+# no published release. Core deps only (tiktoken, PyYAML, rank-bm25, mcp,
+# jsonschema, typer, rich); the gateway requires no optional extras, and all
+# core deps ship manylinux/pure-python wheels so no compiler is needed.
+COPY . /app
+RUN pip install .
+
+# Expose the packaged reference catalog at a stable path (copied from the
+# source tree so this does not depend on wheel package-data), and fail the
+# build early if the gateway config does not validate.
+RUN cp /app/src/contextweaver/data/mcp_gateway_catalog.yaml /app/catalog.yaml \
+    && contextweaver mcp serve --gateway --catalog /app/catalog.yaml --dry-run
+
+# Run the long-lived server process unprivileged.
+RUN useradd --create-home --uid 10001 app && chown -R app:app /app
+USER app
+
+# Speak MCP in gateway mode over stdio. --quiet keeps stdout reserved for the
+# protocol (lifecycle logs are suppressed). Extra `docker run` arguments are
+# appended to this command, so `--catalog /path` overrides the bundled catalog.
+ENTRYPOINT ["contextweaver", "mcp", "serve", "--gateway", "--catalog", "/app/catalog.yaml", "--quiet"]

--- a/src/contextweaver/_mcp_cli.py
+++ b/src/contextweaver/_mcp_cli.py
@@ -38,6 +38,7 @@ from typing import Annotated, Any
 import typer
 import yaml
 
+from contextweaver._version import __version__
 from contextweaver.adapters.gateway_catalog_diagnostics import catalog_diagnostic_summary
 from contextweaver.adapters.mcp_gateway_server import McpGatewayServer
 from contextweaver.adapters.mcp_proxy_server import McpProxyServer
@@ -490,7 +491,13 @@ def serve(
     ] = "contextweaver",
     version: Annotated[
         str | None,
-        typer.Option("--version", help="Optional MCP server version string."),
+        typer.Option(
+            "--version",
+            help=(
+                "MCP server version advertised on init. Defaults to the installed "
+                "contextweaver package version."
+            ),
+        ),
     ] = None,
     dry_run: Annotated[
         bool,
@@ -563,6 +570,11 @@ def serve(
         )
     resolved_mode = _ServeMode.gateway if gateway else _ServeMode.proxy if proxy else mode
 
+    # Advertise the installed contextweaver version on MCP ``initialize`` unless
+    # an explicit version was supplied via ``--version`` or the config file.
+    if version is None:
+        version = __version__
+
     diagnostic_sink = JsonlDiagnosticSink(diagnostics) if diagnostics is not None else None
     runtime = _build_runtime(
         catalog,
@@ -579,7 +591,7 @@ def serve(
             f"contextweaver mcp serve: mode={resolved_mode.value} "
             f"catalog={catalog} tools={tool_count} top_k={top_k} "
             f"beam_width={beam_width} cache_stable={cache_stable} "
-            f"diagnostics={diagnostics or 'off'}",
+            f"version={version} diagnostics={diagnostics or 'off'}",
             err=True,
         )
 

--- a/tests/test_mcp_serve_cli.py
+++ b/tests/test_mcp_serve_cli.py
@@ -117,6 +117,26 @@ def test_serve_dry_run_with_packaged_gateway_catalog() -> None:
     assert "dry-run" in combined
 
 
+def test_serve_dry_run_advertises_installed_package_version() -> None:
+    """``serve`` advertises the installed contextweaver version by default."""
+    import contextweaver
+
+    catalog = gateway_catalog_path()
+    result = _run("mcp", "serve", "--catalog", str(catalog), "--dry-run")
+    assert result.returncode == 0
+    combined = result.stderr + result.stdout
+    assert f"version={contextweaver.__version__}" in combined
+
+
+def test_serve_dry_run_explicit_version_overrides_default() -> None:
+    """An explicit ``--version`` wins over the package-version default."""
+    catalog = gateway_catalog_path()
+    result = _run("mcp", "serve", "--catalog", str(catalog), "--version", "9.9.9-test", "--dry-run")
+    assert result.returncode == 0
+    combined = result.stderr + result.stdout
+    assert "version=9.9.9-test" in combined
+
+
 def test_serve_dry_run_proxy_mode_with_packaged_catalog() -> None:
     """Proxy mode also validates the catalog and exits 0."""
     catalog = gateway_catalog_path()


### PR DESCRIPTION
## What

Two related changes to make the contextweaver MCP gateway easy to build, run, and introspect from a container — the prerequisite for a Glama listing (issue #348 follow-up).

- **`Dockerfile` + `.dockerignore`** — boots `contextweaver mcp serve --gateway` over stdio against the packaged 60-tool reference catalog. Self-contained (core deps only, non-root user), and the image build validates the catalog with `--dry-run`. An MCP client or automated scanner (e.g. Glama) can build the image, start it, and get a working `initialize` + `tools/list` with no extra configuration.
- **`mcp serve --version` now defaults to the installed package version** (was `None`) when neither the `--version` flag nor the config file sets it. The resolved version is shown in the serve lifecycle line and advertised on MCP `initialize`.

## Why

The Glama listing check (and good container hygiene generally) needs a Dockerfile whose container starts and responds to introspection. Advertising the real package version on `initialize` makes the server self-describe correctly to clients and registries instead of echoing the MCP SDK version.

## Validation

- `contextweaver mcp serve --gateway --catalog <packaged> --dry-run` → `mode=gateway tools=60 ... version=<pkg>`, catalog validated.
- Live stdio MCP handshake → `initialize` + `tools/list` returns `tool_browse`, `tool_execute`, `tool_view`.
- `ruff format --check`, `ruff check`, `mypy` clean on changed files.
- `pytest tests/test_mcp_serve_cli.py` → 32 passed (incl. 2 new: package-version default + explicit `--version` override).

## Notes

- Docker is not installed on the dev machine, so the image was validated by running the exact ENTRYPOINT command + a real stdio introspection handshake rather than `docker build`. CI / Glama will exercise the actual build.
- No runtime dependency changes; the gateway needs no optional extras.
