### PR TITLE
feat(gateway): harden untrusted upstream input across ingest, validation, and dispatch (#464, #484, #485, #488)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,9 @@ It prepares context and routes tools but never calls models or executes tools.
 | `adapters/mcp_upstream.py` | Concrete `UpstreamCall` adapters (`StubUpstream`, `McpClientUpstream`, `MultiplexUpstream`) |
 | `adapters/mcp_gateway_server.py` | Bind `mcp_gateway` onto `mcp.server.Server` over stdio (issue #28) |
 | `adapters/mcp_proxy_server.py` | Bind `mcp_proxy` onto `mcp.server.Server` over stdio (issue #13) |
-| `adapters/gateway_error.py` | Structured `GatewayError` (codes + §3.4 wire shape) |
+| `adapters/gateway_error.py` | Structured `GatewayError` (codes + §3.4 wire shape) + `retryable` hint. Upstream-error taxonomy: `classify_upstream_exception` maps timeouts/connection/auth/permission/rate failures to `UPSTREAM_TIMEOUT`/`UPSTREAM_UNAVAILABLE`/`AUTH_FAILED`/`PERMISSION_DENIED`/`RATE_LIMITED` (fallback `UPSTREAM_ERROR`); `redact_upstream_detail` strips control chars + caps length on model-visible detail (issue #485). |
+| `adapters/gateway_validation.py` | Untrusted-schema hardening for the gateway ingest path (issues #464/#484): `SchemaLimits`/`SchemaFinding`/`SkippedTool`/`CatalogRefreshReport`, `check_schema_health` (meta-validation + iterative size/depth/property bounds), `build_validator` (cached per `tool_id`). Pure, deterministic; iterative traversal avoids stack exhaustion on hostile schemas. |
+| `adapters/gateway_args.py` | Opt-in deterministic tool-call argument repair (issue #488): `normalize_args` (stringified-object parse + schema-demanded `str→int/number/boolean/null` coercion) + `Repair`. Gated behind `ProxyRuntime(tolerant_args=True)`; never renames keys, drops keys, or fuzzy-matches. |
 | `adapters/openai_messages.py` | OpenAI Chat Completions `messages` ↔ `ContextItem` round-trip (`from_/to_openai_messages`, issue #219) |
 | `adapters/anthropic_messages.py` | Anthropic Messages API `messages` ↔ `ContextItem` round-trip (`from_/to_anthropic_messages`, issue #222) |
 | `adapters/gemini_contents.py` | Google Gemini `contents[]` ↔ `ContextItem` round-trip (`from_/to_gemini_contents`, issue #222) |
@@ -148,10 +150,10 @@ For full pipeline descriptions and design rationale, see [docs/agent-context/arc
 | `MaskRedactionHook` | Built-in redaction hook for sensitivity enforcement |
 | `HydrationResult` | Result of hydrating a tool call with context |
 | `ViewRegistry` | Maps content-type patterns to view generators for progressive disclosure |
-| `ProxyRuntime` | Shared core for MCP proxy (#13) and gateway (#28) modes — owns upstream catalog, per-session `ContextManager`, browse / execute / view dispatch; persisted text results are returned as envelope artifact refs for `tool_view` |
+| `ProxyRuntime` | Shared core for MCP proxy (#13) and gateway (#28) modes — owns upstream catalog, per-session `ContextManager`, browse / execute / view dispatch; persisted text results are returned as envelope artifact refs for `tool_view`. Hardens the untrusted-input boundary (issues #464/#484/#485/#488): `on_invalid` (skip/raise) + `schema_limits` + `last_refresh_report` at ingest, cached per-`tool_id` validators, classified+redacted upstream errors, and opt-in `tolerant_args`. |
 | `ExposureMode` | `TRANSPARENT` (#13) vs `GATEWAY` (#28) for `ProxyRuntime` |
 | `UpstreamCall` | Transport-agnostic Protocol over upstream MCP fan-out (used by `ProxyRuntime`) |
-| `GatewayError` | Structured error payload (§3.4) returned from every gateway/proxy meta-tool |
+| `GatewayError` | Structured error payload (§3.4) returned from every gateway/proxy meta-tool. Carries a `retryable` hint and a classified upstream-error taxonomy (issue #485) plus the `SCHEMA_INVALID` ingest code (issue #484) |
 | `ToolIdParts` | Destructured canonical `tool_id` (namespace / name / version / hash8) |
 
 **Vocabulary notes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   raise a label, never lower it. Every raise records
   `metadata["sensitivity_raised_by"]` (the classifier's type name) so the
   decision is auditable.
+- **Gateway untrusted-input hardening (#464, #484, #485, #488).** The
+  proxy/gateway ingest, validation, and dispatch boundary now defends against
+  malformed or hostile upstream input:
+  - **Defensive tool-def registration (#464).** A malformed upstream tool
+    definition (non-dict, or missing a non-empty string `name`) no longer
+    aborts catalog refresh; the offending tool is skipped and recorded on the
+    new `ProxyRuntime.last_refresh_report` (`CatalogRefreshReport`). A new
+    `on_invalid="raise"` mode fails loudly for development catalogs.
+  - **Untrusted-schema validation + validator caching (#484).** Upstream
+    `inputSchema`/`outputSchema` are meta-validated (`check_schema`) and bounded
+    for serialized size, nesting depth, and property count (configurable via
+    `SchemaLimits`) at ingest, surfacing `SchemaFinding`s on the refresh report.
+    Compiled `jsonschema` validators are cached per `tool_id`, removing
+    per-call recompilation from the hot `tool_execute` path. A malformed schema
+    surfaces as the new `SCHEMA_INVALID` error code.
+  - **Structured upstream-error taxonomy (#485).** `GatewayError` gains a
+    `retryable` hint and the codes `UPSTREAM_TIMEOUT`, `UPSTREAM_UNAVAILABLE`,
+    `AUTH_FAILED`, `PERMISSION_DENIED`, and `RATE_LIMITED`
+    (`classify_upstream_exception`), with `UPSTREAM_ERROR` kept as the fallback.
+    Model-visible upstream detail is now control-character-stripped and
+    length-capped (`redact_upstream_detail`); operators keep full detail via
+    logging.
+  - **Opt-in tolerant argument normalization (#488).**
+    `ProxyRuntime(tolerant_args=True)` runs a deterministic, rule-based repair
+    pass (`normalize_args`) before strict validation — stringified JSON objects
+    and string→`int`/`number`/`boolean`/`null` coercions, only when the schema
+    type demands it. Off by default (byte-identical behaviour); every repair is
+    recorded under the result envelope's `provenance["arg_repairs"]`.
 
 ### Changed
 

--- a/docs/gateway_spec.md
+++ b/docs/gateway_spec.md
@@ -293,15 +293,35 @@ the gateway):
 
 ```json
 {
-  "error": "PATH_INVALID" | "PATH_NOT_FOUND" | "ARGS_INVALID",
-  "message": "<human-readable>",
+  "error": "PATH_INVALID" | "PATH_NOT_FOUND" | "ARGS_INVALID" | "SCHEMA_INVALID"
+         | "UPSTREAM_ERROR" | "UPSTREAM_TIMEOUT" | "UPSTREAM_UNAVAILABLE"
+         | "AUTH_FAILED" | "PERMISSION_DENIED" | "RATE_LIMITED"
+         | "HYDRATE_FAILED" | "VIEW_FAILED",
+  "message": "<human-readable, redacted>",
   "path": "<offending path or empty>",
+  "retryable": false,
   "details": { /* optional, implementation-defined */ }
 }
 ```
 
 `PATH_INVALID` covers malformed paths (§3.2 violations); `PATH_NOT_FOUND`
 covers well-formed paths that do not exist in the current `ChoiceGraph`.
+
+**Upstream-error taxonomy (issue #485).** Failures from the wrapped MCP
+server are classified so agents can branch without string-matching:
+`UPSTREAM_TIMEOUT` and `UPSTREAM_UNAVAILABLE` (transient transport
+failures), `AUTH_FAILED` / `PERMISSION_DENIED` (credential/authorization
+problems), `RATE_LIMITED` (throttling), with `UPSTREAM_ERROR` as the
+conservative fallback for everything else. The `retryable` boolean is a hint
+that the same call may succeed on retry (set for timeouts, unavailability,
+and rate limits). `SCHEMA_INVALID` flags an *upstream tool schema* that
+failed ingest-time validation (§4.4), as opposed to `ARGS_INVALID` which
+flags caller-supplied arguments.
+
+**Detail redaction.** Upstream exception text can carry hostnames, paths, or
+tokens. The `message` field is collapsed to a single control-character-free
+line and length-capped before it reaches model-visible context; operators
+retain the full, unredacted detail via server-side logging / event hooks.
 
 ## 4. Schema-exposure strategy
 
@@ -391,6 +411,36 @@ semantics are implementation-defined per backend but MUST honour the
 `args` against the hydrated schema before invoking upstream. Validation
 errors return `{"error": "ARGS_INVALID", ...}` per §3.4 and MUST NOT
 reach the upstream server.
+
+**Schema trust and complexity (issue #484).** Upstream `inputSchema` /
+`outputSchema` are themselves untrusted. At catalog ingest the runtime runs
+JSON-Schema meta-validation (`check_schema`) and bounds schema complexity —
+serialized size, nesting depth, and total property count, all configurable
+via `SchemaLimits` with generous defaults. Findings are recorded on
+`ProxyRuntime.last_refresh_report`; in the default lenient mode the tool is
+still registered (flag-and-continue), while `on_invalid="raise"` rejects the
+catalog. Compiled validators are cached per `tool_id` so repeated
+`tool_execute` calls do not recompile. A schema that fails meta-validation
+surfaces as `SCHEMA_INVALID` (not `ARGS_INVALID`) at execute time.
+
+**Tolerant argument normalization (issue #488, opt-in).** With
+`ProxyRuntime(tolerant_args=True)`, a deterministic, rule-based repair pass
+runs *before* strict validation. The fixed rule set is:
+
+| Rule | Condition | Action |
+|---|---|---|
+| `parse_stringified_object` | `args` is a string that parses as a JSON object | parse it (after stripping a leading BOM + surrounding whitespace) |
+| `str_to_integer` | field schema type is `integer` and value is an exact integer literal | coerce to `int` |
+| `str_to_number` | field schema type is `number` and value is a finite numeric literal | coerce to `float` |
+| `str_to_boolean` | field schema type is `boolean` and value is exactly `"true"`/`"false"` | coerce to `bool` |
+| `str_to_null` | field schema type is `null` (and not also `string`) and value is `"null"` | coerce to `None` |
+
+No key renaming, no fuzzy matching, no dropping of unknown keys; a coercion
+is applied only when the target schema type demands it (so a `string`-typed
+field is never coerced). Anything not repaired still fails `ARGS_INVALID`.
+Off by default, behaviour is byte-identical to strict validation. Every
+applied repair is recorded under the result envelope's
+`provenance["arg_repairs"]` so the normalization is auditable.
 
 ## 5. Cache-stable tool browsing (`cache_stable=True`)
 

--- a/src/contextweaver/adapters/__init__.py
+++ b/src/contextweaver/adapters/__init__.py
@@ -61,7 +61,19 @@ from contextweaver.adapters.fastmcp import (
     make_context_hook,
     make_discovery_tool,
 )
-from contextweaver.adapters.gateway_error import GatewayError
+from contextweaver.adapters.gateway_args import Repair, normalize_args
+from contextweaver.adapters.gateway_error import (
+    GatewayError,
+    classify_upstream_exception,
+    redact_upstream_detail,
+)
+from contextweaver.adapters.gateway_validation import (
+    CatalogRefreshReport,
+    SchemaFinding,
+    SchemaLimits,
+    SkippedTool,
+    check_schema_health,
+)
 from contextweaver.adapters.gemini_contents import (
     from_gemini_contents,
     to_gemini_contents,
@@ -124,6 +136,7 @@ from contextweaver.adapters.weaver_contracts import (
 )
 
 __all__ = [
+    "CatalogRefreshReport",
     "ExposureMode",
     "GATEWAY_TOOL_NAMES",
     "GatewayError",
@@ -131,6 +144,10 @@ __all__ = [
     "MultiplexUpstream",
     "PROXY_META_TOOL_NAMES",
     "ProxyRuntime",
+    "Repair",
+    "SchemaFinding",
+    "SchemaLimits",
+    "SkippedTool",
     "StubUpstream",
     "UpstreamCall",
     "a2a_agent_to_selectable",
@@ -139,6 +156,8 @@ __all__ = [
     "agno_tools_to_catalog",
     "chainweaver_flow_to_selectable",
     "chainweaver_flows_to_catalog",
+    "check_schema_health",
+    "classify_upstream_exception",
     "crewai_tool_to_selectable",
     "crewai_tools_to_catalog",
     "dispatch_meta_tool",
@@ -178,8 +197,10 @@ __all__ = [
     "make_stripped_tools_list",
     "mcp_result_to_envelope",
     "mcp_tool_to_selectable",
+    "normalize_args",
     "pydantic_ai_tool_to_selectable",
     "pydantic_ai_tools_to_catalog",
+    "redact_upstream_detail",
     "selectable_from_agno_tool",
     "selectable_from_pydantic_tool",
     "selectable_from_smolagents_tool",

--- a/src/contextweaver/adapters/gateway_args.py
+++ b/src/contextweaver/adapters/gateway_args.py
@@ -1,0 +1,151 @@
+"""Opt-in tolerant argument normalization for the gateway execute path (#488).
+
+Models routinely emit tool-call arguments that are *semantically* correct but
+*structurally* off: the whole ``args`` object serialized as a JSON string,
+``"42"`` for an integer field, ``"true"`` for a boolean.  Under strict schema
+validation these hard-fail with ``ARGS_INVALID`` and cost a full model
+round-trip to repair.
+
+:func:`normalize_args` is a bounded, **deterministic, rule-based** repair tier —
+no fuzzy matching, no key renaming, no dropping of unknown keys.  It is gated
+behind ``ProxyRuntime(tolerant_args=True)`` and runs *before* strict validation,
+so anything not covered by an explicit rule still fails validation exactly as it
+does today.  Every repair is reported so the behaviour stays auditable.
+
+Coercion is applied only when the target schema type *demands* it: a string
+value whose field is typed ``string`` is never coerced, and ``"yes"`` is never
+turned into a boolean because that is not an exact JSON-boolean literal.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from dataclasses import dataclass
+from typing import Any
+
+#: Exact lexical form of a JSON integer (no leading ``+``, no decimal point).
+_INTEGER_RE = re.compile(r"^-?(?:0|[1-9][0-9]*)$")
+#: Exact lexical form of a JSON number (integer, decimal, or exponent).
+_NUMBER_RE = re.compile(r"^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?$")
+
+#: UTF-8 byte-order-mark sometimes prepended to stringified payloads.
+_BOM = "﻿"
+
+
+@dataclass(frozen=True)
+class Repair:
+    """A single normalization applied to one argument (#488).
+
+    Attributes:
+        path: JSON-path-ish location of the repair (``"$"`` for the whole
+            object, ``"$.field"`` for a single field).
+        rule: The rule that fired — one of ``parse_stringified_object``,
+            ``str_to_integer``, ``str_to_number``, ``str_to_boolean``,
+            or ``str_to_null``.
+    """
+
+    path: str
+    rule: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialise to a JSON-compatible dict."""
+        return {"path": self.path, "rule": self.rule}
+
+
+def _target_types(field_schema: object) -> set[str]:
+    """Return the declared JSON Schema ``type`` set for a field, if any."""
+    if not isinstance(field_schema, dict):
+        return set()
+    declared = field_schema.get("type")
+    if isinstance(declared, str):
+        return {declared}
+    if isinstance(declared, list):
+        return {t for t in declared if isinstance(t, str)}
+    return set()
+
+
+def _coerce_scalar(value: str, types: set[str]) -> tuple[Any, str | None]:
+    """Coerce a string *value* to a scalar demanded by *types*.
+
+    Returns ``(coerced_value, rule_name)`` on success, or ``(value, None)``
+    when no rule applies.  Rules are tried in a fixed order; ``string`` in the
+    target set means the value is already valid and is left untouched.
+    """
+    if "string" in types or not types:
+        return value, None
+    if "integer" in types and _INTEGER_RE.match(value):
+        return int(value), "str_to_integer"
+    if "number" in types and _NUMBER_RE.match(value):
+        number = float(value)
+        if math.isfinite(number):
+            return number, "str_to_number"
+    if "boolean" in types and value in ("true", "false"):
+        return value == "true", "str_to_boolean"
+    if "null" in types and value == "null":
+        return None, "str_to_null"
+    return value, None
+
+
+def normalize_args(
+    args: object,
+    schema: dict[str, Any] | None,
+) -> tuple[Any, list[Repair]]:
+    """Deterministically repair common LLM argument malformations (#488).
+
+    Applies, in order:
+
+    1. If *args* is a string that parses as a JSON object, parse it (after
+       stripping a leading BOM and surrounding whitespace).
+    2. For each field whose schema ``type`` demands a non-string scalar and
+       whose value is a string in the exact lexical form of that scalar,
+       coerce it.
+
+    No key renaming, no fuzzy matching, no dropping of unknown keys.  Anything
+    not repaired is returned unchanged for strict validation to reject.
+
+    Args:
+        args: The raw arguments (usually a dict, occasionally a JSON string).
+        schema: The hydrated input schema, used to decide which coercions are
+            warranted.  ``None`` / empty disables per-field coercion.
+
+    Returns:
+        ``(normalized_args, repairs)`` where *repairs* lists every applied rule.
+    """
+    repairs: list[Repair] = []
+
+    if isinstance(args, str):
+        candidate = args.lstrip(_BOM).strip()
+        try:
+            parsed = json.loads(candidate)
+        except (ValueError, TypeError):
+            parsed = None
+        if isinstance(parsed, dict):
+            args = parsed
+            repairs.append(Repair("$", "parse_stringified_object"))
+        else:
+            # Not a JSON object — leave untouched; strict validation will reject.
+            return args, repairs
+
+    if not isinstance(args, dict):
+        return args, repairs
+
+    properties = (schema or {}).get("properties")
+    if not isinstance(properties, dict):
+        return args, repairs
+
+    out: dict[str, Any] = dict(args)
+    for key, value in list(out.items()):
+        if not isinstance(value, str):
+            continue
+        types = _target_types(properties.get(key))
+        coerced, rule = _coerce_scalar(value.strip(), types)
+        if rule is not None:
+            out[key] = coerced
+            repairs.append(Repair(f"$.{key}", rule))
+
+    return out, repairs
+
+
+__all__ = ["Repair", "normalize_args"]

--- a/src/contextweaver/adapters/gateway_error.py
+++ b/src/contextweaver/adapters/gateway_error.py
@@ -5,10 +5,19 @@ specified by ``docs/gateway_spec.md`` §3.4.  It is returned from
 ``tool_browse``, ``tool_execute``, ``tool_view``, and ``tool_hydrate``
 when an invocation cannot be satisfied — the meta-tools never raise
 across the MCP boundary.
+
+A structured upstream-error taxonomy (issue #485) distinguishes failures
+agents recover from differently — a timeout invites retry, an auth failure
+invites escalation — via :func:`classify_upstream_exception`.  Upstream
+exception text (which can carry hostnames, paths, or tokens) is passed
+through :func:`redact_upstream_detail` before it reaches model-visible
+context; operators keep the full detail via server-side logging.
 """
 
 from __future__ import annotations
 
+import asyncio
+import re
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -16,10 +25,23 @@ GatewayErrorCode = Literal[
     "PATH_INVALID",
     "PATH_NOT_FOUND",
     "ARGS_INVALID",
+    "SCHEMA_INVALID",
     "UPSTREAM_ERROR",
+    "UPSTREAM_TIMEOUT",
+    "UPSTREAM_UNAVAILABLE",
+    "AUTH_FAILED",
+    "PERMISSION_DENIED",
+    "RATE_LIMITED",
     "HYDRATE_FAILED",
     "VIEW_FAILED",
 ]
+
+#: Default cap on the length of model-visible upstream error detail.
+DEFAULT_DETAIL_MAX_LEN = 256
+
+# Matches C0/C1 control characters (including newlines and tabs) so redacted
+# detail is a single clean line with no terminal-escape or layout-breaking bytes.
+_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
 
 @dataclass
@@ -27,14 +49,20 @@ class GatewayError:
     """Structured error payload returned from a gateway/proxy meta-tool.
 
     Attributes:
-        code: One of the gateway error codes (§3.4).  ``UPSTREAM_ERROR``
-            extends the spec list to cover transport failures from the
-            wrapped MCP server; ``HYDRATE_FAILED`` and ``VIEW_FAILED``
-            cover the analogous failures on the gateway's other two
-            meta-tools.
-        message: A short, human-readable description of the failure.
+        code: One of the gateway error codes (§3.4).  ``UPSTREAM_ERROR`` and the
+            finer-grained ``UPSTREAM_TIMEOUT`` / ``UPSTREAM_UNAVAILABLE`` /
+            ``AUTH_FAILED`` / ``PERMISSION_DENIED`` / ``RATE_LIMITED`` codes
+            classify failures from the wrapped MCP server (issue #485);
+            ``SCHEMA_INVALID`` flags an upstream tool schema that failed
+            ingest-time validation (issue #484); ``HYDRATE_FAILED`` and
+            ``VIEW_FAILED`` cover the gateway's other two meta-tools.
+        message: A short, human-readable description of the failure.  For
+            upstream failures this is redacted detail safe for model context.
         path: The offending path or tool_id when relevant; empty string
             otherwise.
+        retryable: Hint that a client may retry the same call (e.g. timeouts,
+            transient unavailability, rate limits).  Lets agent loops branch
+            without string-matching the message.
         details: Optional implementation-defined diagnostics (e.g.
             ``jsonschema`` validation error path lists).
     """
@@ -42,6 +70,7 @@ class GatewayError:
     code: GatewayErrorCode
     message: str
     path: str = ""
+    retryable: bool = False
     details: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -50,6 +79,7 @@ class GatewayError:
             "error": self.code,
             "message": self.message,
             "path": self.path,
+            "retryable": self.retryable,
         }
         if self.details:
             out["details"] = dict(self.details)
@@ -62,5 +92,59 @@ class GatewayError:
             code=data["error"],
             message=data.get("message", ""),
             path=data.get("path", ""),
+            retryable=bool(data.get("retryable", False)),
             details=dict(data.get("details", {})),
         )
+
+
+def redact_upstream_detail(text: str, *, max_len: int = DEFAULT_DETAIL_MAX_LEN) -> str:
+    """Return *text* stripped of control characters and capped in length (#485).
+
+    Upstream exception text can contain hostnames, filesystem paths, tokens, or
+    terminal-escape bytes.  This collapses it to a single bounded line safe for
+    model-visible context; operators retain the full detail via logging.
+
+    Args:
+        text: Raw upstream error detail.
+        max_len: Maximum length of the returned string.
+
+    Returns:
+        A single-line, length-bounded, control-character-free string.
+    """
+    cleaned = " ".join(_CONTROL_RE.sub(" ", text).split())
+    if len(cleaned) > max_len:
+        cleaned = cleaned[: max_len - 1].rstrip() + "…"
+    return cleaned
+
+
+def classify_upstream_exception(exc: BaseException) -> tuple[GatewayErrorCode, bool]:
+    """Map an upstream-call exception to a taxonomy code + retryable hint (#485).
+
+    The mapping is intentionally conservative: well-understood exception types
+    (timeouts, connection failures) map structurally, a small set of
+    auth/permission/rate signatures map by message, and everything else falls
+    back to the generic ``UPSTREAM_ERROR``.
+
+    Args:
+        exc: The exception raised by the upstream ``call_tool`` invocation.
+
+    Returns:
+        ``(code, retryable)``.
+    """
+    if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+        return "UPSTREAM_TIMEOUT", True
+    if isinstance(exc, ConnectionError):
+        return "UPSTREAM_UNAVAILABLE", True
+
+    text = str(exc).lower()
+    if any(
+        marker in text for marker in ("unauthorized", "401", "authentication", "invalid api key")
+    ):
+        return "AUTH_FAILED", False
+    if any(marker in text for marker in ("forbidden", "403", "permission denied", "access denied")):
+        return "PERMISSION_DENIED", False
+    if any(marker in text for marker in ("rate limit", "429", "too many requests")):
+        return "RATE_LIMITED", True
+    if "timed out" in text or "timeout" in text:
+        return "UPSTREAM_TIMEOUT", True
+    return "UPSTREAM_ERROR", False

--- a/src/contextweaver/adapters/gateway_error.py
+++ b/src/contextweaver/adapters/gateway_error.py
@@ -104,6 +104,11 @@ def redact_upstream_detail(text: str, *, max_len: int = DEFAULT_DETAIL_MAX_LEN) 
     terminal-escape bytes.  This collapses it to a single bounded line safe for
     model-visible context; operators retain the full detail via logging.
 
+    Note: this **sanitises and bounds** the text — it strips control characters
+    and truncates to *max_len* — it does **not** scrub secrets.  Secrets are not
+    detectable in arbitrary upstream text; the length cap bounds the exposure
+    blast radius, and full detail is kept operator-side only (never the model).
+
     Args:
         text: Raw upstream error detail.
         max_len: Maximum length of the returned string.

--- a/src/contextweaver/adapters/gateway_validation.py
+++ b/src/contextweaver/adapters/gateway_validation.py
@@ -23,12 +23,27 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Literal, Protocol, cast, runtime_checkable
 
 import jsonschema
 import jsonschema.exceptions
-import jsonschema.protocols
 import jsonschema.validators
+
+
+@runtime_checkable
+class SchemaValidator(Protocol):
+    """Minimal structural type for a compiled ``jsonschema`` validator.
+
+    Only the :meth:`validate` method is used by the gateway hot path.  Typing
+    against this local Protocol rather than ``jsonschema.protocols.Validator``
+    keeps the module import-safe across the whole ``jsonschema>=4.0`` floor and
+    avoids coupling to that submodule's availability.
+    """
+
+    def validate(self, instance: object) -> None:
+        """Validate *instance*, raising ``ValidationError`` on failure."""
+        ...
+
 
 #: Finding categories emitted by :func:`check_schema_health`.
 SchemaFindingKind = Literal[
@@ -229,7 +244,7 @@ def check_schema_health(
     return findings
 
 
-def build_validator(schema: dict[str, Any]) -> jsonschema.protocols.Validator:
+def build_validator(schema: dict[str, Any]) -> SchemaValidator:
     """Compile a reusable ``jsonschema`` validator for *schema* (#484).
 
     The compiled validator is cached by the runtime keyed on ``tool_id`` so the
@@ -246,7 +261,7 @@ def build_validator(schema: dict[str, Any]) -> jsonschema.protocols.Validator:
     """
     validator_cls = jsonschema.validators.validator_for(schema)
     validator_cls.check_schema(schema)
-    return validator_cls(schema)
+    return cast(SchemaValidator, validator_cls(schema))
 
 
 __all__ = [
@@ -254,6 +269,7 @@ __all__ = [
     "CatalogRefreshReport",
     "SchemaFinding",
     "SchemaFindingKind",
+    "SchemaValidator",
     "SchemaLimits",
     "SkippedTool",
     "build_validator",

--- a/src/contextweaver/adapters/gateway_validation.py
+++ b/src/contextweaver/adapters/gateway_validation.py
@@ -1,0 +1,261 @@
+"""Untrusted tool-definition and schema hardening for the gateway ingest path.
+
+External MCP servers supply tool definitions and JSON Schemas the gateway does
+not control.  Two failure classes are handled here:
+
+* **Malformed tool definitions** (issue #464) — a definition that is not a dict,
+  or lacks a non-empty string ``name``, must degrade *that* tool, not abort the
+  whole catalog refresh.  :class:`CatalogRefreshReport` records every skip so the
+  loss is auditable rather than silent.
+* **Untrusted / pathological schemas** (issue #484) — a schema that is not
+  well-formed, or whose size / nesting depth / property count is pathological,
+  is detected at *ingest* (via :func:`check_schema_health`) instead of at first
+  execution.  :func:`build_validator` compiles a reusable ``jsonschema``
+  validator so the hot ``tool_execute`` path no longer recompiles per call.
+
+Everything in this module is pure and deterministic — no I/O, no runtime state.
+The complexity traversal is iterative on purpose: a recursive walk over a
+hostile, deeply-nested schema could exhaust the interpreter stack, which is
+exactly the kind of untrusted-input failure this module exists to prevent.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import jsonschema
+import jsonschema.exceptions
+import jsonschema.protocols
+import jsonschema.validators
+
+#: Finding categories emitted by :func:`check_schema_health`.
+SchemaFindingKind = Literal[
+    "not_well_formed",
+    "size_exceeded",
+    "depth_exceeded",
+    "properties_exceeded",
+]
+
+
+@dataclass(frozen=True)
+class SchemaLimits:
+    """Conservative complexity bounds applied to untrusted tool schemas (#484).
+
+    Defaults are deliberately generous so legitimate large enterprise schemas
+    pass; tighten them per deployment when wrapping less-trusted upstreams.
+
+    Attributes:
+        max_bytes: Maximum serialized schema size in UTF-8 bytes.
+        max_depth: Maximum nesting depth of dict/list containers.
+        max_properties: Maximum total ``properties`` keys across the schema.
+    """
+
+    max_bytes: int = 65_536
+    max_depth: int = 32
+    max_properties: int = 512
+
+
+#: Shared default used when a caller does not supply its own limits.
+DEFAULT_SCHEMA_LIMITS = SchemaLimits()
+
+
+@dataclass(frozen=True)
+class SchemaFinding:
+    """A single schema-health problem detected at catalog ingest (#484).
+
+    Attributes:
+        tool_id: Canonical ``tool_id`` whose schema produced the finding.
+        kind: The category of problem (see :data:`SchemaFindingKind`).
+        detail: Short, human-readable explanation (already bounded in length).
+    """
+
+    tool_id: str
+    kind: SchemaFindingKind
+    detail: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Serialise to a JSON-compatible dict."""
+        return {"tool_id": self.tool_id, "kind": self.kind, "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class SkippedTool:
+    """A malformed upstream tool definition that was skipped at ingest (#464).
+
+    Attributes:
+        index: Position of the definition in the upstream ``tools/list`` array.
+        name: The raw ``name`` value if one could be read, else an empty string.
+        reason: Short, human-readable reason the definition was skipped.
+    """
+
+    index: int
+    name: str
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-compatible dict."""
+        return {"index": self.index, "name": self.name, "reason": self.reason}
+
+
+@dataclass
+class CatalogRefreshReport:
+    """Outcome of a catalog refresh: what registered, what was rejected (#464/#484).
+
+    A fully-valid catalog yields ``registered == len(tool_defs)`` with empty
+    :attr:`skipped` and :attr:`schema_findings`.  Supports ``int(report)`` so
+    callers that only want the registered count keep a terse call site.
+
+    Attributes:
+        registered: Number of tools successfully registered.
+        skipped: Malformed definitions that were dropped (lenient mode).
+        schema_findings: Schema-health problems detected on registered tools.
+    """
+
+    registered: int = 0
+    skipped: list[SkippedTool] = field(default_factory=list)
+    schema_findings: list[SchemaFinding] = field(default_factory=list)
+
+    def __int__(self) -> int:
+        """Return the registered-tool count (terse-call-site convenience)."""
+        return self.registered
+
+    @property
+    def ok(self) -> bool:
+        """``True`` when nothing was skipped and no schema findings were raised."""
+        return not self.skipped and not self.schema_findings
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-compatible dict."""
+        return {
+            "registered": self.registered,
+            "skipped": [s.to_dict() for s in self.skipped],
+            "schema_findings": [f.to_dict() for f in self.schema_findings],
+        }
+
+
+def _schema_metrics(schema: object) -> tuple[int, int]:
+    """Return ``(max_depth, property_count)`` via an iterative traversal.
+
+    Iterative rather than recursive so a hostile, deeply-nested untrusted
+    schema cannot exhaust the interpreter stack before the depth bound is
+    even checked.
+
+    Args:
+        schema: A parsed JSON Schema value (dict, list, or scalar).
+
+    Returns:
+        The maximum container-nesting depth and the total number of
+        ``properties`` keys found anywhere in the schema.
+    """
+    max_depth = 0
+    property_count = 0
+    stack: list[tuple[Any, int]] = [(schema, 0)]
+    while stack:
+        node, depth = stack.pop()
+        if depth > max_depth:
+            max_depth = depth
+        if isinstance(node, dict):
+            properties = node.get("properties")
+            if isinstance(properties, dict):
+                property_count += len(properties)
+            for value in node.values():
+                stack.append((value, depth + 1))
+        elif isinstance(node, list):
+            for value in node:
+                stack.append((value, depth + 1))
+    return max_depth, property_count
+
+
+def check_schema_health(
+    tool_id: str,
+    schema: dict[str, Any] | None,
+    *,
+    limits: SchemaLimits = DEFAULT_SCHEMA_LIMITS,
+) -> list[SchemaFinding]:
+    """Validate an untrusted tool *schema* and bound its complexity (#484).
+
+    Runs the JSON Schema meta-validation (``check_schema``) plus serialized-size,
+    nesting-depth, and property-count bounds.  Returns a list of findings; an
+    empty list means the schema is well-formed and within bounds.  An empty or
+    ``None`` schema is always healthy (the sentinel ``{"type": "object"}`` and
+    "no schema" cases impose no validation).
+
+    Args:
+        tool_id: Canonical ``tool_id`` the schema belongs to (for the finding).
+        schema: The tool's ``inputSchema`` / ``outputSchema`` dict, or ``None``.
+        limits: Complexity bounds to enforce.
+
+    Returns:
+        A list of :class:`SchemaFinding`, possibly empty.
+    """
+    findings: list[SchemaFinding] = []
+    if not schema:
+        return findings
+
+    try:
+        serialized = json.dumps(schema, sort_keys=True, separators=(",", ":"))
+    except (TypeError, ValueError, RecursionError) as exc:
+        return [SchemaFinding(tool_id, "not_well_formed", f"schema is not serialisable: {exc}")]
+
+    size = len(serialized.encode("utf-8"))
+    if size > limits.max_bytes:
+        findings.append(
+            SchemaFinding(tool_id, "size_exceeded", f"{size} bytes > {limits.max_bytes}")
+        )
+
+    depth, property_count = _schema_metrics(schema)
+    if depth > limits.max_depth:
+        findings.append(
+            SchemaFinding(tool_id, "depth_exceeded", f"depth {depth} > {limits.max_depth}")
+        )
+    if property_count > limits.max_properties:
+        findings.append(
+            SchemaFinding(
+                tool_id,
+                "properties_exceeded",
+                f"{property_count} properties > {limits.max_properties}",
+            )
+        )
+
+    try:
+        validator_cls = jsonschema.validators.validator_for(schema)
+        validator_cls.check_schema(schema)
+    except jsonschema.exceptions.SchemaError as exc:
+        first_line = str(exc).splitlines()[0] if str(exc) else "invalid schema"
+        findings.append(SchemaFinding(tool_id, "not_well_formed", first_line[:200]))
+
+    return findings
+
+
+def build_validator(schema: dict[str, Any]) -> jsonschema.protocols.Validator:
+    """Compile a reusable ``jsonschema`` validator for *schema* (#484).
+
+    The compiled validator is cached by the runtime keyed on ``tool_id`` so the
+    hot ``tool_execute`` path validates without recompiling on every call.
+
+    Args:
+        schema: A well-formed JSON Schema dict.
+
+    Returns:
+        A ready-to-use ``jsonschema`` validator instance.
+
+    Raises:
+        jsonschema.exceptions.SchemaError: If *schema* is not well-formed.
+    """
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator_cls.check_schema(schema)
+    return validator_cls(schema)
+
+
+__all__ = [
+    "DEFAULT_SCHEMA_LIMITS",
+    "CatalogRefreshReport",
+    "SchemaFinding",
+    "SchemaFindingKind",
+    "SchemaLimits",
+    "SkippedTool",
+    "build_validator",
+    "check_schema_health",
+]

--- a/src/contextweaver/adapters/proxy_runtime.py
+++ b/src/contextweaver/adapters/proxy_runtime.py
@@ -38,19 +38,34 @@ import logging
 from dataclasses import dataclass, field
 from enum import Enum
 from time import perf_counter
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Literal, Protocol, runtime_checkable
 
 import jsonschema
 import jsonschema.exceptions
+import jsonschema.protocols
 
+from contextweaver.adapters.gateway_args import Repair, normalize_args
 from contextweaver.adapters.gateway_diagnostics import GatewayTelemetry
-from contextweaver.adapters.gateway_error import GatewayError
+from contextweaver.adapters.gateway_error import (
+    GatewayError,
+    classify_upstream_exception,
+    redact_upstream_detail,
+)
+from contextweaver.adapters.gateway_validation import (
+    DEFAULT_SCHEMA_LIMITS,
+    CatalogRefreshReport,
+    SchemaLimits,
+    SkippedTool,
+    build_validator,
+    check_schema_health,
+)
 from contextweaver.adapters.mcp import mcp_result_to_envelope, mcp_tool_to_selectable
 from contextweaver.context.manager import ContextManager
 from contextweaver.diagnostics import DiagnosticSink
 from contextweaver.envelope import ChoiceCard, HydrationResult, ResultEnvelope
 from contextweaver.exceptions import (
     ArtifactNotFoundError,
+    CatalogError,
     ContextWeaverError,
     ItemNotFoundError,
     PathInvalidError,
@@ -155,6 +170,17 @@ class ProxyRuntime:
             hydrate, execute, and artifact-view events.
         session_id: Optional stable identifier attached to diagnostic events.
             A random identifier is generated when omitted.
+        on_invalid: How to handle malformed upstream tool definitions and
+            schemas at catalog ingest (issues #464 / #484).  ``"skip"`` (default)
+            drops the offending tool and records it on
+            :attr:`last_refresh_report`; ``"raise"`` re-raises so development
+            catalogs fail loudly.
+        schema_limits: Complexity bounds applied to untrusted tool schemas at
+            ingest (issue #484).  Defaults to ``DEFAULT_SCHEMA_LIMITS``.
+        tolerant_args: When ``True``, run a deterministic, opt-in argument
+            repair pass (issue #488) before strict validation in
+            :meth:`execute`.  Off by default — behaviour is then byte-identical
+            to strict validation.
     """
 
     def __init__(
@@ -170,6 +196,9 @@ class ProxyRuntime:
         diagnostic_sink: DiagnosticSink | None = None,
         session_id: str | None = None,
         redact_secrets: bool = False,
+        on_invalid: Literal["skip", "raise"] = "skip",
+        schema_limits: SchemaLimits | None = None,
+        tolerant_args: bool = False,
     ) -> None:
         self._upstream = upstream
         self._mode = mode
@@ -210,6 +239,16 @@ class ProxyRuntime:
         self._upstream_names = _UpstreamNameIndex()
         self._raw_tool_defs: dict[str, dict[str, Any]] = {}
         self._telemetry = GatewayTelemetry(diagnostic_sink, session_id=session_id)
+        #: Ingest-time hardening configuration (issues #464 / #484 / #488).
+        self._on_invalid = on_invalid
+        self._schema_limits = schema_limits or DEFAULT_SCHEMA_LIMITS
+        self._tolerant_args = tolerant_args
+        #: Compiled ``jsonschema`` validators keyed by ``tool_id`` so the hot
+        #: ``execute`` path validates without recompiling (issue #484). Cleared
+        #: on every catalog refresh.
+        self._validator_cache: dict[str, jsonschema.protocols.Validator] = {}
+        #: Outcome of the most recent catalog refresh (issues #464 / #484).
+        self._last_refresh_report = CatalogRefreshReport()
 
     # ------------------------------------------------------------------
     # Properties
@@ -271,14 +310,19 @@ class ProxyRuntime:
         return self._register_tool_defs(tool_defs)
 
     def _register_tool_defs(self, tool_defs: list[dict[str, Any]]) -> int:
-        # Invalidate cache-stable state: tool definitions may have changed.
+        # Invalidate cache-stable state and compiled validators: tool
+        # definitions (and therefore schemas) may have changed.
         self._cached_cards.clear()
         self._browsed_tool_ids.clear()
+        self._validator_cache.clear()
+        report = CatalogRefreshReport()
         items: list[SelectableItem] = []
         upstream_index: dict[str, str] = {}
         raw_defs: dict[str, dict[str, Any]] = {}
-        for tool_def in tool_defs:
-            item = mcp_tool_to_selectable(tool_def)
+        for index, tool_def in enumerate(tool_defs):
+            item = self._convert_tool_def(index, tool_def, report)
+            if item is None:
+                continue
             items.append(item)
             upstream_index[item.id] = str(tool_def["name"])
             raw_defs[item.id] = dict(tool_def)
@@ -298,9 +342,83 @@ class ProxyRuntime:
         else:
             self._graph = None
             self._router = None
+        report.registered = len(items)
+        self._last_refresh_report = report
         self._telemetry.catalog_registered(items, raw_defs, mode=self._mode.value)
-        logger.debug("proxy_runtime: registered %d tools", len(items))
+        logger.debug(
+            "proxy_runtime: registered %d tools (%d skipped, %d schema findings)",
+            len(items),
+            len(report.skipped),
+            len(report.schema_findings),
+        )
         return len(items)
+
+    def _convert_tool_def(
+        self,
+        index: int,
+        tool_def: object,
+        report: CatalogRefreshReport,
+    ) -> SelectableItem | None:
+        """Convert one upstream tool def defensively (issues #464 / #484).
+
+        Returns the :class:`SelectableItem`, or ``None`` when the definition is
+        malformed and ``on_invalid="skip"`` (the skip is recorded on *report*).
+        Raises in ``on_invalid="raise"`` mode.
+        """
+        name_repr = ""
+        try:
+            if not isinstance(tool_def, dict):
+                raise CatalogError(f"tool definition is not a dict: {type(tool_def).__name__}")
+            raw_name = tool_def.get("name")
+            name_repr = str(raw_name) if isinstance(raw_name, str) else ""
+            if not isinstance(raw_name, str) or not raw_name.strip():
+                raise CatalogError("tool definition has no non-empty string 'name'")
+            item = mcp_tool_to_selectable(tool_def)
+        except (CatalogError, KeyError, TypeError, ValueError) as exc:
+            if self._on_invalid == "raise":
+                raise
+            report.skipped.append(
+                SkippedTool(index=index, name=name_repr, reason=redact_upstream_detail(str(exc)))
+            )
+            logger.warning(
+                "proxy_runtime: skipping malformed tool def at index %d (%s): %s",
+                index,
+                name_repr or "<no name>",
+                exc,
+            )
+            return None
+
+        findings = check_schema_health(item.id, item.args_schema, limits=self._schema_limits)
+        if item.output_schema:
+            findings += check_schema_health(item.id, item.output_schema, limits=self._schema_limits)
+        if findings:
+            if self._on_invalid == "raise":
+                first = findings[0]
+                raise CatalogError(
+                    f"tool {item.id} has an invalid schema ({first.kind}): {first.detail}"
+                )
+            report.schema_findings.extend(findings)
+            for finding in findings:
+                logger.warning(
+                    "proxy_runtime: schema finding for %s: %s (%s)",
+                    finding.tool_id,
+                    finding.kind,
+                    finding.detail,
+                )
+            # Lenient mode flags and continues: the tool is still registered so
+            # one bad schema does not erase a usable catalog (#484).
+        return item
+
+    @property
+    def last_refresh_report(self) -> CatalogRefreshReport:
+        """Outcome of the most recent catalog refresh (issues #464 / #484).
+
+        Records every malformed tool definition skipped and every schema-health
+        finding raised during the last :meth:`refresh_catalog` /
+        :meth:`register_tool_defs_sync` call, so operators can audit catalog
+        quality without parsing log lines.
+        """
+        return self._last_refresh_report
 
     def list_tool_ids(self) -> list[str]:
         """Return the canonical ``tool_id`` for every registered tool."""
@@ -547,30 +665,37 @@ class ProxyRuntime:
                 arg_keys=arg_keys,
             )
             return error
-        validation_error = _validate_args(args, hydrated.args_schema)
+        schema = hydrated.args_schema
+        repairs: list[Repair] = []
+        if self._tolerant_args and schema:
+            args, repairs = normalize_args(args, schema)
+            arg_keys = sorted(args) if isinstance(args, dict) else arg_keys
+        validation_error = self._validate_args(tool_id, args, schema)
         if validation_error is not None:
-            error = GatewayError(
-                code="ARGS_INVALID",
-                message=validation_error.message,
-                path=tool_id,
-                details={"path": list(validation_error.path)},
-            )
             self._telemetry.execute_failed(
                 tool_id,
-                error,
+                validation_error,
                 duration_ms=(perf_counter() - started) * 1000,
                 namespace=namespace,
                 arg_keys=arg_keys,
             )
-            return error
+            return validation_error
         upstream_name = self._upstream_names.by_tool_id.get(tool_id, hydrated.item.name)
         try:
             raw = await self._upstream.call_tool(upstream_name, args)
         except Exception as exc:  # noqa: BLE001
+            code, retryable = classify_upstream_exception(exc)
+            # Full, unredacted detail goes to the operator-side log only; the
+            # model-visible message is classified, length-capped, and stripped
+            # of control characters (issue #485).
+            logger.warning(
+                "proxy_runtime: upstream call for %s failed [%s]: %r", tool_id, code, exc
+            )
             error = GatewayError(
-                code="UPSTREAM_ERROR",
-                message=f"upstream call failed: {exc}",
+                code=code,
+                message=f"upstream call failed: {redact_upstream_detail(str(exc))}",
                 path=tool_id,
+                retryable=retryable,
             )
             self._telemetry.execute_failed(
                 tool_id,
@@ -604,6 +729,10 @@ class ProxyRuntime:
                 )
             envelope.artifacts.append(text_ref)
         envelope.provenance.setdefault("tool_id", tool_id)
+        if repairs:
+            # Surface every applied normalization so the behaviour is auditable
+            # in the result metadata and downstream traces (issue #488).
+            envelope.provenance["arg_repairs"] = [repair.to_dict() for repair in repairs]
         if self._cache_stable:
             self._browsed_tool_ids.add(tool_id)
         self._telemetry.execute_completed(
@@ -674,16 +803,39 @@ class ProxyRuntime:
             )
         return out
 
+    def _validate_args(
+        self,
+        tool_id: str,
+        args: object,
+        schema: dict[str, Any],
+    ) -> GatewayError | None:
+        """Validate *args* against *tool_id*'s schema; ``None`` on success.
 
-def _validate_args(
-    args: dict[str, Any],
-    schema: dict[str, Any],
-) -> jsonschema.exceptions.ValidationError | None:
-    """Validate *args* against *schema*; return ``None`` on success."""
-    if not schema:
+        Compiles the schema's validator once and caches it by ``tool_id`` so the
+        hot execute path skips recompilation (issue #484).  An upstream schema
+        that fails meta-validation maps to ``SCHEMA_INVALID`` (#484); an
+        argument that fails the schema maps to ``ARGS_INVALID`` (§4.4).
+        """
+        if not schema:
+            return None
+        validator = self._validator_cache.get(tool_id)
+        if validator is None:
+            try:
+                validator = build_validator(schema)
+            except jsonschema.exceptions.SchemaError as exc:
+                return GatewayError(
+                    code="SCHEMA_INVALID",
+                    message=redact_upstream_detail(str(exc)),
+                    path=tool_id,
+                )
+            self._validator_cache[tool_id] = validator
+        try:
+            validator.validate(args)
+        except jsonschema.exceptions.ValidationError as exc:
+            return GatewayError(
+                code="ARGS_INVALID",
+                message=exc.message,
+                path=tool_id,
+                details={"path": list(exc.path)},
+            )
         return None
-    try:
-        jsonschema.validate(instance=args, schema=schema)
-        return None
-    except jsonschema.exceptions.ValidationError as exc:
-        return exc

--- a/src/contextweaver/adapters/proxy_runtime.py
+++ b/src/contextweaver/adapters/proxy_runtime.py
@@ -40,9 +40,7 @@ from enum import Enum
 from time import perf_counter
 from typing import Any, Literal, Protocol, runtime_checkable
 
-import jsonschema
 import jsonschema.exceptions
-import jsonschema.protocols
 
 from contextweaver.adapters.gateway_args import Repair, normalize_args
 from contextweaver.adapters.gateway_diagnostics import GatewayTelemetry
@@ -55,6 +53,7 @@ from contextweaver.adapters.gateway_validation import (
     DEFAULT_SCHEMA_LIMITS,
     CatalogRefreshReport,
     SchemaLimits,
+    SchemaValidator,
     SkippedTool,
     build_validator,
     check_schema_health,
@@ -246,7 +245,7 @@ class ProxyRuntime:
         #: Compiled ``jsonschema`` validators keyed by ``tool_id`` so the hot
         #: ``execute`` path validates without recompiling (issue #484). Cleared
         #: on every catalog refresh.
-        self._validator_cache: dict[str, jsonschema.protocols.Validator] = {}
+        self._validator_cache: dict[str, SchemaValidator] = {}
         #: Outcome of the most recent catalog refresh (issues #464 / #484).
         self._last_refresh_report = CatalogRefreshReport()
 
@@ -380,8 +379,11 @@ class ProxyRuntime:
             report.skipped.append(
                 SkippedTool(index=index, name=name_repr, reason=redact_upstream_detail(str(exc)))
             )
+            # Use %r for upstream-controlled values (name, exception text): repr
+            # escapes any control characters, preventing terminal-escape /
+            # log-injection via a hostile tool definition (#464).
             logger.warning(
-                "proxy_runtime: skipping malformed tool def at index %d (%s): %s",
+                "proxy_runtime: skipping malformed tool def at index %d (%r): %r",
                 index,
                 name_repr or "<no name>",
                 exc,
@@ -399,8 +401,9 @@ class ProxyRuntime:
                 )
             report.schema_findings.extend(findings)
             for finding in findings:
+                # detail can embed untrusted schema text — repr it (#464/#484).
                 logger.warning(
-                    "proxy_runtime: schema finding for %s: %s (%s)",
+                    "proxy_runtime: schema finding for %s: %s (%r)",
                     finding.tool_id,
                     finding.kind,
                     finding.detail,

--- a/tests/test_gateway_args.py
+++ b/tests/test_gateway_args.py
@@ -1,0 +1,137 @@
+"""Tests for contextweaver.adapters.gateway_args (#488).
+
+Covers the deterministic, opt-in argument-normalization rules: stringified
+objects, scalar coercions, and the negative cases that must NOT coerce.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from contextweaver.adapters.gateway_args import Repair, normalize_args
+
+_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "order_id": {"type": "string"},
+        "amount": {"type": "number"},
+        "count": {"type": "integer"},
+        "active": {"type": "boolean"},
+        "note": {"type": "string"},
+        "maybe": {"type": ["string", "null"]},
+        "cleared": {"type": "null"},
+    },
+}
+
+
+def _rules(repairs: list[Repair]) -> list[tuple[str, str]]:
+    return [(r.path, r.rule) for r in repairs]
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: stringified object
+# ---------------------------------------------------------------------------
+
+
+def test_parses_stringified_object() -> None:
+    args, repairs = normalize_args('{"order_id": "4471", "amount": "129.0"}', _SCHEMA)
+    # order_id stays a string (schema says string); amount coerces to number.
+    assert args == {"order_id": "4471", "amount": 129.0}
+    assert ("$", "parse_stringified_object") in _rules(repairs)
+    assert ("$.amount", "str_to_number") in _rules(repairs)
+
+
+def test_strips_bom_and_whitespace_before_parsing() -> None:
+    args, repairs = normalize_args('﻿  {"count": "7"}  ', _SCHEMA)
+    assert args == {"count": 7}
+    assert ("$", "parse_stringified_object") in _rules(repairs)
+
+
+def test_non_object_string_is_left_untouched() -> None:
+    # A bare string that is not a JSON object is not repaired; strict
+    # validation downstream is responsible for rejecting it.
+    args, repairs = normalize_args('"just a string"', _SCHEMA)
+    assert args == '"just a string"'
+    assert repairs == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: scalar coercions, only when the schema type demands it
+# ---------------------------------------------------------------------------
+
+
+def test_str_to_integer() -> None:
+    args, repairs = normalize_args({"count": "42"}, _SCHEMA)
+    assert args == {"count": 42}
+    assert _rules(repairs) == [("$.count", "str_to_integer")]
+
+
+def test_str_to_boolean_only_exact_literals() -> None:
+    args, repairs = normalize_args({"active": "true"}, _SCHEMA)
+    assert args == {"active": True}
+    assert _rules(repairs) == [("$.active", "str_to_boolean")]
+
+
+def test_str_to_null() -> None:
+    args, repairs = normalize_args({"cleared": "null"}, _SCHEMA)
+    assert args == {"cleared": None}
+    assert _rules(repairs) == [("$.cleared", "str_to_null")]
+
+
+def test_string_or_null_field_leaves_null_literal_untouched() -> None:
+    # When "string" is an accepted type, the literal "null" is a valid string
+    # and must not be coerced to None.
+    args, repairs = normalize_args({"maybe": "null"}, _SCHEMA)
+    assert args == {"maybe": "null"}
+    assert repairs == []
+
+
+def test_string_typed_field_is_never_coerced() -> None:
+    # order_id is string-typed even though it looks numeric — leave it.
+    args, repairs = normalize_args({"order_id": "4471"}, _SCHEMA)
+    assert args == {"order_id": "4471"}
+    assert repairs == []
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — must NOT coerce
+# ---------------------------------------------------------------------------
+
+
+def test_yes_does_not_coerce_to_boolean() -> None:
+    args, repairs = normalize_args({"active": "yes"}, _SCHEMA)
+    assert args == {"active": "yes"}
+    assert repairs == []
+
+
+def test_overflowing_exponent_does_not_coerce_to_inf() -> None:
+    # "1e999" parses to float('inf'); a non-finite result must be rejected.
+    args, repairs = normalize_args({"amount": "1e999"}, _SCHEMA)
+    assert args == {"amount": "1e999"}
+    assert repairs == []
+
+
+def test_non_numeric_string_for_integer_field_untouched() -> None:
+    args, repairs = normalize_args({"count": "lots"}, _SCHEMA)
+    assert args == {"count": "lots"}
+    assert repairs == []
+
+
+def test_already_correct_types_are_untouched() -> None:
+    args, repairs = normalize_args({"count": 42, "active": True}, _SCHEMA)
+    assert args == {"count": 42, "active": True}
+    assert repairs == []
+
+
+def test_unknown_keys_are_preserved_not_dropped() -> None:
+    args, repairs = normalize_args({"surprise": "x", "count": "3"}, _SCHEMA)
+    assert args == {"surprise": "x", "count": 3}
+    assert _rules(repairs) == [("$.count", "str_to_integer")]
+
+
+def test_determinism_identical_inputs_identical_repairs() -> None:
+    payload = {"count": "3", "amount": "1.5", "active": "false"}
+    args1, repairs1 = normalize_args(dict(payload), _SCHEMA)
+    args2, repairs2 = normalize_args(dict(payload), _SCHEMA)
+    assert args1 == args2
+    assert _rules(repairs1) == _rules(repairs2)

--- a/tests/test_gateway_error.py
+++ b/tests/test_gateway_error.py
@@ -1,0 +1,98 @@
+"""Tests for contextweaver.adapters.gateway_error (#485).
+
+Covers the structured upstream-error taxonomy, the ``retryable`` hint, detail
+redaction, and the exception classifier.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from contextweaver.adapters.gateway_error import (
+    GatewayError,
+    classify_upstream_exception,
+    redact_upstream_detail,
+)
+
+# ---------------------------------------------------------------------------
+# GatewayError shape — retryable round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_includes_retryable() -> None:
+    err = GatewayError(code="UPSTREAM_TIMEOUT", message="took too long", retryable=True)
+    payload = err.to_dict()
+    assert payload == {
+        "error": "UPSTREAM_TIMEOUT",
+        "message": "took too long",
+        "path": "",
+        "retryable": True,
+    }
+
+
+def test_from_dict_round_trip() -> None:
+    err = GatewayError(
+        code="AUTH_FAILED",
+        message="bad token",
+        path="crm:lookup#abcd1234",
+        retryable=False,
+        details={"path": ["arg"]},
+    )
+    restored = GatewayError.from_dict(err.to_dict())
+    assert restored == err
+
+
+def test_from_dict_defaults_retryable_false() -> None:
+    restored = GatewayError.from_dict({"error": "UPSTREAM_ERROR", "message": "boom"})
+    assert restored.retryable is False
+
+
+# ---------------------------------------------------------------------------
+# redact_upstream_detail
+# ---------------------------------------------------------------------------
+
+
+def test_redaction_strips_control_chars_and_collapses_whitespace() -> None:
+    # ESC (\x1b) and NUL (\x00) are control chars; stripping them neutralises
+    # any terminal-escape injection. Newlines/tabs collapse to single spaces.
+    raw = "line one\nline\ttwo\x1b\x00  three"
+    cleaned = redact_upstream_detail(raw)
+    assert "\n" not in cleaned
+    assert "\t" not in cleaned
+    assert "\x1b" not in cleaned
+    assert "\x00" not in cleaned
+    assert cleaned == "line one line two three"
+
+
+def test_redaction_caps_length() -> None:
+    cleaned = redact_upstream_detail("x" * 1000, max_len=32)
+    assert len(cleaned) == 32
+    assert cleaned.endswith("…")
+
+
+def test_redaction_short_string_unchanged() -> None:
+    assert redact_upstream_detail("connection refused") == "connection refused"
+
+
+# ---------------------------------------------------------------------------
+# classify_upstream_exception
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("exc", "code", "retryable"),
+    [
+        (TimeoutError("slow"), "UPSTREAM_TIMEOUT", True),
+        (asyncio.TimeoutError(), "UPSTREAM_TIMEOUT", True),
+        (ConnectionError("refused"), "UPSTREAM_UNAVAILABLE", True),
+        (RuntimeError("401 Unauthorized"), "AUTH_FAILED", False),
+        (RuntimeError("403 Forbidden: permission denied"), "PERMISSION_DENIED", False),
+        (RuntimeError("429 too many requests"), "RATE_LIMITED", True),
+        (RuntimeError("upstream timed out waiting"), "UPSTREAM_TIMEOUT", True),
+        (RuntimeError("transport collapsed"), "UPSTREAM_ERROR", False),
+    ],
+)
+def test_classification(exc: BaseException, code: str, retryable: bool) -> None:
+    assert classify_upstream_exception(exc) == (code, retryable)

--- a/tests/test_gateway_validation.py
+++ b/tests/test_gateway_validation.py
@@ -1,0 +1,132 @@
+"""Tests for contextweaver.adapters.gateway_validation (#464, #484).
+
+Covers the pure schema-health and catalog-refresh-report helpers that harden
+the gateway ingest path against untrusted upstream tool definitions.
+"""
+
+from __future__ import annotations
+
+import jsonschema.exceptions
+import pytest
+
+from contextweaver.adapters.gateway_validation import (
+    CatalogRefreshReport,
+    SchemaFinding,
+    SchemaLimits,
+    SkippedTool,
+    build_validator,
+    check_schema_health,
+)
+
+# ---------------------------------------------------------------------------
+# check_schema_health — well-formedness
+# ---------------------------------------------------------------------------
+
+
+def test_well_formed_schema_has_no_findings() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"title": {"type": "string"}},
+        "required": ["title"],
+    }
+    assert check_schema_health("acme:deploy#deadbeef", schema) == []
+
+
+@pytest.mark.parametrize("schema", [None, {}])
+def test_empty_schema_is_always_healthy(schema: dict[str, object] | None) -> None:
+    # The sentinel "no schema" / "{}" cases impose no validation.
+    assert check_schema_health("acme:noop#00000000", schema) == []
+
+
+def test_malformed_schema_reports_not_well_formed() -> None:
+    # "type": "strnig" is not a valid JSON Schema type keyword value.
+    findings = check_schema_health("acme:query#00000000", {"type": "strnig"})
+    assert len(findings) == 1
+    assert findings[0].kind == "not_well_formed"
+    assert findings[0].tool_id == "acme:query#00000000"
+
+
+# ---------------------------------------------------------------------------
+# check_schema_health — complexity bounds
+# ---------------------------------------------------------------------------
+
+
+def test_depth_bound_flagged() -> None:
+    # Nest objects one level past a limit of 2: properties->a->properties->b.
+    schema: dict[str, object] = {"type": "object"}
+    node = schema
+    for _ in range(4):
+        child: dict[str, object] = {"type": "object"}
+        node["properties"] = {"x": child}
+        node = child
+    findings = check_schema_health("acme:deep#00000000", schema, limits=SchemaLimits(max_depth=2))
+    kinds = {f.kind for f in findings}
+    assert "depth_exceeded" in kinds
+
+
+def test_size_bound_flagged() -> None:
+    big = {"type": "object", "description": "x" * 5000}
+    findings = check_schema_health("acme:big#00000000", big, limits=SchemaLimits(max_bytes=512))
+    assert any(f.kind == "size_exceeded" for f in findings)
+
+
+def test_property_count_bound_flagged() -> None:
+    schema = {"type": "object", "properties": {f"p{i}": {"type": "string"} for i in range(10)}}
+    findings = check_schema_health(
+        "acme:wide#00000000", schema, limits=SchemaLimits(max_properties=3)
+    )
+    assert any(f.kind == "properties_exceeded" for f in findings)
+
+
+def test_generous_defaults_pass_a_realistic_schema() -> None:
+    schema = {
+        "type": "object",
+        "properties": {f"field_{i}": {"type": "string"} for i in range(50)},
+    }
+    # 50 properties is well within the default 512 cap.
+    assert check_schema_health("acme:realistic#00000000", schema) == []
+
+
+# ---------------------------------------------------------------------------
+# build_validator + caching contract
+# ---------------------------------------------------------------------------
+
+
+def test_build_validator_validates_against_schema() -> None:
+    validator = build_validator(
+        {"type": "object", "properties": {"n": {"type": "integer"}}, "required": ["n"]}
+    )
+    validator.validate({"n": 5})  # ok
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        validator.validate({})  # missing required
+
+
+def test_build_validator_rejects_malformed_schema() -> None:
+    with pytest.raises(jsonschema.exceptions.SchemaError):
+        build_validator({"type": "strnig"})
+
+
+# ---------------------------------------------------------------------------
+# Report dataclasses
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_refresh_report_int_and_ok() -> None:
+    report = CatalogRefreshReport(registered=3)
+    assert int(report) == 3
+    assert report.ok is True
+
+    report.skipped.append(SkippedTool(index=1, name="bad", reason="no name"))
+    assert report.ok is False
+
+
+def test_report_to_dict_round_trips_findings() -> None:
+    report = CatalogRefreshReport(
+        registered=1,
+        skipped=[SkippedTool(index=0, name="", reason="not a dict")],
+        schema_findings=[SchemaFinding("acme:x#00000000", "depth_exceeded", "depth 41 > 32")],
+    )
+    payload = report.to_dict()
+    assert payload["registered"] == 1
+    assert payload["skipped"][0] == {"index": 0, "name": "", "reason": "not a dict"}
+    assert payload["schema_findings"][0]["kind"] == "depth_exceeded"

--- a/tests/test_proxy_runtime.py
+++ b/tests/test_proxy_runtime.py
@@ -537,3 +537,214 @@ def test_proxy_no_warn_when_supplied_manager_scrubs(
     with caplog.at_level(logging.WARNING, logger="contextweaver.adapters.proxy_runtime"):
         ProxyRuntime(StubUpstream(_tool_defs()), context_manager=mgr, redact_secrets=True)
     assert not any("firewall summaries will not" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Defensive tool-definition registration (#464)
+# ---------------------------------------------------------------------------
+
+
+def test_malformed_def_among_valid_registers_the_valid_ones() -> None:
+    """One garbage def must not abort registration of the healthy tools."""
+    defs: list[Any] = [
+        _tool_defs()[0],
+        {"description": "no name field"},  # missing required name
+        "not-even-a-dict",
+        {"name": "", "description": "blank name"},  # blank name
+        _tool_defs()[2],
+    ]
+    runtime = ProxyRuntime(StubUpstream(_tool_defs()))
+    registered = runtime.register_tool_defs_sync(defs)
+    assert registered == 2
+    report = runtime.last_refresh_report
+    assert report.registered == 2
+    assert len(report.skipped) == 3
+    # Indices are preserved so operators can locate the offending entries.
+    assert sorted(s.index for s in report.skipped) == [1, 2, 3]
+
+
+def test_fully_malformed_response_yields_empty_catalog_not_exception() -> None:
+    runtime = ProxyRuntime(StubUpstream(_tool_defs()))
+    registered = runtime.register_tool_defs_sync([{"bad": 1}, 42, None])
+    assert registered == 0
+    assert runtime.list_tool_ids() == []
+    assert len(runtime.last_refresh_report.skipped) == 3
+
+
+def test_valid_catalog_report_is_clean() -> None:
+    runtime = _make_runtime()
+    report = runtime.last_refresh_report
+    assert report.registered == 3
+    assert report.ok is True
+
+
+def test_on_invalid_raise_mode_propagates() -> None:
+    from contextweaver.exceptions import CatalogError
+
+    runtime = ProxyRuntime(StubUpstream(_tool_defs()), on_invalid="raise")
+    with pytest.raises(CatalogError):
+        runtime.register_tool_defs_sync([{"description": "no name"}])
+
+
+# ---------------------------------------------------------------------------
+# Untrusted schema hardening (#484)
+# ---------------------------------------------------------------------------
+
+
+def _deep_schema(depth: int) -> dict[str, Any]:
+    schema: dict[str, Any] = {"type": "object"}
+    node = schema
+    for _ in range(depth):
+        child: dict[str, Any] = {"type": "object"}
+        node["properties"] = {"x": child}
+        node = child
+    return schema
+
+
+def test_pathological_schema_flagged_in_report_but_tool_registered() -> None:
+    """Lenient mode flags an over-deep schema yet still registers the tool."""
+    from contextweaver.adapters.gateway_validation import SchemaLimits
+
+    bad = {"name": "svc.deep", "description": "deep tool", "inputSchema": _deep_schema(40)}
+    runtime = ProxyRuntime(StubUpstream([]), schema_limits=SchemaLimits(max_depth=8))
+    registered = runtime.register_tool_defs_sync([bad])
+    assert registered == 1  # flag-and-continue
+    findings = runtime.last_refresh_report.schema_findings
+    assert any(f.kind == "depth_exceeded" for f in findings)
+
+
+async def test_validator_is_cached_across_executes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The compiled validator is built once per tool, then reused (#484)."""
+    import contextweaver.adapters.proxy_runtime as pr
+
+    calls: list[str] = []
+    real_build = pr.build_validator
+
+    def counting_build(schema: dict[str, Any]) -> object:
+        calls.append("build")
+        return real_build(schema)
+
+    monkeypatch.setattr(pr, "build_validator", counting_build)
+    runtime = _make_runtime()
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:create_issue"))
+    await runtime.execute(tool_id, {"title": "a"})
+    await runtime.execute(tool_id, {"title": "b"})
+    await runtime.execute(tool_id, {"title": "c"})
+    assert len(calls) == 1, "validator should compile once and be cached thereafter"
+
+
+async def test_refresh_clears_validator_cache() -> None:
+    runtime = _make_runtime()
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:create_issue"))
+    await runtime.execute(tool_id, {"title": "a"})
+    assert runtime._validator_cache  # populated
+    runtime.register_tool_defs_sync(_tool_defs())
+    assert runtime._validator_cache == {}
+
+
+async def test_malformed_schema_maps_to_schema_invalid_at_execute() -> None:
+    """A registered-but-malformed schema surfaces SCHEMA_INVALID, not a crash."""
+    bad = {"name": "svc.broken", "description": "broken schema", "inputSchema": {"type": "strnig"}}
+    runtime = ProxyRuntime(StubUpstream([bad]))
+    runtime.register_tool_defs_sync([bad])
+    tool_id = runtime.list_tool_ids()[0]
+    result = await runtime.execute(tool_id, {"anything": 1})
+    assert isinstance(result, GatewayError)
+    assert result.code == "SCHEMA_INVALID"
+
+
+# ---------------------------------------------------------------------------
+# Structured upstream-error taxonomy (#485)
+# ---------------------------------------------------------------------------
+
+
+async def _runtime_with_failing_upstream(exc: BaseException) -> ProxyRuntime:
+    async def boom(name: str, args: dict[str, Any]) -> dict[str, Any]:
+        raise exc
+
+    runtime = ProxyRuntime(StubUpstream(_tool_defs(), handler=boom))
+    runtime.register_tool_defs_sync(_tool_defs())
+    return runtime
+
+
+async def test_timeout_maps_to_retryable_upstream_timeout() -> None:
+    runtime = await _runtime_with_failing_upstream(TimeoutError("slow upstream"))
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:create_issue"))
+    err = await runtime.execute(tool_id, {"title": "x"})
+    assert isinstance(err, GatewayError)
+    assert err.code == "UPSTREAM_TIMEOUT"
+    assert err.retryable is True
+
+
+async def test_auth_failure_maps_to_auth_failed_not_retryable() -> None:
+    runtime = await _runtime_with_failing_upstream(
+        RuntimeError("401 Unauthorized: invalid api key")
+    )
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:create_issue"))
+    err = await runtime.execute(tool_id, {"title": "x"})
+    assert isinstance(err, GatewayError)
+    assert err.code == "AUTH_FAILED"
+    assert err.retryable is False
+
+
+async def test_generic_failure_still_falls_back_to_upstream_error() -> None:
+    runtime = await _runtime_with_failing_upstream(RuntimeError("transport collapsed"))
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:create_issue"))
+    err = await runtime.execute(tool_id, {"title": "x"})
+    assert isinstance(err, GatewayError)
+    assert err.code == "UPSTREAM_ERROR"
+    assert "transport collapsed" in err.message
+
+
+async def test_upstream_error_detail_is_redacted() -> None:
+    runtime = await _runtime_with_failing_upstream(RuntimeError("boom\nat host secret-host\x1b[0m"))
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:create_issue"))
+    err = await runtime.execute(tool_id, {"title": "x"})
+    assert isinstance(err, GatewayError)
+    # Control characters / newlines never reach the model-visible message.
+    assert "\n" not in err.message
+    assert "\x1b" not in err.message
+
+
+# ---------------------------------------------------------------------------
+# Tolerant argument normalization (#488)
+# ---------------------------------------------------------------------------
+
+
+def _close_issue_id(runtime: ProxyRuntime) -> str:
+    return next(i for i in runtime.list_tool_ids() if i.startswith("github:close_issue"))
+
+
+async def test_tolerant_args_off_by_default_rejects_string_int() -> None:
+    """Default behaviour is byte-identical to strict validation."""
+    runtime = _make_runtime()
+    err = await runtime.execute(_close_issue_id(runtime), {"issue_id": "42"})
+    assert isinstance(err, GatewayError)
+    assert err.code == "ARGS_INVALID"
+
+
+async def test_tolerant_args_coerces_and_records_repairs() -> None:
+    runtime = ProxyRuntime(StubUpstream(_tool_defs(), handler=_ok_handler), tolerant_args=True)
+    runtime.register_tool_defs_sync(_tool_defs())
+    result = await runtime.execute(_close_issue_id(runtime), {"issue_id": "42"})
+    assert isinstance(result, ResultEnvelope)
+    repairs = result.provenance.get("arg_repairs")
+    assert repairs == [{"path": "$.issue_id", "rule": "str_to_integer"}]
+
+
+async def test_tolerant_args_undocumented_malformation_still_fails() -> None:
+    """A coercion the rules do not cover still hard-fails ARGS_INVALID."""
+    runtime = ProxyRuntime(StubUpstream(_tool_defs(), handler=_ok_handler), tolerant_args=True)
+    runtime.register_tool_defs_sync(_tool_defs())
+    err = await runtime.execute(_close_issue_id(runtime), {"issue_id": "not-a-number"})
+    assert isinstance(err, GatewayError)
+    assert err.code == "ARGS_INVALID"
+
+
+async def test_tolerant_args_no_repairs_leaves_provenance_clean() -> None:
+    runtime = ProxyRuntime(StubUpstream(_tool_defs(), handler=_ok_handler), tolerant_args=True)
+    runtime.register_tool_defs_sync(_tool_defs())
+    tool_id = next(i for i in runtime.list_tool_ids() if i.startswith("github:create_issue"))
+    result = await runtime.execute(tool_id, {"title": "already valid"})
+    assert isinstance(result, ResultEnvelope)
+    assert "arg_repairs" not in result.provenance


### PR DESCRIPTION
## Summary

Hardens the proxy/gateway untrusted-input boundary end-to-end — catalog ingest, schema validation, and `tool_execute` dispatch all now defend against malformed and hostile upstream input. The four issues converge on the same code path (`ProxyRuntime._register_tool_defs` / `_validate_args`) and the shared `GatewayError` taxonomy, so they ship cleaner together than apart.

Closes #464
Closes #484
Closes #485
Closes #488

## Changes

- **#464 — defensive tool-def registration.** `adapters/proxy_runtime.py:_register_tool_defs` now validates each upstream def (dict shape + non-empty string `name`) with per-item isolation via `_convert_tool_def`, so one malformed def no longer `KeyError`s the whole catalog refresh. Skips are recorded on the new `ProxyRuntime.last_refresh_report` (`CatalogRefreshReport`); `on_invalid="raise"` adds a fail-loud mode.
- **#484 — untrusted-schema hardening + validator caching.** New `adapters/gateway_validation.py`: `check_schema_health` meta-validates schemas (`check_schema`) and bounds serialized size / nesting depth / property count (`SchemaLimits`, generous defaults) at ingest, surfacing `SchemaFinding`s on the refresh report. `build_validator` compiles a `jsonschema` validator that the runtime caches per `tool_id` (cleared on refresh), removing per-call recompilation from the execute hot path. Malformed schemas surface as the new `SCHEMA_INVALID` code. The complexity traversal is iterative to stay safe on hostile, deeply-nested schemas.
- **#485 — structured upstream-error taxonomy.** `adapters/gateway_error.py` gains a `retryable` hint and the codes `UPSTREAM_TIMEOUT`, `UPSTREAM_UNAVAILABLE`, `AUTH_FAILED`, `PERMISSION_DENIED`, `RATE_LIMITED` (`classify_upstream_exception`), keeping `UPSTREAM_ERROR` as the conservative fallback. `redact_upstream_detail` strips control characters and caps length on model-visible detail; full detail goes to the operator log only.
- **#488 — opt-in tolerant argument normalization.** New `adapters/gateway_args.py`: `normalize_args` runs a deterministic, rule-based repair pass (stringified-object parse + schema-demanded `str→int/number/boolean/null` coercion) gated behind `ProxyRuntime(tolerant_args=True)`. Off by default → byte-identical behaviour; every repair is recorded under the result envelope's `provenance["arg_repairs"]`.
- **Docs/exports.** `docs/gateway_spec.md` §3.4 (taxonomy + redaction) and §4.4 (schema trust + tolerant-args rule table); `AGENTS.md` module map + key types; `CHANGELOG.md`; new public symbols exported from `adapters/__init__.py`.

## How verified

- `ruff format --check src/ tests/` — clean
- `ruff check src/ tests/` — **All checks passed**
- `mypy src/` (strict) — **Success: no issues found in 131 source files**
- `python -m pytest -q` — **2189 passed, 30 skipped, 1 xfailed**, plus **1 pre-existing environmental failure** (`test_mcp_serve_cli::test_serve_dry_run_writes_catalog_diagnostic_event` — asserts empty stderr but `tiktoken` can't fetch `cl100k_base` in the network-restricted sandbox and logs a fallback warning; fails identically on the base tree with my changes stashed, unrelated to this PR).
- `make schemas-check` — schemas up to date
- Gateway examples (`mcp_gateway_demo.py`, `mcp_proxy_demo.py`, `architectures/.../main_live.py`) and `python -m contextweaver demo` — all OK
- New tests: `tests/test_gateway_validation.py`, `tests/test_gateway_args.py`, `tests/test_gateway_error.py`, and integration tests in `tests/test_proxy_runtime.py` (91 new assertions: happy path + edge + error/negative cases incl. validator-cache-reuse counter, `tolerant_args` default-off byte-identical behaviour, and redaction).

## Checklist

- [x] Tests added or updated for every new/changed public function
- [x] `make ci` passes locally (1 unrelated environmental test failure noted above; all other targets green)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] Docstrings added for all new public APIs (Google-style)
- [x] Every modified module stays ≤ 300 lines — N/A for `proxy_runtime.py`, which **already** exceeds 300 lines on `main` (pre-existing; tracked by #456). All new logic was placed in two small dedicated modules (`gateway_validation.py`, `gateway_args.py`) precisely to avoid growing it further; the net addition to `proxy_runtime.py` is the orchestration glue only.
- [x] Related issues linked in the summary above
- [x] Agent-facing docs updated (`AGENTS.md`, `docs/gateway_spec.md`)

## Notes for reviewers

- **Mode B latitude used:** `GatewayError.to_dict()` now always emits `retryable` (no backward-compat shim), per the "no retro-compat needed" steer. `GatewayError` is not part of the generated `schemas/` set, so `make schemas-check` is unaffected.
- **`register_tool_defs_sync` / `refresh_catalog` still return `int`** (the registered count) to keep the many existing call sites untouched; the structured `CatalogRefreshReport` is exposed via the new `last_refresh_report` property and also implements `__int__`.
- **Conservative classification:** `classify_upstream_exception` maps well-understood exception *types* structurally (timeouts, `ConnectionError`) and a small set of auth/permission/rate *message* signatures, falling back to `UPSTREAM_ERROR` — deliberately avoiding over-classification across MCP client library versions.
- The `retryable` field is also added to `GatewayError.from_dict` for round-trip stability.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdWQ5crtG2HWWRfvigSyR3)_