### PR TITLE
add .editorconfig and devcontainer configuration (#535)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "contextweaver",
+  "image": "mcr.microsoft.com/devcontainers/python:3.10",
+  "postCreateCommand": "pip install -e '.[dev]' && pre-commit install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff"
+      ]
+    }
+  }
+}

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+max_line_length = 100
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,12 @@ pre-commit install
 make ci     # the validation gate — everything below must pass
 ```
 
+**Fastest path — open in Codespaces:**
+Click "Code → Open with Codespaces" on GitHub. The dev container installs all dev dependencies and pre-commit hooks automatically.
+
+An `.editorconfig` is included — most editors pick it up automatically or via a plugin.
+
+
 `pre-commit install` wires up `ruff format`, `ruff check --fix`, and
 standard file-hygiene hooks to every `git commit`. Hooks may modify
 files — re-stage with `git add` if needed.


### PR DESCRIPTION
## Summary
Fixes #535

Adds `.editorconfig` and `.devcontainer/devcontainer.json` to reduce contributor friction —
editors get project style hints automatically and Codespaces/VS Code users get a
ready-to-run environment without manual setup steps. Also updates `CONTRIBUTING.md`
to document both.

## Changes
- Add `.editorconfig` matching enforced style (100-char lines, 4-space indent, LF, final newline)
- Add `.devcontainer/devcontainer.json` with Python 3.10 base image, `pip install -e ".[dev]"` and `pre-commit install` on create, and recommended VS Code extensions (Python, Ruff)
- Update `CONTRIBUTING.md` setup section to mention Codespaces as the fastest path and note `.editorconfig` support

## Checklist
- [ ] Tests added or updated for every new/changed public function
- [x] `make ci` passes locally (fmt + lint + type + test + schemas-check + example + demo)
- [ ] `CHANGELOG.md` updated under `## [Unreleased]`
- [ ] Docstrings added for all new public APIs (Google-style)
- [x] Every modified module stays ≤ 300 lines (or a decomposition issue is linked above)
- [x] Related issue linked in the summary above
- [ ] Agent-facing docs updated if pipeline, API, or conventions changed

## Notes for reviewers
No Python files modified. `ruff format --check .` and `ruff check .` pass clean.
`make ci` run as individual commands (Windows/Python 3.14 local env — `crewai>=0.80` unavailable for 3.14, so full `pip install -e ".[dev]"` fails locally; CI will confirm).