### PR TITLE
docs: consolidate backlog around the offline capability compiler

### DIFF
--- a/docs/roadmap/compiler-first-backlog-audit-2026-07.md
+++ b/docs/roadmap/compiler-first-backlog-audit-2026-07.md
@@ -1,9 +1,9 @@
 # Compiler-first backlog audit — July 2026
 
-Status: proposed operating baseline  
+Status: applied operating baseline  
 Repository: `dgenio/contextweaver`  
 Audit date: 2026-07-12  
-Inventory covered: 119 open issues
+Inventory covered: 119 open issues at the start of the audit
 
 ## Executive decision
 
@@ -104,7 +104,7 @@ The classifications below are product-governance decisions, not claims that the 
 
 ### Rewrite as canonical compiler-first work
 
-These issues remain open but their scope/title/body should be rewritten around the approved architecture:
+These issues remain open but their scope/title/body are rewritten around the approved architecture:
 
 - #376 — legacy gateway freeze, transition, deprecation, and extraction;
 - #408 — `CompiledAgent` loader and phase-aware runtime API;
@@ -114,6 +114,7 @@ These issues remain open but their scope/title/body should be rewritten around t
 - #477 — bundle and persisted-contract compatibility policy;
 - #561 — host-provided outcome/evaluation ingestion, not autonomous runtime learning;
 - #610 — public API inventory with `core`/`experimental`/`legacy`/`internal-accidental` levels;
+- #631 — cross-platform semantic reproducibility with profile-scoped byte identity;
 - #651 — official adapter lifecycle, support window, conformance, and retirement policy;
 - #758 — canonical offline capability compiler and phase-aware runtime epic.
 
@@ -143,8 +144,7 @@ Do not execute these as independent product tracks. Preserve useful acceptance c
 - #549 and #611 → #651 adapter lifecycle and compatibility matrix;
 - #558 → #434 example consolidation;
 - #618 → platform/reproducibility compatibility work;
-- #759 → phase rendering and inference-aware context layout;
-- #631 → #376 as a documented legacy capability; execution ownership is not expanded in core.
+- #759 → phase rendering and inference-aware context layout.
 
 ### Defer until the compiler MVP has adoption evidence
 
@@ -176,8 +176,7 @@ Promotion requires all of:
 
 ### Close as not planned
 
-- #628 — typed Python execution stubs conflict with the host-executes boundary and add an execution surface the core should not own;
-- #631 — close after its useful result-safety requirements are referenced from #376 and the host/result-ingestion contracts.
+- #628 — typed Python execution stubs conflict with the host-executes boundary and add an execution surface the core should not own.
 
 ## Canonical implementation tracks
 
@@ -245,10 +244,10 @@ The compiler direction should be reconsidered if, after the 0.20 proof release:
 - Labels are normalized through #717; no new ad-hoc priority/status taxonomy should be introduced.
 - Milestones represent the release sequence above, not arbitrary issue batches.
 
-## Immediate next actions
+## Applied actions
 
-1. Rewrite #758, #376, #408, #409, #433, #434, #477, #561, #610, and #651.
-2. Close #628 and #631 as not planned/absorbed.
-3. Apply accepted/deferred/experiment classifications through the repository's canonical label taxonomy once #717 defines it.
-4. Start 0.17 with the architecture boundary, API surface classification, gateway freeze, and adapter lifecycle.
-5. Create only the minimum missing implementation issues under #758 after checking the rewritten canonical issues for coverage.
+1. Rewrote #758, #376, #408, #409, #433, #434, #477, #561, #610, #631, and #651.
+2. Closed #628 as not planned.
+3. Preserved deferred and experimental work without promoting it into the compiler MVP.
+4. Deferred bulk relabeling until #717 defines the canonical taxonomy, avoiding another conflicting label system.
+5. Established 0.17 as the immediate execution focus: architecture boundary, API classification, gateway freeze, adapter lifecycle, and reproducibility contracts.

--- a/docs/roadmap/compiler-first-backlog-audit-2026-07.md
+++ b/docs/roadmap/compiler-first-backlog-audit-2026-07.md
@@ -1,0 +1,254 @@
+# Compiler-first backlog audit — July 2026
+
+Status: proposed operating baseline  
+Repository: `dgenio/contextweaver`  
+Audit date: 2026-07-12  
+Inventory covered: 119 open issues
+
+## Executive decision
+
+ContextWeaver should be developed as an **offline capability compiler with a phase-aware context runtime**.
+
+The product should:
+
+1. discover capabilities from MCP/FastMCP, A2A Agent Cards, Agent Skills, OpenAPI, native functions, ChainWeaver assets, and the framework adapters already maintained by the project;
+2. normalize those inputs into a framework-independent capability model;
+3. analyse identity, ambiguity, dependencies, resources, schemas, provenance, and routing quality offline;
+4. optionally enrich the normalized model through deterministic enrichers and reviewable LLM-produced proposals;
+5. evaluate the candidate artifact before promotion;
+6. compile a versioned, content-addressed agent bundle;
+7. load the bundle at runtime to route, hydrate, and build context for the `route`, `call`, `interpret`, and `answer` phases.
+
+The host runtime remains responsible for model loops, authentication, authorization, execution, retries, transactions, side effects, operational audit, and cancellation.
+
+The existing MCP gateway is a supported transition surface, not the long-term product identity.
+
+## North-star outcome
+
+The north star is **correct capability selection and successful task completion with bounded, phase-appropriate context**.
+
+Token reduction remains a useful measurement, but it is not the primary product claim. Current routing benchmarks are not yet strong enough to justify broad superiority claims, so quality gates and representative task evaluation precede distribution work.
+
+## Scope guardrails
+
+### Compiler-owned
+
+- source discovery and snapshots;
+- normalization and stable capability identity;
+- duplicate, ambiguity, dependency, and resource analysis;
+- deterministic and explicitly accepted enrichment;
+- routing indexes and evaluation artifacts;
+- versioned bundle, lock, provenance, diff, and drift detection;
+- runtime routing, hydration, phase context compilation, and normalized result ingestion.
+
+### Host-owned
+
+- model/agent loop;
+- credentials, identity, authentication, and authorization;
+- tool/agent execution and transports;
+- retries, timeouts, transactions, idempotency, and side effects;
+- production enforcement, deployment control, and operational audit.
+
+### Explicit non-goals for the compiler MVP
+
+- becoming a general MCP control plane;
+- owning production orchestration;
+- executing arbitrary Python stubs generated from schemas;
+- online revocation and deployment-policy infrastructure;
+- conversation-memory, multi-agent memory, or vertical-agent products as core commitments;
+- 10k-tool scale claims before routing quality is fixed at representative smaller scales.
+
+## Release sequence
+
+### 0.17 — Stabilize the boundary
+
+- publish the compiler-first architecture decision;
+- classify public APIs as `core`, `experimental`, `legacy`, or `internal-accidental`;
+- freeze new gateway execution/platform features;
+- establish adapter lifecycle rules and a lazy registry;
+- keep security, correctness, compatibility, and migration fixes flowing.
+
+### 0.18 — Compiled artifact MVP
+
+- multi-source discovery and normalized source snapshots;
+- canonical directory bundle with content-addressed components;
+- manifest, lock, provenance, containment, and compatibility contracts;
+- writer, loader, verifier, diff, and deterministic packaging;
+- explicit external resource descriptors and host-provided resolution.
+
+### 0.19 — Runtime and host seam
+
+- `CompiledAgent.load(...)`;
+- `route(...)`, `hydrate(...)`, `build_context(...)`, and `ingest_result(...)`;
+- host executor and normalized-result protocols;
+- phase-aware context contracts and restriction projection;
+- no execution implementation in core.
+
+### 0.20 — Evaluation, killer demo, and adoption proof
+
+- generated routing evaluation datasets and gates;
+- representative real-model/task-success evaluation;
+- one end-to-end demo: MCP + OpenAPI + Agent Skill + framework capability + A2A agent → one bundle → route/hydrate/host-execute/interpret;
+- compiler tutorial, evidence-based claims, and migration examples.
+
+### 0.21 — Gateway deprecation and migration
+
+- migrate docs and examples to compiler-first APIs;
+- deprecate gateway execution entry points after replacement coverage exists;
+- retain discovery/hydration compatibility where useful;
+- decide whether reusable execution concepts move to a host example or another repository.
+
+## Backlog classification
+
+The classifications below are product-governance decisions, not claims that the underlying engineering work is complete.
+
+### Rewrite as canonical compiler-first work
+
+These issues remain open but their scope/title/body should be rewritten around the approved architecture:
+
+- #376 — legacy gateway freeze, transition, deprecation, and extraction;
+- #408 — `CompiledAgent` loader and phase-aware runtime API;
+- #409 — offline analysis/compile report command;
+- #433 — neutral landscape for capability discovery, model-side tool search, gateways, and context compilation;
+- #434 — compiler-first killer demo and narrative tutorial;
+- #477 — bundle and persisted-contract compatibility policy;
+- #561 — host-provided outcome/evaluation ingestion, not autonomous runtime learning;
+- #610 — public API inventory with `core`/`experimental`/`legacy`/`internal-accidental` levels;
+- #651 — official adapter lifecycle, support window, conformance, and retirement policy;
+- #758 — canonical offline capability compiler and phase-aware runtime epic.
+
+### Keep — P0
+
+These directly protect the compiler thesis, artifact correctness, routing quality, security, or maintainability:
+
+- #440, #445, #453, #478, #480, #486, #489, #492, #499, #506, #527, #641, #717, #749, #752, #753, #754.
+
+### Keep — P1
+
+These are useful after or alongside the P0 path, without redefining the product:
+
+- #359, #397, #412, #423, #441, #449, #452, #455, #457, #465, #475, #476, #481, #490, #503, #528, #537, #541, #559, #560, #586, #613, #614, #617, #619, #653, #747, #748, #755.
+
+### Merge or absorb into canonical work
+
+Do not execute these as independent product tracks. Preserve useful acceptance criteria by moving them into the referenced canonical epic or implementation track:
+
+- #421 → #433 documentation/landscape;
+- #431 and #532 → #434 runtime/provider examples;
+- #436 → release/documentation operations after the 0.18 artifact contract;
+- #470, #471, and #557 → runtime/compiler performance track;
+- #500 and #544 → enrichment/evaluation track;
+- #513 and #540 → source snapshot and bundle contracts;
+- #536 and #740 → compiler CLI design after command shape stabilizes;
+- #549 and #611 → #651 adapter lifecycle and compatibility matrix;
+- #558 → #434 example consolidation;
+- #618 → platform/reproducibility compatibility work;
+- #759 → phase rendering and inference-aware context layout;
+- #631 → #376 as a documented legacy capability; execution ownership is not expanded in core.
+
+### Defer until the compiler MVP has adoption evidence
+
+These may be valuable, but they should not consume the 0.17–0.20 critical path:
+
+- #350, #407, #425, #435, #439, #444, #446, #533, #550, #551, #553, #556, #587, #612, #615, #636, #658, #663, #667, #719, #735, #737, #750, #751, #756.
+
+Key rules:
+
+- #350 and broader distribution work follow verified adapters, the killer demo, and credible claims;
+- #444 waits until representative routing quality is fixed before 10k-scale optimization;
+- #636 waits for evidence that the scorer is stable and materially improves outcomes;
+- gateway operations/control-plane work remains maintenance-only during the transition;
+- custom phases wait until the four canonical phases prove insufficient.
+
+### Experiment — evidence required before roadmap promotion
+
+These vertical packs, workbenches, and domain-specific agent experiences may be useful as experiments or downstream examples. They are not core roadmap commitments yet:
+
+- #761, #762, #764, #765, #766, #769, #770, #775, #776, #777, #778, #781, #782, #783, #784, #786, #787, #788.
+
+Promotion requires all of:
+
+1. an identifiable external user/problem;
+2. evidence that the capability belongs in ContextWeaver rather than an example or separate project;
+3. a reusable normalized contract rather than domain-specific orchestration;
+4. measurable improvement in task success, selection quality, or context quality;
+5. no diversion from the compiler MVP.
+
+### Close as not planned
+
+- #628 — typed Python execution stubs conflict with the host-executes boundary and add an execution surface the core should not own;
+- #631 — close after its useful result-safety requirements are referenced from #376 and the host/result-ingestion contracts.
+
+## Canonical implementation tracks
+
+The compiler epic should contain a compact set of tracks rather than dozens of policy micro-issues:
+
+1. **Architecture and boundary** — ADR, public surface classification, legacy gateway freeze.
+2. **Sources and adapters** — `CapabilitySourceAdapter`, `CapabilitySourceSnapshot`, multi-source failure/fallback rules, official adapter conformance.
+3. **Bundle and reproducibility** — manifest, lock, content-addressed components, logical/binary identities, compatibility, migration, deterministic package.
+4. **Resources and containment** — resource descriptors, closure validation, external resolver contract, integrity checks.
+5. **Runtime** — `CompiledAgent`, route/hydrate/context APIs, host executor seam, normalized results.
+6. **Evaluation** — routing gold sets, adversarial cases, real-model/task-success gates, ablations.
+7. **Enrichment** — deterministic enrichers, optional LLM proposals, provenance, acceptance and evaluation gates.
+8. **Minimal trust metadata** — recomputable `TrustSummary` and runtime assessment, without deployment-policy infrastructure.
+9. **Demo and migration** — killer demo, tutorial, gateway migration, evidence-based claims.
+
+## Adapter policy
+
+Official support means **framework object/configuration → normalized capability snapshot → compiled bundle**. It does not mean ContextWeaver executes the framework.
+
+Three tiers:
+
+1. protocol/core-source adapters;
+2. official framework adapters, experimental and maintained in the main repository behind lazy imports/extras;
+3. community/long-tail plugins after the normalized contract stabilizes.
+
+Each official adapter requires:
+
+- SDK-free fixture and representative real-SDK fixture;
+- deterministic conversion and bundle round-trip;
+- provenance, non-secret runtime binding, and structured unsupported-field reporting;
+- identity-collision and secret-leakage tests;
+- declared minimum and tested/latest framework versions;
+- periodic real-SDK CI, without allowing one experimental adapter to block unrelated core/security releases.
+
+## Bundle and trust decisions
+
+- canonical bundle is a diffable directory; deterministic ZIP is a transport;
+- components are content-addressed and referenced by a manifest;
+- required hydration closure is embedded or explicitly externalized, never silently omitted;
+- the host resolves external resources; ContextWeaver performs no network access by default;
+- `lock.json` pins semantic inputs and is updated only by an explicit lock-update flow;
+- logical identity is separate from platform-derived binary indexes;
+- `TrustSummary` is stored in the manifest as a recomputable projection;
+- detailed evidence remains in separate content-addressed reports;
+- runtime checks produce a separate `RuntimeTrustAssessment` and never mutate bundle identity;
+- deployment authorization, online revocation, acknowledgement, and operational enforcement remain outside the MVP.
+
+## Kill criteria
+
+The compiler direction should be reconsidered if, after the 0.20 proof release:
+
+- representative catalogs cannot be compiled reproducibly;
+- routing quality and task success do not pass defined gates;
+- phase-aware compilation produces no measurable context/task benefit;
+- no external users demonstrate demand;
+- the design remains materially dependent on one provider or framework.
+
+## Backlog operating rules
+
+- Every new issue must identify the user/problem, evidence, product track, and measurable acceptance criteria.
+- New gateway execution/control-plane features are rejected unless required for security, correctness, compatibility, data-loss prevention, or migration.
+- Vertical ideas start as experiments and do not receive core milestones without promotion evidence.
+- Issues that duplicate a canonical track are absorbed rather than maintained as parallel epics.
+- Claims and distribution follow reproducible evidence.
+- Labels are normalized through #717; no new ad-hoc priority/status taxonomy should be introduced.
+- Milestones represent the release sequence above, not arbitrary issue batches.
+
+## Immediate next actions
+
+1. Rewrite #758, #376, #408, #409, #433, #434, #477, #561, #610, and #651.
+2. Close #628 and #631 as not planned/absorbed.
+3. Apply accepted/deferred/experiment classifications through the repository's canonical label taxonomy once #717 defines it.
+4. Start 0.17 with the architecture boundary, API surface classification, gateway freeze, and adapter lifecycle.
+5. Create only the minimum missing implementation issues under #758 after checking the rewritten canonical issues for coverage.

--- a/docs/roadmap/compiler-first-implementation-map.md
+++ b/docs/roadmap/compiler-first-implementation-map.md
@@ -1,0 +1,119 @@
+# Compiler-first implementation map
+
+This map turns the July 2026 backlog audit into a compact executable issue graph.
+
+## Product epics
+
+- #758 — offline capability compiler and phase-aware context runtime;
+- #376 — legacy gateway freeze, migration, deprecation and extraction.
+
+## 0.17 — boundary and stabilization
+
+- #610 — classify and gate public APIs as core, experimental, legacy and internal-accidental;
+- #651 — adapter tiers, compatibility windows, conformance and retirement;
+- #717 — canonical GitHub label and roadmap-disposition taxonomy;
+- #631 — cross-platform semantic reproducibility and profile-scoped byte identity;
+- #749 — Windows compatibility;
+- #752 — invariants;
+- #753 — module-size policy;
+- #754 — isolate adapter and core development dependencies.
+
+Exit condition: the host-executes boundary, legacy surface and official adapter support policy are explicit and testable.
+
+## 0.18 — compiled artifact MVP
+
+### Source discovery and normalization
+
+- #793 — `CapabilitySourceAdapter`, `CapabilitySourceSnapshot`, multi-source discovery, fallback and atomic lock update;
+- #651 — adapter conformance/support governance;
+- #506 — capability identity and alias collisions;
+- #480 — untrusted catalog text handling.
+
+### Bundle and reproducibility
+
+- #794 — content-addressed bundle, manifest, lock, writer, loader, verifier and diff;
+- #477 — logical/physical compatibility and migrations;
+- #631 — cross-platform semantic reproducibility;
+- #486 — version model-facing surfaces;
+- #527 — fuzz loaders, bundle contracts, schemas and graphs;
+- #586 — pinned context/configuration behavior.
+
+### Resources and containment
+
+- #795 — resource closure, containment and host-provided `ResourceResolver`;
+- #478 — executable invariants;
+- #613, #614, #617 and #619 — adjacent hardening and compatibility work retained by the audit.
+
+### Enrichment
+
+- #796 — deterministic enrichers, optional LLM proposals, provenance, acceptance and ablation gates;
+- #489 — adversarial evaluation;
+- #480 — model/catalog text sanitization.
+
+### Minimal trust metadata
+
+- #797 — recomputable `TrustSummary` and separate `RuntimeTrustAssessment`;
+- #794 — storage and verification;
+- #409 — candidate preview/report.
+
+Exit condition: representative multi-source inputs produce a deterministic, inspectable, verifiable candidate bundle without executing capabilities.
+
+## 0.19 — runtime and host seam
+
+- #408 — `CompiledAgent.load`, route, hydrate, context and result APIs;
+- #453 — routing ownership/boundary;
+- #499 — context contracts;
+- #412 — phase budget semantics;
+- #561 — host-provided outcome/evaluation ingestion;
+- #641 — sync/async parity;
+- #795 — external resource resolution;
+- #797 — runtime restriction/trust assessment.
+
+Exit condition: two host styles can use the same bundle and produce equivalent route/hydrate/result-reintegration behavior without ContextWeaver owning execution.
+
+## 0.20 — evaluation and adoption proof
+
+- #492 — routing gold set;
+- #445 — representative real-model evaluation;
+- #489 — adversarial evaluation;
+- #440 — property tests;
+- #434 — compiler-first killer demo and tutorial;
+- #409 — pre-compilation analysis report;
+- #397 — evidence-based claims;
+- #433 — neutral ecosystem/landscape positioning.
+
+Exit condition: the killer demo passes deterministic CI, representative routing/task gates are credible, and claims are linked to reproducible evidence.
+
+## 0.21 — migration
+
+- #376 — gateway transition and deprecation gates;
+- #610 — legacy API inventory and replacements;
+- #434 — migration examples;
+- #433 — updated positioning and non-goals.
+
+Exit condition: compiler-first documentation is the default, every legacy execution surface has a replacement/extract/remove decision, and at least one deprecation release has elapsed before removal.
+
+## Dependency order
+
+```text
+#610 + #651 + #717
+        ↓
+#793 ──→ #795
+  │        │
+  └──→ #794 ←── #477 + #631
+             │
+#796 ────────┤
+#797 ────────┤
+             ↓
+           #408
+             ↓
+#492 + #445 + #489 + #440
+             ↓
+        #409 + #434
+             ↓
+           #376
+```
+
+## Scope rule
+
+No child issue may expand core ownership into capability execution, credentials, IAM, production orchestration, deployment enforcement or a general MCP control plane. Such requirements belong to the host or a separately evaluated integration/plugin.

--- a/docs/roadmap/compiler-first-implementation-map.md
+++ b/docs/roadmap/compiler-first-implementation-map.md
@@ -60,7 +60,7 @@ Exit condition: representative multi-source inputs produce a deterministic, insp
 
 ## 0.19 — runtime and host seam
 
-- #408 — `CompiledAgent.load`, route, hydrate, context and result APIs;
+- #408 — `CompiledAgent.load(...)`, route, hydrate, context and result APIs;
 - #453 — routing ownership/boundary;
 - #499 — context contracts;
 - #412 — phase budget semantics;


### PR DESCRIPTION
## Summary

The July 2026 backlog audit reviewed all 119 open issues and found no shared product thesis: compiler, gateway, runtime, memory, and vertical-agent directions competed for the same milestones with no rule for what belongs in core. This PR commits that audit as the repository's durable operating baseline so future issues and releases are judged against one architecture.

It establishes ContextWeaver as an **offline capability compiler with a phase-aware context runtime**, and keeps capability execution, credentials, side effects, and production enforcement in the host runtime. The existing MCP gateway becomes a supported transition surface, not the long-term product identity.

Tracked under the compiler epic #758 (this PR governs the backlog; it does not close an issue).

## Changes

- Add `docs/roadmap/compiler-first-backlog-audit-2026-07.md` — thesis, scope guardrails, 0.17–0.21 release sequence, backlog classification, and kill criteria.
- Add `docs/roadmap/compiler-first-implementation-map.md` — release-by-release dependency graph with per-release exit conditions.
- No runtime code or tests change; the classification is applied to live issues via GitHub metadata (below).

Issue governance applied alongside these docs:

- **Rewritten** around the architecture: #758, #376, #408, #409, #433, #434, #477, #561, #610, #631, #651.
- **Created** as the missing implementation tracks: #793 (source snapshots), #794 (bundle/lock), #795 (resources), #796 (enrichment), #797 (trust metadata).
- **Closed** as not planned: #628 (typed Python execution stubs — conflict with the host-executes boundary).
- **Kept** as P0 governance: #717 (canonical label/roadmap-disposition taxonomy); bulk relabeling waits on it.

## Checklist

- [x] Tests added or updated — N/A, documentation and issue-metadata only.
- [x] `make ci` passes — no Python touched locally; the GitHub CI matrix is green.
- [x] `CHANGELOG.md` updated — N/A, roadmap governance docs (not a shipped surface).
- [x] Docstrings for new public APIs — N/A, no code.
- [x] Public-API change — No; `api/public_api.txt` unaffected.
- [x] Modules ≤ 300 lines — N/A, no modules changed.
- [x] Related issue linked — compiler epic #758.
- [x] Agent-facing docs updated — N/A; this is roadmap documentation, not a pipeline/API/convention change.

## Notes for reviewers

Review focus:

- Is the compiler/host responsibility boundary explicit and testable enough?
- Does the 0.17–0.21 sequence front-load risk reduction and produce adoption evidence early?
- Are any deferred or experimental issues wrongly promoted into the core path?
- Are the kill criteria strong enough to stop investment that lacks evidence?

Scope is documentation plus issue metadata. Out of scope: any runtime/code change, and implementing the classified work — the issues are governed here, not executed.

## Reproducibility (scoring / context-pipeline changes)

N/A — no routing, scoring, tokenization, or context-pipeline code changed. The CI benchmark-delta comment reports Δ+0.0000 across every matrix cell, as expected for a documentation-only PR.