### PR TITLE
Single-source README integrations and gate roadmap current marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,9 +308,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     code and the gating CI scripts.
   - **`make ci` ⇄ CI alignment + workflow hygiene (#474).** `make ci` now runs
     the consolidated drift gate, module-size, doc-snippet, and README-version
-    checks, so a local pass mirrors the gating CI checks. CI gains workflow
-    `timeout-minutes`, a PR `concurrency` group, and a docs-build job that gates
-    `mkdocs build` on PRs (network-only `weaver-conformance` stays CI-only).
+  checks, so a local pass mirrors the gating CI checks. CI gains workflow
+  `timeout-minutes`, a PR `concurrency` group, and a docs-build job that gates
+  `mkdocs build` on PRs (network-only `weaver-conformance` stays CI-only).
+- **README roadmap drift guard (#531).** The README now single-sources the
+  framework integration table, marks the current roadmap row with the package
+  version, and extends `readme-version-check` so stale roadmap `current` markers
+  fail CI instead of drifting silently.
 - **Gateway `tool_execute` dispatch hardening (#529, #512, #483, #482, #507).**
   The gateway/proxy dispatch path gains four opt-in, deterministic controls,
   all inert by default so an unconfigured runtime behaves exactly as before:

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ techniques, and performance optimisation tips.
 
 contextweaver is built for production use with comprehensive quality gates:
 
-- **1100+ passing tests** across all modules — context pipeline, routing engine, firewall,
+- **Broad regression suite** across all modules — context pipeline, routing engine, firewall,
   adapters, stores, CLI, sensitivity enforcement
 - **mypy strict** type checking — zero errors across all source files
 - **ruff clean** linting — zero warnings
@@ -561,24 +561,8 @@ contextweaver works with any LLM provider and any agent framework:
   Pipecat, custom loops
 - **No vendor lock-in**: stdlib-only core; no cloud dependencies; runs anywhere Python 3.10+ runs
 
-<!-- mirrors the Framework Integrations table above; keep in sync -->
-| Framework | Guide | Code adapter | Use Case |
-|---|---|---|---|
-| MCP | [Guide](docs/integration_mcp.md) | `adapters.mcp` | Tool conversion, session loading, firewall |
-| A2A | [Guide](docs/integration_a2a.md) | `adapters.a2a` | Agent cards, multi-agent sessions |
-| FastMCP | [Cookbook recipe](docs/cookbook.md#1-fastmcp--contextweaver-routing) | `adapters.fastmcp` · `[fastmcp]` | Composed MCP servers → bounded-choice routing |
-| LlamaIndex | [Guide](docs/integration_llamaindex.md) | _Guide only_ | RAG + tools with budget control |
-| OpenAI Agents SDK | [Guide](docs/integration_openai_adk.md) | `adapters.openai_agents` · `[openai-agents]` | Swarm hand-offs with unified context |
-| Google ADK / Vertex AI | [Guide](docs/integration_google_adk.md) | `adapters.google_adk` · `[google-adk]` | Gemini tool-use with context budgets |
-| LangChain + LangGraph | [Guide](docs/integration_langchain.md) | `adapters.langchain` · `[langchain]` | Chain + graph agents with firewall |
-| Pipecat | [Guide](docs/integration_pipecat.md) | _Guide only_ | Real-time voice agents with async context build |
-| CrewAI | [Guide](docs/integration_crewai.md) | `adapters.crewai` · `[crewai]` | Role-based crews with bounded tool shortlists |
-| Pydantic AI | [Guide](docs/integration_pydantic_ai.md) | `adapters.pydantic_ai` · `[pydantic-ai]` | Type-safe agents with lossless message round-trip |
-| smolagents | [Guide](docs/integration_smolagents.md) | `adapters.smolagents` · `[smolagents]` | `CodeAgent` / `ToolCallingAgent` with step-log ingestion |
-| Agno | [Guide](docs/integration_agno.md) | `adapters.agno` · `[agno]` | Toolkit-routed agents; layers above Agno `Memory` |
-| Microsoft Agent Framework | [Guide](docs/integration_agent_framework.md) | `adapters.agent_framework` · `[agent-framework]` | AutoGen / Semantic Kernel tools + thread history |
-| OpenAPI | [Guide](docs/integration_openapi.md) | `adapters.openapi` | Route over REST API operations (no extra) |
-| Agent Skills | [Guide](docs/integration_agent_skills.md) | `adapters.agent_skills` | Route over SKILL.md libraries with lazy body hydration |
+See the [Framework Integrations](#framework-integrations) table and the
+[interop guide](docs/interop.md) for supported adapters and positioning.
 
 > You are not locked into a specific framework or LLM provider. contextweaver is a layer
 > *beneath* frameworks — context management as a composable primitive.
@@ -647,6 +631,7 @@ Recent milestones:
 | **v0.9** | ✅ complete | Provider message adapters, cache-stable routing, launch polish |
 | **v0.10** | ✅ complete | `contextweaver mcp serve`, MCP Context Gateway architecture, gateway benchmark suite, route/context explanations |
 | **v0.11** | ✅ complete | Memory-source adapter interface, session-handoff context pack, "when not to use" guidance |
+| **v0.15.0** | ✅ current (v0.15.0) | Selection contracts, framework adapters, CI gate consolidation, routing cache, sidecar API |
 | **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
 | **v1.0** | 📋 planned | API freeze, documented deprecation policy, long-term compatibility window |
 
@@ -824,7 +809,8 @@ you have. All contributors agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 | **v0.8 — CrewAI + Mem0** (2026-05-19) | ✅ complete | CrewAI adapter (Phase 1), Mem0 external-memory backend, provider-SDK-leak invariant tests |
 | **v0.9 — Launch polish + adapters** (2026-05-20) | ✅ complete | Budget checks, provider adapters, benchmark transparency suite, launch polish |
 | **v0.10 — MCP serve + gateway polish** (2026-05-22) | ✅ complete | `contextweaver mcp serve`, schema hydration helpers, full MCP Context Gateway demos, context-build explanations |
-| **v0.11 — Memory source + session handoff** (2026-05-27) | ✅ current | `MemorySource` protocol + `JsonFixtureMemorySource`, session-handoff context pack, "when not to use" section |
+| **v0.11 — Memory source + session handoff** (2026-05-27) | ✅ complete | `MemorySource` protocol + `JsonFixtureMemorySource`, session-handoff context pack, "when not to use" section |
+| **v0.15.0 — Selection/adapters and CI hardening** (2026-06-14) | ✅ current (v0.15.0) | Selection contracts, framework adapters, CI gate consolidation, routing cache, sidecar API |
 | **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
 | **v1.0 — API stability** | 📋 planned | API freeze, semantic-versioning commitment, long-term support window |
 | **Future** | 📋 planned | DAG visualization, LLM-assisted labeler, distributed stores, multi-agent coordination |

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -23,7 +23,7 @@ make scorecard-check  # verify scorecard.md is up to date (gating CI step; exits
 make sweep-scoring    # weight sweep for ScoringConfig (#214); writes benchmarks/sweep_scoring.md
 make context-rot       # render context-rot demo JSON + docs/assets/context_rot.svg (#349)
 make context-rot-check # verify context_rot.svg matches its committed JSON (gating CI step; exits non-zero on drift)
-make readme-version-check  # verify README version refs and Python classifiers match sources (gating CI step; #347/#473)
+make readme-version-check  # verify README package/comparison/roadmap refs and Python classifiers match sources (gating CI step; #347/#473/#531)
 make llms        # regenerate llms.txt and llms-full.txt from canonical docs
 make llms-check  # verify llms.txt and llms-full.txt are up to date (gating CI step; exits non-zero on drift)
 make gateway-scorecard-check  # verify gateway scorecard Markdown matches its committed JSON (gating CI step)
@@ -37,7 +37,7 @@ make weaver-conformance  # round-trip + JSON-Schema validate the weaver-spec ada
 > offline: the consolidated generated-artifact drift gate `make drift-check`
 > (#522 — schemas, scorecards, recorded demos, llms.txt, context-rot SVG, and
 > the public-API manifest #518), plus `make module-size-check` (#456),
-> `make doc-snippets-check` (#526), and `make readme-version-check` (#347).
+> `make doc-snippets-check` (#526), and `make readme-version-check` (#347/#473/#531).
 > The individual `*-check` targets still exist for granular use, but you no
 > longer need to remember to run them separately before a PR.
 >

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -501,7 +501,7 @@ techniques, and performance optimisation tips.
 
 contextweaver is built for production use with comprehensive quality gates:
 
-- **1100+ passing tests** across all modules — context pipeline, routing engine, firewall,
+- **Broad regression suite** across all modules — context pipeline, routing engine, firewall,
   adapters, stores, CLI, sensitivity enforcement
 - **mypy strict** type checking — zero errors across all source files
 - **ruff clean** linting — zero warnings
@@ -594,24 +594,8 @@ contextweaver works with any LLM provider and any agent framework:
   Pipecat, custom loops
 - **No vendor lock-in**: stdlib-only core; no cloud dependencies; runs anywhere Python 3.10+ runs
 
-<!-- mirrors the Framework Integrations table above; keep in sync -->
-| Framework | Guide | Code adapter | Use Case |
-|---|---|---|---|
-| MCP | [Guide](docs/integration_mcp.md) | `adapters.mcp` | Tool conversion, session loading, firewall |
-| A2A | [Guide](docs/integration_a2a.md) | `adapters.a2a` | Agent cards, multi-agent sessions |
-| FastMCP | [Cookbook recipe](docs/cookbook.md#1-fastmcp--contextweaver-routing) | `adapters.fastmcp` · `[fastmcp]` | Composed MCP servers → bounded-choice routing |
-| LlamaIndex | [Guide](docs/integration_llamaindex.md) | _Guide only_ | RAG + tools with budget control |
-| OpenAI Agents SDK | [Guide](docs/integration_openai_adk.md) | `adapters.openai_agents` · `[openai-agents]` | Swarm hand-offs with unified context |
-| Google ADK / Vertex AI | [Guide](docs/integration_google_adk.md) | `adapters.google_adk` · `[google-adk]` | Gemini tool-use with context budgets |
-| LangChain + LangGraph | [Guide](docs/integration_langchain.md) | `adapters.langchain` · `[langchain]` | Chain + graph agents with firewall |
-| Pipecat | [Guide](docs/integration_pipecat.md) | _Guide only_ | Real-time voice agents with async context build |
-| CrewAI | [Guide](docs/integration_crewai.md) | `adapters.crewai` · `[crewai]` | Role-based crews with bounded tool shortlists |
-| Pydantic AI | [Guide](docs/integration_pydantic_ai.md) | `adapters.pydantic_ai` · `[pydantic-ai]` | Type-safe agents with lossless message round-trip |
-| smolagents | [Guide](docs/integration_smolagents.md) | `adapters.smolagents` · `[smolagents]` | `CodeAgent` / `ToolCallingAgent` with step-log ingestion |
-| Agno | [Guide](docs/integration_agno.md) | `adapters.agno` · `[agno]` | Toolkit-routed agents; layers above Agno `Memory` |
-| Microsoft Agent Framework | [Guide](docs/integration_agent_framework.md) | `adapters.agent_framework` · `[agent-framework]` | AutoGen / Semantic Kernel tools + thread history |
-| OpenAPI | [Guide](docs/integration_openapi.md) | `adapters.openapi` | Route over REST API operations (no extra) |
-| Agent Skills | [Guide](docs/integration_agent_skills.md) | `adapters.agent_skills` | Route over SKILL.md libraries with lazy body hydration |
+See the [Framework Integrations](#framework-integrations) table and the
+[interop guide](docs/interop.md) for supported adapters and positioning.
 
 > You are not locked into a specific framework or LLM provider. contextweaver is a layer
 > *beneath* frameworks — context management as a composable primitive.
@@ -680,6 +664,7 @@ Recent milestones:
 | **v0.9** | ✅ complete | Provider message adapters, cache-stable routing, launch polish |
 | **v0.10** | ✅ complete | `contextweaver mcp serve`, MCP Context Gateway architecture, gateway benchmark suite, route/context explanations |
 | **v0.11** | ✅ complete | Memory-source adapter interface, session-handoff context pack, "when not to use" guidance |
+| **v0.15.0** | ✅ current (v0.15.0) | Selection contracts, framework adapters, CI gate consolidation, routing cache, sidecar API |
 | **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
 | **v1.0** | 📋 planned | API freeze, documented deprecation policy, long-term compatibility window |
 
@@ -857,7 +842,8 @@ you have. All contributors agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 | **v0.8 — CrewAI + Mem0** (2026-05-19) | ✅ complete | CrewAI adapter (Phase 1), Mem0 external-memory backend, provider-SDK-leak invariant tests |
 | **v0.9 — Launch polish + adapters** (2026-05-20) | ✅ complete | Budget checks, provider adapters, benchmark transparency suite, launch polish |
 | **v0.10 — MCP serve + gateway polish** (2026-05-22) | ✅ complete | `contextweaver mcp serve`, schema hydration helpers, full MCP Context Gateway demos, context-build explanations |
-| **v0.11 — Memory source + session handoff** (2026-05-27) | ✅ current | `MemorySource` protocol + `JsonFixtureMemorySource`, session-handoff context pack, "when not to use" section |
+| **v0.11 — Memory source + session handoff** (2026-05-27) | ✅ complete | `MemorySource` protocol + `JsonFixtureMemorySource`, session-handoff context pack, "when not to use" section |
+| **v0.15.0 — Selection/adapters and CI hardening** (2026-06-14) | ✅ current (v0.15.0) | Selection contracts, framework adapters, CI gate consolidation, routing cache, sidecar API |
 | **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
 | **v1.0 — API stability** | 📋 planned | API freeze, semantic-versioning commitment, long-term support window |
 | **Future** | 📋 planned | DAG visualization, LLM-assisted labeler, distributed stores, multi-agent coordination |
@@ -3395,7 +3381,7 @@ make scorecard-check  # verify scorecard.md is up to date (gating CI step; exits
 make sweep-scoring    # weight sweep for ScoringConfig (#214); writes benchmarks/sweep_scoring.md
 make context-rot       # render context-rot demo JSON + docs/assets/context_rot.svg (#349)
 make context-rot-check # verify context_rot.svg matches its committed JSON (gating CI step; exits non-zero on drift)
-make readme-version-check  # verify README version refs and Python classifiers match sources (gating CI step; #347/#473)
+make readme-version-check  # verify README package/comparison/roadmap refs and Python classifiers match sources (gating CI step; #347/#473/#531)
 make llms        # regenerate llms.txt and llms-full.txt from canonical docs
 make llms-check  # verify llms.txt and llms-full.txt are up to date (gating CI step; exits non-zero on drift)
 make gateway-scorecard-check  # verify gateway scorecard Markdown matches its committed JSON (gating CI step)
@@ -3409,7 +3395,7 @@ make weaver-conformance  # round-trip + JSON-Schema validate the weaver-spec ada
 > offline: the consolidated generated-artifact drift gate `make drift-check`
 > (#522 — schemas, scorecards, recorded demos, llms.txt, context-rot SVG, and
 > the public-API manifest #518), plus `make module-size-check` (#456),
-> `make doc-snippets-check` (#526), and `make readme-version-check` (#347).
+> `make doc-snippets-check` (#526), and `make readme-version-check` (#347/#473/#531).
 > The individual `*-check` targets still exist for granular use, but you no
 > longer need to remember to run them separately before a PR.
 >

--- a/scripts/check_readme_version.py
+++ b/scripts/check_readme_version.py
@@ -61,7 +61,7 @@ _CI_PYTHON_MATRIX_RE = re.compile(r"python-version:\s*\[([^\]]+)\]")
 _QUOTED_RE = re.compile(r'"([^"]+)"')
 # Roadmap status row: ``| **v0.14.1 — ...** | ✅ current (v0.14.1) | ... |``.
 _ROADMAP_CURRENT_RE = re.compile(
-    r"^\|\s*\*\*([^|]+?)\*\*\s*\|\s*✅ current(?: \(([^)]+)\))?\s*\|",
+    r"^\|\s*\*\*([^|]+?)\*\*(?:\s*\([^)]+\))?\s*\|\s*✅ current(?: \(([^)]+)\))?\s*\|",
     re.MULTILINE,
 )
 

--- a/scripts/check_readme_version.py
+++ b/scripts/check_readme_version.py
@@ -11,11 +11,15 @@ The same gate also keeps Python support metadata honest: the CI matrix is the
 source of truth for supported Python minors, and PyPI classifiers must match it
 exactly.
 
-Three references are checked:
+README references checked:
 
 1. The ``Current package version: **X.Y.Z**`` line in the Roadmap section.
 2. The comparison-table self-reference ``(this repo, [vX.Y.Z](...))``.
-3. The ``Programming Language :: Python :: 3.x`` classifiers against CI.
+3. Roadmap rows marked ``✅ current (vX.Y.Z)``.
+
+Python metadata checked:
+
+1. The ``Programming Language :: Python :: 3.x`` classifiers against CI.
 
 Usage::
 
@@ -55,6 +59,11 @@ _PYTHON_CLASSIFIER_RE = re.compile(r'"Programming Language :: Python :: (3\.\d+)
 # CI matrix form: ``python-version: ["3.10", "3.11", ...]``.
 _CI_PYTHON_MATRIX_RE = re.compile(r"python-version:\s*\[([^\]]+)\]")
 _QUOTED_RE = re.compile(r'"([^"]+)"')
+# Roadmap status row: ``| **v0.14.1 — ...** | ✅ current (v0.14.1) | ... |``.
+_ROADMAP_CURRENT_RE = re.compile(
+    r"^\|\s*\*\*([^|]+?)\*\*\s*\|\s*✅ current(?: \(([^)]+)\))?\s*\|",
+    re.MULTILINE,
+)
 
 
 def read_pyproject_version(pyproject: Path) -> str:
@@ -110,6 +119,21 @@ def find_drift(version: str, readme_text: str) -> list[str]:
         problems.append(
             f"README comparison self-reference is 'v{compare.group(1)}', expected 'v{version}'."
         )
+
+    expected_marker = f"v{version}"
+    current_rows = _ROADMAP_CURRENT_RE.findall(readme_text)
+    if not current_rows:
+        problems.append("README roadmap is missing a '✅ current (vX)' marker row.")
+    for milestone, marker in current_rows:
+        if marker != expected_marker:
+            problems.append(
+                "README roadmap current marker for "
+                f"{milestone!r} is {marker!r}, expected {expected_marker!r}."
+            )
+        if expected_marker not in milestone:
+            problems.append(
+                f"README roadmap current row {milestone!r} does not name {expected_marker!r}."
+            )
 
     return problems
 

--- a/tests/test_check_readme_version.py
+++ b/tests/test_check_readme_version.py
@@ -90,6 +90,16 @@ def test_find_drift_passes_when_in_sync() -> None:
     assert check_readme_version.find_drift("0.12.0", readme) == []
 
 
+def test_find_drift_matches_dated_current_roadmap_row() -> None:
+    """The current roadmap row may include a date after the bold milestone."""
+    readme = (
+        "Current package version: **0.12.0**.\n"
+        "... (this repo, [v0.12.0](url)) ...\n"
+        "| **v0.12.0 — Current** (2026-06-16) | ✅ current (v0.12.0) | ok |"
+    )
+    assert check_readme_version.find_drift("0.12.0", readme) == []
+
+
 def test_find_drift_reports_missing_references() -> None:
     """Missing references are reported rather than silently passing."""
     problems = check_readme_version.find_drift("0.12.0", "no version references here")

--- a/tests/test_check_readme_version.py
+++ b/tests/test_check_readme_version.py
@@ -66,24 +66,34 @@ def test_read_ci_python_versions(tmp_path: Path) -> None:
 
 
 def test_find_drift_flags_mismatch() -> None:
-    """Both tracked references are flagged when they lag the version."""
-    readme = "Current package version: **0.11.0**.\n... (this repo, [v0.10.0](url)) ..."
+    """All tracked references are flagged when they lag the version."""
+    readme = (
+        "Current package version: **0.11.0**.\n"
+        "... (this repo, [v0.10.0](url)) ...\n"
+        "| **v0.11 — Old** | ✅ current (v0.11.0) | stale |"
+    )
     problems = check_readme_version.find_drift("0.12.0", readme)
-    assert len(problems) == 2
+    assert len(problems) == 4
     assert any("Current package version" in p for p in problems)
     assert any("comparison self-reference" in p for p in problems)
+    assert any("roadmap current marker" in p for p in problems)
+    assert any("does not name" in p for p in problems)
 
 
 def test_find_drift_passes_when_in_sync() -> None:
-    """No problems when both references equal the version."""
-    readme = "Current package version: **0.12.0**.\n... (this repo, [v0.12.0](url)) ..."
+    """No problems when tracked references equal the version."""
+    readme = (
+        "Current package version: **0.12.0**.\n"
+        "... (this repo, [v0.12.0](url)) ...\n"
+        "| **v0.12.0 — Current** | ✅ current (v0.12.0) | ok |"
+    )
     assert check_readme_version.find_drift("0.12.0", readme) == []
 
 
 def test_find_drift_reports_missing_references() -> None:
     """Missing references are reported rather than silently passing."""
     problems = check_readme_version.find_drift("0.12.0", "no version references here")
-    assert len(problems) == 2
+    assert len(problems) == 3
     assert all("missing" in p for p in problems)
 
 
@@ -106,6 +116,18 @@ def test_find_classifier_drift_passes_when_in_sync() -> None:
         )
         == []
     )
+
+
+def test_find_drift_flags_current_marker_without_explicit_version() -> None:
+    """The roadmap current marker must include the pyproject version."""
+    readme = (
+        "Current package version: **0.12.0**.\n"
+        "... (this repo, [v0.12.0](url)) ...\n"
+        "| **v0.11 — Old** | ✅ current | stale |"
+    )
+    problems = check_readme_version.find_drift("0.12.0", readme)
+    assert any("roadmap current marker" in p for p in problems)
+    assert any("does not name" in p for p in problems)
 
 
 def test_repo_readme_is_in_sync() -> None:


### PR DESCRIPTION
Closes #531

## Summary
- replace the duplicated Framework Integrations table in the Framework Agnostic section with links to the single source table and interop guide
- update README roadmap/recent milestones so v0.14.1 is the explicit current row and v0.11 is complete
- extend `readme-version-check` to fail when roadmap `current` rows omit or lag the pyproject version

## Verification
- `python3 scripts/check_readme_version.py`
- `uvx --from ruff ruff format --check scripts/check_readme_version.py tests/test_check_readme_version.py`
- `uvx --from ruff ruff check scripts/check_readme_version.py tests/test_check_readme_version.py`
- `uvx --with . --with pytest --with pytest-asyncio python -m pytest tests/test_check_readme_version.py -q`
- `tmpdir=$(mktemp -d); ln -s /Users/wuyangfan/.local/bin/python3.11 "$tmpdir/python"; PATH="$tmpdir:$PATH" make readme-version-check`
- `git diff --check`