### PR TITLE
Release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-12
+
 ### Added
 
 - **MCP gateway platform-maturity cluster (epics #365, #376, #385).** A large

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 > front of your MCP servers and the model sees a bounded `ChoiceCard` shortlist
 > instead of every tool schema, plus an artifact-backed firewall that swaps a
 > huge raw tool result for a compact summary. Deterministic, no model in the
-> loop, and 42-84 % fewer prompt tokens on the committed benchmarks.
+> loop, and 43-85 % fewer prompt tokens on the committed benchmarks.
 
 **Who it's for:** anyone whose agent — Claude Desktop, Cursor, VS Code, or a
 custom loop — keeps tripping over *"too many tools"* or *"a 16 KB tool result
@@ -167,12 +167,12 @@ Agent hallucinates tool calls, repeats questions, forgets context
 Route phase:  5 tool cards (≈500 tokens), no full schemas
 Answer phase: 3 relevant turns + dependency closure (≈2k tokens)
 Result:       2.5k tokens, complete context, deterministic
-Cost:         41.6 %-84.3 % fewer prompt tokens [^naive-baseline]  ·  Latency: sub-second  ·  Quality: relevant context only
+Cost:         42.7 %-85.0 % fewer prompt tokens [^naive-baseline]  ·  Latency: sub-second  ·  Quality: relevant context only
 ```
 
 [^naive-baseline]: Measured against the "concatenate all tool schemas + full
     conversation history" baseline using `tiktoken.cl100k_base` on the six
-    committed benchmark scenarios. Range 41.6 %-84.3 %, average 64.3 %.
+    committed benchmark scenarios. Range 42.7 %-85.0 %, average 65.0 %.
     Reproducible via `make benchmark-matrix && make scorecard` — see the
     *vs. naïve concat baseline* section of
     [`benchmarks/scorecard.md`](benchmarks/scorecard.md) and the
@@ -660,14 +660,14 @@ Recent milestones:
 
 | Approach | Tool routing | History compaction | Sensitivity firewall | Deterministic | MCP-native |
 |---|---|---|---|---|---|
-| **contextweaver** (this repo, [v0.17.0](https://pypi.org/project/contextweaver/0.17.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42-84 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
+| **contextweaver** (this repo, [v0.17.0](https://pypi.org/project/contextweaver/0.17.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 43-85 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
 | **Naïve concat-everything** | ❌ No router · prompt carries every tool schema | ❌ No compaction · prompt grows with turn count | ❌ Raw outputs in the prompt | ⚠️ Only if the upstream LLM is | ⚠️ Compatible but no shaping |
 | **LangGraph memory** ([0.6.x](https://github.com/langchain-ai/langgraph/releases)) | ❌ Out of scope — LangGraph routes state, not tools | ⚠️ Optional via `ConversationSummaryMemory` (LLM-based, non-deterministic) [^lg-mem] | ❌ Not provided | ⚠️ Workflow yes; memory summarizer no | ⚠️ Possible via custom adapter, not first-class |
 | **LlamaIndex retrievers** ([0.11.x](https://github.com/run-llama/llama_index/releases)) | ⚠️ Tool retrieval via `ObjectIndex` is unranked similarity, no bounded routing | ⚠️ `ChatMemoryBuffer(token_limit=...)` truncates oldest-first; no phase awareness and no dependency closure [^li-mem] | ❌ Not provided · large outputs flow through verbatim | ⚠️ Retriever yes; summarizer no | ⚠️ Possible via custom tool wrapper |
 | **Raw MCP** ([modelcontextprotocol v0.1](https://modelcontextprotocol.io)) | ❌ Servers expose tools; routing across many servers is the client's problem | ❌ Out of scope for the protocol | ❌ Out of scope for the protocol | ✅ Wire protocol is deterministic | ✅ — _is_ the protocol |
 
 [^cw-route]: `contextweaver.routing.router.Router` ships a four-stage pipeline (`retrieve → rerank → navigate → pack`) with deterministic tie-break by `id`. Locked by `tests/test_cards.py::test_make_choice_cards_byte_identical_stable_order`.
-[^cw-bench]: Range from the committed scorecard ([`benchmarks/scorecard.md`](benchmarks/scorecard.md)) using `tiktoken.cl100k_base` against the naïve baseline ([`scripts/baseline_naive.py`](scripts/baseline_naive.py)). Average 64.3 %; min 41.6 % on `long_conversation.jsonl`; max 84.3 % on `tiny_payload.jsonl`.
+[^cw-bench]: Range from the committed scorecard ([`benchmarks/scorecard.md`](benchmarks/scorecard.md)) using `tiktoken.cl100k_base` against the naïve baseline ([`scripts/baseline_naive.py`](scripts/baseline_naive.py)). Average 65.0 %; min 42.7 % on `long_conversation.jsonl`; max 85.0 % on `tiny_payload.jsonl`.
 [^cw-fire]: `contextweaver.context.firewall.apply_firewall` plus `ArtifactRef` drilldown selectors (`head` / `lines` / `json_keys` / `rows`). See [`docs/context_firewall.md`](docs/context_firewall.md) and the [`firewall_drilldown_recipe`](examples/cookbook/firewall_drilldown_recipe.py).
 [^cw-det]: Determinism is an invariant — see `docs/agent-context/invariants.md` and `make scorecard-check` in the CI gate.
 [^cw-mcp]: `src/contextweaver/adapters/mcp_proxy.py`, `mcp_gateway.py`, `mcp_proxy_server.py`, `mcp_gateway_server.py`. Bound by `docs/gateway_spec.md`.

--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 
 ### 6. Roadmap & Community
 
-Current package version: **0.16.0**.
+Current package version: **0.17.0**.
 
 Recent milestones:
 
@@ -636,7 +636,8 @@ Recent milestones:
 | **v0.10** | ✅ complete | `contextweaver mcp serve`, MCP Context Gateway architecture, gateway benchmark suite, route/context explanations |
 | **v0.11** | ✅ complete | Memory-source adapter interface, session-handoff context pack, "when not to use" guidance |
 | **v0.15.0** | ✅ complete | Selection contracts, framework adapters, CI gate consolidation, routing cache, sidecar API |
-| **v0.16.0** | ✅ current (v0.16.0) | Memory consolidation, cross-primitive identity, stable error codes, deprecation machinery, resource/prompt gateway |
+| **v0.16.0** | ✅ complete | Memory consolidation, cross-primitive identity, stable error codes, deprecation machinery, resource/prompt gateway |
+| **v0.17.0** | ✅ current (v0.17.0) | MCP gateway platform-maturity cluster (catalog governance, observability, model assist, transport/lifecycle, interop tooling), knowledge-bundle adapters, secret-scrubbing parity, onboarding wizard |
 | **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
 | **v1.0** | 📋 planned | API freeze, documented deprecation policy, long-term compatibility window |
 
@@ -659,7 +660,7 @@ Recent milestones:
 
 | Approach | Tool routing | History compaction | Sensitivity firewall | Deterministic | MCP-native |
 |---|---|---|---|---|---|
-| **contextweaver** (this repo, [v0.16.0](https://pypi.org/project/contextweaver/0.16.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42-84 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
+| **contextweaver** (this repo, [v0.17.0](https://pypi.org/project/contextweaver/0.17.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42-84 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
 | **Naïve concat-everything** | ❌ No router · prompt carries every tool schema | ❌ No compaction · prompt grows with turn count | ❌ Raw outputs in the prompt | ⚠️ Only if the upstream LLM is | ⚠️ Compatible but no shaping |
 | **LangGraph memory** ([0.6.x](https://github.com/langchain-ai/langgraph/releases)) | ❌ Out of scope — LangGraph routes state, not tools | ⚠️ Optional via `ConversationSummaryMemory` (LLM-based, non-deterministic) [^lg-mem] | ❌ Not provided | ⚠️ Workflow yes; memory summarizer no | ⚠️ Possible via custom adapter, not first-class |
 | **LlamaIndex retrievers** ([0.11.x](https://github.com/run-llama/llama_index/releases)) | ⚠️ Tool retrieval via `ObjectIndex` is unranked similarity, no bounded routing | ⚠️ `ChatMemoryBuffer(token_limit=...)` truncates oldest-first; no phase awareness and no dependency closure [^li-mem] | ❌ Not provided · large outputs flow through verbatim | ⚠️ Retriever yes; summarizer no | ⚠️ Possible via custom tool wrapper |
@@ -817,7 +818,8 @@ you have. All contributors agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 | **v0.10 — MCP serve + gateway polish** (2026-05-22) | ✅ complete | `contextweaver mcp serve`, schema hydration helpers, full MCP Context Gateway demos, context-build explanations |
 | **v0.11 — Memory source + session handoff** (2026-05-27) | ✅ complete | `MemorySource` protocol + `JsonFixtureMemorySource`, session-handoff context pack, "when not to use" section |
 | **v0.15.0** | ✅ complete | Selection contracts, framework adapters, CI gate consolidation, routing cache, sidecar API |
-| **v0.16.0** | ✅ current (v0.16.0) | Memory consolidation, cross-primitive identity, stable error codes, deprecation machinery, resource/prompt gateway |
+| **v0.16.0** | ✅ complete | Memory consolidation, cross-primitive identity, stable error codes, deprecation machinery, resource/prompt gateway |
+| **v0.17.0** | ✅ current (v0.17.0) | MCP gateway platform-maturity cluster (catalog governance, observability, model assist, transport/lifecycle, interop tooling), knowledge-bundle adapters, secret-scrubbing parity, onboarding wizard |
 | **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
 | **v1.0 — API stability** | 📋 planned | API freeze, semantic-versioning commitment, long-term support window |
 | **Future** | 📋 planned | DAG visualization, LLM-assisted labeler, distributed stores, multi-agent coordination |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the latest patch release in the current minor series receives security upda
 
 | Version | Supported |
 |---------|-----------|
-| 0.16.x  | Yes       |
-| < 0.16  | No        |
+| 0.17.x  | Yes       |
+| < 0.17  | No        |
 
 > This table is kept honest by `scripts/check_security_policy.py`, a gating CI
 > check that fails when the supported series drifts from the package version in

--- a/benchmarks/results/history/0.17.0.json
+++ b/benchmarks/results/history/0.17.0.json
@@ -1,0 +1,24 @@
+{
+  "metrics": {
+    "mean_token_reduction_pct": 65.01,
+    "routing_mrr": {
+      "1000": 0.1456,
+      "50": 0.4978,
+      "83": 0.3242
+    },
+    "routing_precision_at_k": {
+      "1000": 0.031,
+      "50": 0.1191,
+      "83": 0.08
+    },
+    "routing_recall_at_k": {
+      "1000": 0.1475,
+      "50": 0.5649,
+      "83": 0.3825
+    },
+    "total_dedup_removed": 4,
+    "total_items_dropped": 11
+  },
+  "release": "0.17.0",
+  "schema_version": 1
+}

--- a/benchmarks/results/latest.json
+++ b/benchmarks/results/latest.json
@@ -26,9 +26,9 @@
       "precision_at_k": 0.1191,
       "recall_at_k": 0.5649,
       "mrr": 0.4978,
-      "latency_ms_p50": 0.423,
-      "latency_ms_p95": 0.548,
-      "latency_ms_p99": 0.759
+      "latency_ms_p50": 0.42,
+      "latency_ms_p95": 0.514,
+      "latency_ms_p99": 0.65
     },
     {
       "catalog_size": 83,
@@ -36,9 +36,9 @@
       "precision_at_k": 0.08,
       "recall_at_k": 0.3825,
       "mrr": 0.3242,
-      "latency_ms_p50": 0.667,
-      "latency_ms_p95": 0.779,
-      "latency_ms_p99": 1.134
+      "latency_ms_p50": 0.691,
+      "latency_ms_p95": 0.841,
+      "latency_ms_p99": 1.205
     },
     {
       "catalog_size": 1000,
@@ -46,9 +46,9 @@
       "precision_at_k": 0.031,
       "recall_at_k": 0.1475,
       "mrr": 0.1456,
-      "latency_ms_p50": 36.007,
-      "latency_ms_p95": 37.467,
-      "latency_ms_p99": 41.711
+      "latency_ms_p50": 37.086,
+      "latency_ms_p95": 40.61,
+      "latency_ms_p99": 47.855
     }
   ],
   "context": [
@@ -58,15 +58,15 @@
       "items_included": 60,
       "items_dropped": 0,
       "dedup_removed": 0,
-      "prompt_tokens": 1514,
+      "prompt_tokens": 1480,
       "budget_tokens": 6000,
-      "budget_utilization_pct": 25.2,
+      "budget_utilization_pct": 24.7,
       "artifacts_created": 15,
       "avg_compaction_ratio": 1.0,
       "naive_delta": {
         "naive_tokens": 2767,
-        "cw_tokens": 1514,
-        "pct_reduction": 45.28,
+        "cw_tokens": 1480,
+        "pct_reduction": 46.51,
         "coverage_pct": 100.0
       }
     },
@@ -76,15 +76,15 @@
       "items_included": 82,
       "items_dropped": 0,
       "dedup_removed": 0,
-      "prompt_tokens": 2548,
+      "prompt_tokens": 2500,
       "budget_tokens": 6000,
-      "budget_utilization_pct": 42.5,
+      "budget_utilization_pct": 41.7,
       "artifacts_created": 21,
       "avg_compaction_ratio": 1.41,
       "naive_delta": {
         "naive_tokens": 4365,
-        "cw_tokens": 2548,
-        "pct_reduction": 41.63,
+        "cw_tokens": 2500,
+        "pct_reduction": 42.73,
         "coverage_pct": 100.0
       }
     },
@@ -94,15 +94,15 @@
       "items_included": 15,
       "items_dropped": 0,
       "dedup_removed": 0,
-      "prompt_tokens": 497,
+      "prompt_tokens": 488,
       "budget_tokens": 6000,
-      "budget_utilization_pct": 8.3,
+      "budget_utilization_pct": 8.1,
       "artifacts_created": 4,
       "avg_compaction_ratio": 1.64,
       "naive_delta": {
         "naive_tokens": 2277,
-        "cw_tokens": 497,
-        "pct_reduction": 78.17,
+        "cw_tokens": 488,
+        "pct_reduction": 78.57,
         "coverage_pct": 100.0
       }
     },
@@ -112,15 +112,15 @@
       "items_included": 18,
       "items_dropped": 0,
       "dedup_removed": 0,
-      "prompt_tokens": 496,
+      "prompt_tokens": 487,
       "budget_tokens": 6000,
-      "budget_utilization_pct": 8.3,
+      "budget_utilization_pct": 8.1,
       "artifacts_created": 4,
       "avg_compaction_ratio": 1.0,
       "naive_delta": {
         "naive_tokens": 1946,
-        "cw_tokens": 496,
-        "pct_reduction": 74.51,
+        "cw_tokens": 487,
+        "pct_reduction": 74.97,
         "coverage_pct": 100.0
       }
     },
@@ -128,17 +128,17 @@
       "scenario": "stress_conversation",
       "event_count": 147,
       "items_included": 136,
-      "items_dropped": 7,
+      "items_dropped": 11,
       "dedup_removed": 4,
-      "prompt_tokens": 6651,
+      "prompt_tokens": 6590,
       "budget_tokens": 6000,
-      "budget_utilization_pct": 110.9,
+      "budget_utilization_pct": 109.8,
       "artifacts_created": 32,
       "avg_compaction_ratio": 3.29,
       "naive_delta": {
         "naive_tokens": 17482,
-        "cw_tokens": 6651,
-        "pct_reduction": 61.96,
+        "cw_tokens": 6590,
+        "pct_reduction": 62.3,
         "coverage_pct": 92.52
       }
     },
@@ -148,15 +148,15 @@
       "items_included": 20,
       "items_dropped": 0,
       "dedup_removed": 0,
-      "prompt_tokens": 267,
+      "prompt_tokens": 256,
       "budget_tokens": 6000,
-      "budget_utilization_pct": 4.5,
+      "budget_utilization_pct": 4.3,
       "artifacts_created": 5,
       "avg_compaction_ratio": 1.0,
       "naive_delta": {
         "naive_tokens": 1704,
-        "cw_tokens": 267,
-        "pct_reduction": 84.33,
+        "cw_tokens": 256,
+        "pct_reduction": 84.98,
         "coverage_pct": 100.0
       }
     }
@@ -169,9 +169,9 @@
       "precision_at_k": 0.08,
       "recall_at_k": 0.3825,
       "mrr": 0.3399,
-      "latency_ms_p50": 5.18,
-      "latency_ms_p95": 7.166,
-      "latency_ms_p99": 8.14,
+      "latency_ms_p50": 5.394,
+      "latency_ms_p95": 7.591,
+      "latency_ms_p99": 8.399,
       "status": "ok"
     },
     {
@@ -181,9 +181,9 @@
       "precision_at_k": 0.047,
       "recall_at_k": 0.225,
       "mrr": 0.2165,
-      "latency_ms_p50": 28.506,
-      "latency_ms_p95": 36.817,
-      "latency_ms_p99": 38.989,
+      "latency_ms_p50": 28.707,
+      "latency_ms_p95": 36.881,
+      "latency_ms_p99": 41.865,
       "status": "ok"
     },
     {
@@ -193,9 +193,9 @@
       "precision_at_k": 0.033,
       "recall_at_k": 0.1575,
       "mrr": 0.1525,
-      "latency_ms_p50": 70.705,
-      "latency_ms_p95": 86.805,
-      "latency_ms_p99": 111.716,
+      "latency_ms_p50": 71.638,
+      "latency_ms_p95": 89.514,
+      "latency_ms_p99": 112.387,
       "status": "ok"
     },
     {
@@ -205,9 +205,9 @@
       "precision_at_k": 0.105,
       "recall_at_k": 0.5175,
       "mrr": 0.436,
-      "latency_ms_p50": 0.898,
-      "latency_ms_p95": 6.847,
-      "latency_ms_p99": 7.225,
+      "latency_ms_p50": 0.907,
+      "latency_ms_p95": 6.953,
+      "latency_ms_p99": 7.218,
       "status": "ok"
     },
     {
@@ -217,9 +217,9 @@
       "precision_at_k": 0.056,
       "recall_at_k": 0.27,
       "mrr": 0.2674,
-      "latency_ms_p50": 9.733,
-      "latency_ms_p95": 38.126,
-      "latency_ms_p99": 44.182,
+      "latency_ms_p50": 10.07,
+      "latency_ms_p95": 39.18,
+      "latency_ms_p99": 43.171,
       "status": "ok"
     },
     {
@@ -229,9 +229,9 @@
       "precision_at_k": 0.042,
       "recall_at_k": 0.2,
       "mrr": 0.1931,
-      "latency_ms_p50": 36.778,
-      "latency_ms_p95": 93.261,
-      "latency_ms_p99": 98.277,
+      "latency_ms_p50": 37.094,
+      "latency_ms_p95": 94.277,
+      "latency_ms_p99": 102.979,
       "status": "ok"
     },
     {
@@ -313,9 +313,9 @@
       "precision_at_k": 0.08,
       "recall_at_k": 0.3825,
       "mrr": 0.322,
-      "latency_ms_p50": 0.93,
-      "latency_ms_p95": 1.039,
-      "latency_ms_p99": 1.102,
+      "latency_ms_p50": 0.949,
+      "latency_ms_p95": 1.082,
+      "latency_ms_p99": 1.193,
       "status": "ok"
     },
     {
@@ -325,9 +325,9 @@
       "precision_at_k": 0.049,
       "recall_at_k": 0.2325,
       "mrr": 0.2314,
-      "latency_ms_p50": 9.6,
-      "latency_ms_p95": 10.311,
-      "latency_ms_p99": 11.492,
+      "latency_ms_p50": 9.652,
+      "latency_ms_p95": 10.105,
+      "latency_ms_p99": 10.803,
       "status": "ok"
     },
     {
@@ -337,9 +337,9 @@
       "precision_at_k": 0.031,
       "recall_at_k": 0.1475,
       "mrr": 0.1456,
-      "latency_ms_p50": 36.059,
-      "latency_ms_p95": 39.739,
-      "latency_ms_p99": 50.755,
+      "latency_ms_p50": 36.419,
+      "latency_ms_p95": 39.12,
+      "latency_ms_p99": 42.986,
       "status": "ok"
     }
   ],
@@ -857,9 +857,9 @@
       "precision_at_k": 0.026,
       "recall_at_k": 0.12,
       "mrr": 0.1065,
-      "latency_ms_p50": 19.612,
-      "latency_ms_p95": 23.858,
-      "latency_ms_p99": 25.717,
+      "latency_ms_p50": 20.256,
+      "latency_ms_p95": 24.963,
+      "latency_ms_p99": 26.822,
       "status": "ok"
     },
     {
@@ -869,9 +869,9 @@
       "precision_at_k": 0.034,
       "recall_at_k": 0.155,
       "mrr": 0.1376,
-      "latency_ms_p50": 10.514,
-      "latency_ms_p95": 39.809,
-      "latency_ms_p99": 42.553,
+      "latency_ms_p50": 10.68,
+      "latency_ms_p95": 40.38,
+      "latency_ms_p99": 42.665,
       "status": "ok"
     },
     {
@@ -905,9 +905,9 @@
       "precision_at_k": 0.026,
       "recall_at_k": 0.12,
       "mrr": 0.101,
-      "latency_ms_p50": 9.925,
-      "latency_ms_p95": 10.599,
-      "latency_ms_p99": 11.19,
+      "latency_ms_p50": 9.912,
+      "latency_ms_p95": 10.626,
+      "latency_ms_p99": 13.045,
       "status": "ok"
     }
   ],
@@ -917,7 +917,7 @@
     "max_abs_error": 0,
     "mean_signed_error": 0.0,
     "mean_ratio": 0.0,
-    "status": "skipped: HTTPError"
+    "status": "skipped: ProxyError"
   },
   "e2e_real_model": {
     "provider": "",

--- a/benchmarks/scorecard.md
+++ b/benchmarks/scorecard.md
@@ -24,9 +24,9 @@ for latency percentile stability.
 
 | catalog_size | queries | precision@5 | recall@5 | MRR | p50 (ms) | p95 (ms) | p99 (ms) |
 |---:|---:|---:|---:|---:|---:|---:|---:|
-| 50 | 131 | 0.1191 | 0.5649 | 0.4978 | 0.423 | 0.548 | 0.759 |
-| 83 | 200 | 0.0800 | 0.3825 | 0.3242 | 0.667 | 0.779 | 1.134 |
-| 1000 | 200 | 0.0310 | 0.1475 | 0.1456 | 36.007 | 37.467 | 41.711 |
+| 50 | 131 | 0.1191 | 0.5649 | 0.4978 | 0.420 | 0.514 | 0.650 |
+| 83 | 200 | 0.0800 | 0.3825 | 0.3242 | 0.691 | 0.841 | 1.205 |
+| 1000 | 200 | 0.0310 | 0.1475 | 0.1456 | 37.086 | 40.610 | 47.855 |
 
 ### Per-backend × per-size matrix
 
@@ -39,21 +39,21 @@ Skipped backends are recorded explicitly.
 
 | backend | catalog_size | queries | precision@5 | recall@5 | MRR | p50 (ms) | p95 (ms) | p99 (ms) | status |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---|
-| bm25 | 100 | 200 | 0.0800 | 0.3825 | 0.3399 | 5.180 | 7.166 | 8.140 | ok |
-| bm25 | 500 | 200 | 0.0470 | 0.2250 | 0.2165 | 28.506 | 36.817 | 38.989 | ok |
-| bm25 | 1000 | 200 | 0.0330 | 0.1575 | 0.1525 | 70.705 | 86.805 | 111.716 | ok |
-| embedding_hashing | 100 | 200 | 0.1050 | 0.5175 | 0.4360 | 0.898 | 6.847 | 7.225 | ok |
-| embedding_hashing | 500 | 200 | 0.0560 | 0.2700 | 0.2674 | 9.733 | 38.126 | 44.182 | ok |
-| embedding_hashing | 1000 | 200 | 0.0420 | 0.2000 | 0.1931 | 36.778 | 93.261 | 98.277 | ok |
+| bm25 | 100 | 200 | 0.0800 | 0.3825 | 0.3399 | 5.394 | 7.591 | 8.399 | ok |
+| bm25 | 500 | 200 | 0.0470 | 0.2250 | 0.2165 | 28.707 | 36.881 | 41.865 | ok |
+| bm25 | 1000 | 200 | 0.0330 | 0.1575 | 0.1525 | 71.638 | 89.514 | 112.387 | ok |
+| embedding_hashing | 100 | 200 | 0.1050 | 0.5175 | 0.4360 | 0.907 | 6.953 | 7.218 | ok |
+| embedding_hashing | 500 | 200 | 0.0560 | 0.2700 | 0.2674 | 10.070 | 39.180 | 43.171 | ok |
+| embedding_hashing | 1000 | 200 | 0.0420 | 0.2000 | 0.1931 | 37.094 | 94.277 | 102.979 | ok |
 | embedding_st | 100 | — | — | — | — | — | — | — | skipped: missing sentence-transformers |
 | embedding_st | 500 | — | — | — | — | — | — | — | skipped: missing sentence-transformers |
 | embedding_st | 1000 | — | — | — | — | — | — | — | skipped: missing sentence-transformers |
 | fuzzy | 100 | — | — | — | — | — | — | — | skipped: missing rapidfuzz |
 | fuzzy | 500 | — | — | — | — | — | — | — | skipped: missing rapidfuzz |
 | fuzzy | 1000 | — | — | — | — | — | — | — | skipped: missing rapidfuzz |
-| tfidf | 100 | 200 | 0.0800 | 0.3825 | 0.3220 | 0.930 | 1.039 | 1.102 | ok |
-| tfidf | 500 | 200 | 0.0490 | 0.2325 | 0.2314 | 9.600 | 10.311 | 11.492 | ok |
-| tfidf | 1000 | 200 | 0.0310 | 0.1475 | 0.1456 | 36.059 | 39.739 | 50.755 | ok |
+| tfidf | 100 | 200 | 0.0800 | 0.3825 | 0.3220 | 0.949 | 1.082 | 1.193 | ok |
+| tfidf | 500 | 200 | 0.0490 | 0.2325 | 0.2314 | 9.652 | 10.105 | 10.803 | ok |
+| tfidf | 1000 | 200 | 0.0310 | 0.1475 | 0.1456 | 36.419 | 39.120 | 42.986 | ok |
 
 ### Mixed-namespace catalog (500 tools, head + long tail)
 
@@ -69,11 +69,11 @@ act as targeted noise items.
 
 | backend | catalog_size | queries | precision@5 | recall@5 | MRR | p50 (ms) | p95 (ms) | p99 (ms) | status |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---|
-| bm25 | 500 | 200 | 0.0260 | 0.1200 | 0.1065 | 19.612 | 23.858 | 25.717 | ok |
-| embedding_hashing | 500 | 200 | 0.0340 | 0.1550 | 0.1376 | 10.514 | 39.809 | 42.553 | ok |
+| bm25 | 500 | 200 | 0.0260 | 0.1200 | 0.1065 | 20.256 | 24.963 | 26.822 | ok |
+| embedding_hashing | 500 | 200 | 0.0340 | 0.1550 | 0.1376 | 10.680 | 40.380 | 42.665 | ok |
 | embedding_st | 500 | — | — | — | — | — | — | — | skipped: missing sentence-transformers |
 | fuzzy | 500 | — | — | — | — | — | — | — | skipped: missing rapidfuzz |
-| tfidf | 500 | 200 | 0.0260 | 0.1200 | 0.1010 | 9.925 | 10.599 | 11.190 | ok |
+| tfidf | 500 | 200 | 0.0260 | 0.1200 | 0.1010 | 9.912 | 10.626 | 13.045 | ok |
 
 ### Per-namespace recall@k
 
@@ -182,12 +182,12 @@ prompt sees their summaries instead.
 
 | scenario | events | included | dropped | dedup | tokens | budget | util % | artifacts | compaction |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| large_catalog | 60 | 60 | 0 | 0 | 1514 | 6000 | 25.2% | 15 | 1.00x |
-| long_conversation | 82 | 82 | 0 | 0 | 2548 | 6000 | 42.5% | 21 | 1.41x |
-| mixed_payload | 15 | 15 | 0 | 0 | 497 | 6000 | 8.3% | 4 | 1.64x |
-| short_conversation | 18 | 18 | 0 | 0 | 496 | 6000 | 8.3% | 4 | 1.00x |
-| stress_conversation | 147 | 136 | 7 | 4 | 6651 | 6000 | 110.9% | 32 | 3.29x |
-| tiny_payload | 20 | 20 | 0 | 0 | 267 | 6000 | 4.5% | 5 | 1.00x |
+| large_catalog | 60 | 60 | 0 | 0 | 1480 | 6000 | 24.7% | 15 | 1.00x |
+| long_conversation | 82 | 82 | 0 | 0 | 2500 | 6000 | 41.7% | 21 | 1.41x |
+| mixed_payload | 15 | 15 | 0 | 0 | 488 | 6000 | 8.1% | 4 | 1.64x |
+| short_conversation | 18 | 18 | 0 | 0 | 487 | 6000 | 8.1% | 4 | 1.00x |
+| stress_conversation | 147 | 136 | 11 | 4 | 6590 | 6000 | 109.8% | 32 | 3.29x |
+| tiny_payload | 20 | 20 | 0 | 0 | 256 | 6000 | 4.3% | 5 | 1.00x |
 
 Reading the table:
 
@@ -218,12 +218,12 @@ no LLM judge — see `scripts/baseline_naive.py`).
 
 | scenario | naive_tokens | cw_tokens | token reduction | coverage proxy |
 |---|---:|---:|---:|---:|
-| large_catalog | 2767 | 1514 | 45.28% | 100.00% |
-| long_conversation | 4365 | 2548 | 41.63% | 100.00% |
-| mixed_payload | 2277 | 497 | 78.17% | 100.00% |
-| short_conversation | 1946 | 496 | 74.51% | 100.00% |
-| stress_conversation | 17482 | 6651 | 61.96% | 92.52% |
-| tiny_payload | 1704 | 267 | 84.33% | 100.00% |
+| large_catalog | 2767 | 1480 | 46.51% | 100.00% |
+| long_conversation | 4365 | 2500 | 42.73% | 100.00% |
+| mixed_payload | 2277 | 488 | 78.57% | 100.00% |
+| short_conversation | 1946 | 487 | 74.97% | 100.00% |
+| stress_conversation | 17482 | 6590 | 62.30% | 92.52% |
+| tiny_payload | 1704 | 256 | 84.98% | 100.00% |
 
 ---
 
@@ -280,7 +280,7 @@ two diverge, the headline token figures above are still self-
 consistent, but readers comparing the numbers against an OpenAI
 tokenizer expectation should apply the drift below (#268).
 
-_Token-estimator parity check is unavailable on this run (`status: skipped: HTTPError`); the headline `CharDivFourEstimator` numbers elsewhere in this scorecard are still valid — they do not depend on `tiktoken` at runtime._
+_Token-estimator parity check is unavailable on this run (`status: skipped: ProxyError`); the headline `CharDivFourEstimator` numbers elsewhere in this scorecard are still valid — they do not depend on `tiktoken` at runtime._
 
 ### Optional end-to-end real-model capture
 

--- a/benchmarks/trend.md
+++ b/benchmarks/trend.md
@@ -8,31 +8,35 @@ is excluded — it is environment-dependent and not comparable across release
 machines. This page is visibility only; PR-time regression gating lives in
 `benchmarks/gating.yaml` + `scripts/benchmark_gate.py` (#491).
 
-Releases recorded: 1 (`0.16.0` … `0.16.0`).
+Releases recorded: 2 (`0.16.0` … `0.17.0`).
 
 ## Routing recall@k by catalog size
 
 | release | size=50 | size=83 | size=1000 |
 |---|---:|---:|---:|
 | `0.16.0` | 0.5649 | 0.3825 | 0.1475 |
+| `0.17.0` | 0.5649 | 0.3825 | 0.1475 |
 
 ## Routing MRR by catalog size
 
 | release | size=50 | size=83 | size=1000 |
 |---|---:|---:|---:|
 | `0.16.0` | 0.4978 | 0.3242 | 0.1456 |
+| `0.17.0` | 0.4978 | 0.3242 | 0.1456 |
 
 ## Routing precision@k by catalog size
 
 | release | size=50 | size=83 | size=1000 |
 |---|---:|---:|---:|
 | `0.16.0` | 0.1191 | 0.0800 | 0.0310 |
+| `0.17.0` | 0.1191 | 0.0800 | 0.0310 |
 
 ## Context pipeline quality
 
 | release | mean token reduction | items dropped | dedup removed |
 |---|---:|---:|---:|
 | `0.16.0` | 64.31% | 7 | 4 |
+| `0.17.0` | 65.01% | 11 | 4 |
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -661,7 +661,7 @@ mirrors the published documents at `https://weaver-spec.dev/contracts/v0/`
 
 ### 6. Roadmap & Community
 
-Current package version: **0.16.0**.
+Current package version: **0.17.0**.
 
 Recent milestones:
 
@@ -672,7 +672,8 @@ Recent milestones:
 | **v0.10** | ✅ complete | `contextweaver mcp serve`, MCP Context Gateway architecture, gateway benchmark suite, route/context explanations |
 | **v0.11** | ✅ complete | Memory-source adapter interface, session-handoff context pack, "when not to use" guidance |
 | **v0.15.0** | ✅ complete | Selection contracts, framework adapters, CI gate consolidation, routing cache, sidecar API |
-| **v0.16.0** | ✅ current (v0.16.0) | Memory consolidation, cross-primitive identity, stable error codes, deprecation machinery, resource/prompt gateway |
+| **v0.16.0** | ✅ complete | Memory consolidation, cross-primitive identity, stable error codes, deprecation machinery, resource/prompt gateway |
+| **v0.17.0** | ✅ current (v0.17.0) | MCP gateway platform-maturity cluster (catalog governance, observability, model assist, transport/lifecycle, interop tooling), knowledge-bundle adapters, secret-scrubbing parity, onboarding wizard |
 | **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
 | **v1.0** | 📋 planned | API freeze, documented deprecation policy, long-term compatibility window |
 
@@ -695,7 +696,7 @@ Recent milestones:
 
 | Approach | Tool routing | History compaction | Sensitivity firewall | Deterministic | MCP-native |
 |---|---|---|---|---|---|
-| **contextweaver** (this repo, [v0.16.0](https://pypi.org/project/contextweaver/0.16.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42-84 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
+| **contextweaver** (this repo, [v0.17.0](https://pypi.org/project/contextweaver/0.17.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42-84 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
 | **Naïve concat-everything** | ❌ No router · prompt carries every tool schema | ❌ No compaction · prompt grows with turn count | ❌ Raw outputs in the prompt | ⚠️ Only if the upstream LLM is | ⚠️ Compatible but no shaping |
 | **LangGraph memory** ([0.6.x](https://github.com/langchain-ai/langgraph/releases)) | ❌ Out of scope — LangGraph routes state, not tools | ⚠️ Optional via `ConversationSummaryMemory` (LLM-based, non-deterministic) [^lg-mem] | ❌ Not provided | ⚠️ Workflow yes; memory summarizer no | ⚠️ Possible via custom adapter, not first-class |
 | **LlamaIndex retrievers** ([0.11.x](https://github.com/run-llama/llama_index/releases)) | ⚠️ Tool retrieval via `ObjectIndex` is unranked similarity, no bounded routing | ⚠️ `ChatMemoryBuffer(token_limit=...)` truncates oldest-first; no phase awareness and no dependency closure [^li-mem] | ❌ Not provided · large outputs flow through verbatim | ⚠️ Retriever yes; summarizer no | ⚠️ Possible via custom tool wrapper |
@@ -853,7 +854,8 @@ you have. All contributors agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 | **v0.10 — MCP serve + gateway polish** (2026-05-22) | ✅ complete | `contextweaver mcp serve`, schema hydration helpers, full MCP Context Gateway demos, context-build explanations |
 | **v0.11 — Memory source + session handoff** (2026-05-27) | ✅ complete | `MemorySource` protocol + `JsonFixtureMemorySource`, session-handoff context pack, "when not to use" section |
 | **v0.15.0** | ✅ complete | Selection contracts, framework adapters, CI gate consolidation, routing cache, sidecar API |
-| **v0.16.0** | ✅ current (v0.16.0) | Memory consolidation, cross-primitive identity, stable error codes, deprecation machinery, resource/prompt gateway |
+| **v0.16.0** | ✅ complete | Memory consolidation, cross-primitive identity, stable error codes, deprecation machinery, resource/prompt gateway |
+| **v0.17.0** | ✅ current (v0.17.0) | MCP gateway platform-maturity cluster (catalog governance, observability, model assist, transport/lifecycle, interop tooling), knowledge-bundle adapters, secret-scrubbing parity, onboarding wizard |
 | **Beta readiness** | 🚧 in progress | Provider-adapter render fix, community standards, adopter benchmark report, stability checklist |
 | **v1.0 — API stability** | 📋 planned | API freeze, semantic-versioning commitment, long-term support window |
 | **Future** | 📋 planned | DAG visualization, LLM-assisted labeler, distributed stores, multi-agent coordination |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -51,7 +51,7 @@
 > front of your MCP servers and the model sees a bounded `ChoiceCard` shortlist
 > instead of every tool schema, plus an artifact-backed firewall that swaps a
 > huge raw tool result for a compact summary. Deterministic, no model in the
-> loop, and 42-84 % fewer prompt tokens on the committed benchmarks.
+> loop, and 43-85 % fewer prompt tokens on the committed benchmarks.
 
 **Who it's for:** anyone whose agent — Claude Desktop, Cursor, VS Code, or a
 custom loop — keeps tripping over *"too many tools"* or *"a 16 KB tool result
@@ -203,12 +203,12 @@ Agent hallucinates tool calls, repeats questions, forgets context
 Route phase:  5 tool cards (≈500 tokens), no full schemas
 Answer phase: 3 relevant turns + dependency closure (≈2k tokens)
 Result:       2.5k tokens, complete context, deterministic
-Cost:         41.6 %-84.3 % fewer prompt tokens [^naive-baseline]  ·  Latency: sub-second  ·  Quality: relevant context only
+Cost:         42.7 %-85.0 % fewer prompt tokens [^naive-baseline]  ·  Latency: sub-second  ·  Quality: relevant context only
 ```
 
 [^naive-baseline]: Measured against the "concatenate all tool schemas + full
     conversation history" baseline using `tiktoken.cl100k_base` on the six
-    committed benchmark scenarios. Range 41.6 %-84.3 %, average 64.3 %.
+    committed benchmark scenarios. Range 42.7 %-85.0 %, average 65.0 %.
     Reproducible via `make benchmark-matrix && make scorecard` — see the
     *vs. naïve concat baseline* section of
     [`benchmarks/scorecard.md`](benchmarks/scorecard.md) and the
@@ -696,14 +696,14 @@ Recent milestones:
 
 | Approach | Tool routing | History compaction | Sensitivity firewall | Deterministic | MCP-native |
 |---|---|---|---|---|---|
-| **contextweaver** (this repo, [v0.17.0](https://pypi.org/project/contextweaver/0.17.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 42-84 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
+| **contextweaver** (this repo, [v0.17.0](https://pypi.org/project/contextweaver/0.17.0/)) | ✅ Bounded DAG + beam search · per-phase `ChoiceCard`s [^cw-route] | ✅ Phase-aware budgeted compilation · 43-85 % token reduction vs naïve [^cw-bench] | ✅ Built-in (size-gated, with `ArtifactRef` drilldown) [^cw-fire] | ✅ By default — tie-break by sorted IDs [^cw-det] | ✅ Native proxy + gateway runtimes per `docs/gateway_spec.md` [^cw-mcp] |
 | **Naïve concat-everything** | ❌ No router · prompt carries every tool schema | ❌ No compaction · prompt grows with turn count | ❌ Raw outputs in the prompt | ⚠️ Only if the upstream LLM is | ⚠️ Compatible but no shaping |
 | **LangGraph memory** ([0.6.x](https://github.com/langchain-ai/langgraph/releases)) | ❌ Out of scope — LangGraph routes state, not tools | ⚠️ Optional via `ConversationSummaryMemory` (LLM-based, non-deterministic) [^lg-mem] | ❌ Not provided | ⚠️ Workflow yes; memory summarizer no | ⚠️ Possible via custom adapter, not first-class |
 | **LlamaIndex retrievers** ([0.11.x](https://github.com/run-llama/llama_index/releases)) | ⚠️ Tool retrieval via `ObjectIndex` is unranked similarity, no bounded routing | ⚠️ `ChatMemoryBuffer(token_limit=...)` truncates oldest-first; no phase awareness and no dependency closure [^li-mem] | ❌ Not provided · large outputs flow through verbatim | ⚠️ Retriever yes; summarizer no | ⚠️ Possible via custom tool wrapper |
 | **Raw MCP** ([modelcontextprotocol v0.1](https://modelcontextprotocol.io)) | ❌ Servers expose tools; routing across many servers is the client's problem | ❌ Out of scope for the protocol | ❌ Out of scope for the protocol | ✅ Wire protocol is deterministic | ✅ — _is_ the protocol |
 
 [^cw-route]: `contextweaver.routing.router.Router` ships a four-stage pipeline (`retrieve → rerank → navigate → pack`) with deterministic tie-break by `id`. Locked by `tests/test_cards.py::test_make_choice_cards_byte_identical_stable_order`.
-[^cw-bench]: Range from the committed scorecard ([`benchmarks/scorecard.md`](benchmarks/scorecard.md)) using `tiktoken.cl100k_base` against the naïve baseline ([`scripts/baseline_naive.py`](scripts/baseline_naive.py)). Average 64.3 %; min 41.6 % on `long_conversation.jsonl`; max 84.3 % on `tiny_payload.jsonl`.
+[^cw-bench]: Range from the committed scorecard ([`benchmarks/scorecard.md`](benchmarks/scorecard.md)) using `tiktoken.cl100k_base` against the naïve baseline ([`scripts/baseline_naive.py`](scripts/baseline_naive.py)). Average 65.0 %; min 42.7 % on `long_conversation.jsonl`; max 85.0 % on `tiny_payload.jsonl`.
 [^cw-fire]: `contextweaver.context.firewall.apply_firewall` plus `ArtifactRef` drilldown selectors (`head` / `lines` / `json_keys` / `rows`). See [`docs/context_firewall.md`](docs/context_firewall.md) and the [`firewall_drilldown_recipe`](examples/cookbook/firewall_drilldown_recipe.py).
 [^cw-det]: Determinism is an invariant — see `docs/agent-context/invariants.md` and `make scorecard-check` in the CI gate.
 [^cw-mcp]: `src/contextweaver/adapters/mcp_proxy.py`, `mcp_gateway.py`, `mcp_proxy_server.py`, `mcp_gateway_server.py`. Bound by `docs/gateway_spec.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "contextweaver"
-version = "0.16.0"
+version = "0.17.0"
 description = "Context firewall + tool router for MCP and tool-heavy AI agents"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Prepares the v0.17.0 release: bumps `pyproject.toml`, updates README (current-version line, both roadmap tables, comparison-table self-reference), `SECURITY.md` supported-version series, promotes `CHANGELOG.md` `## [Unreleased]` to `## [0.17.0] - 2026-07-12`, and refreshes the generated benchmark/drift-checked artifacts (`benchmarks/results/latest.json`, `benchmarks/results/history/0.17.0.json`, `benchmarks/scorecard.md`, `benchmarks/trend.md`, `llms-full.txt`).

## Changes

- `pyproject.toml`: version 0.16.0 → 0.17.0
- `README.md`: version references and roadmap tables updated
- `SECURITY.md`: supported-version table updated
- `CHANGELOG.md`: `[Unreleased]` promoted to `[0.17.0] - 2026-07-12`
- Regenerated benchmark/drift-checked artifacts for the new version snapshot

## Checklist

- [x] Tests added or updated for every new/changed public function — N/A, metadata-only release PR
- [x] `make ci` passes locally — one failure: `test_serve_dry_run_writes_catalog_diagnostic_event` fails only because this sandbox's network proxy blocks tiktoken's encoding download (unrelated to this change; reproduces on an unmodified tree). All other `make ci` targets pass individually (fmt, lint, type, drift-check, module-size-check, doc-snippets-check, readme-version-check, security-policy-check, example, demo); full suite otherwise 3497 passed / 41 skipped / 1 xfailed.
- [x] `CHANGELOG.md` updated under `## [Unreleased]` — promoted to `[0.17.0]`
- [x] Docstrings added for all new public APIs — N/A, no API changes
- [x] Public-API change? — none
- [x] Every modified module stays ≤ 300 lines — N/A, no source modules touched
- [ ] Related issue linked in the summary above — release-preparation PR, no linked issue
- [x] Agent-facing docs updated if pipeline, API, or conventions changed — N/A

## Notes for reviewers

Release-preparation PR only — no source/behavior changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuJ4ETDxUpWMdofZQWjAhY)_