### PR TITLE
fix(deps): pin mcp SDK below breaking 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recomputes the trust projection from on-disk artifacts, so a tampered
   `manifest.json` trust status/warnings/findings no longer passes verification.
 
+### Fixed
+
+- **Pinned the `mcp` SDK below its breaking 2.0.0 release.** `mcp>=1.19.0` had
+  no ceiling, so a fresh install floated onto `mcp==2.0.0`, which removed
+  `mcp.shared.session.RequestResponder`, changed `Server`'s generic arity,
+  renamed `Tool`/`CallToolResult` constructor kwargs, and dropped
+  `mcp.client.streamable_http.streamablehttp_client` /
+  `mcp.shared.memory.create_connected_server_and_client_session` — breaking
+  every adapter that imports them (`mypy` and the packaged-wheel smoke test
+  both failed). Ceiling is now `mcp>=1.19.0,<2`.
+
 ## [0.17.0] - 2026-07-12
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,11 @@ dependencies = [
     "PyYAML>=6.0",
     # Floor 1.19.0 (issue #356 floor-deps proof): mcp <1.19 returns content
     # the live gateway suite cannot parse; in-memory transport changed
-    # wire format between 1.0 and 1.19.
-    "mcp>=1.19.0",
+    # wire format between 1.0 and 1.19. Ceiling <2: mcp 2.0.0 removed
+    # mcp.shared.session.RequestResponder, renamed Server's generics/Tool
+    # and CallToolResult kwargs, and dropped streamablehttp_client /
+    # mcp.shared.memory helpers this repo's adapters import directly.
+    "mcp>=1.19.0,<2",
     "jsonschema>=4.0",
     # Floor 0.16.0 (issue #356 floor-deps proof): typer <0.16 breaks the
     # CLI against modern click (8.2 made breaking changes); 0.16.0 is the


### PR DESCRIPTION
## Summary

`mcp>=1.19.0` had no ceiling. A fresh install today resolves to `mcp==2.0.0`, which is a breaking release that removed/renamed APIs this repo's adapters import directly. This broke CI (mypy + the packaged-wheel smoke test) on **every** open PR and would break `main`'s CI too on a fresh install, independent of any specific PR's diff — discovered while finalizing #799.

Fixes # (no tracking issue existed for this; filing directly since it blocks the whole open-PR queue)

## Changes

- `pyproject.toml`: `mcp>=1.19.0` → `mcp>=1.19.0,<2`, with a comment on what breaks above 2.0.
- `CHANGELOG.md`: `### Fixed` entry under `## [Unreleased]`.

## Checklist

- [x] `make ci`-equivalent passes locally: `ruff format --check`, `ruff check`, `mypy src/ examples/ scripts/` (0 errors, was 26), `pytest -q` with `.[dev,bm25]` (3512 passed, 0 failed — the 4 failures seen with a `.[dev]`-only install were due to the missing `bm25` extra, not this change)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [ ] Public-API change — N/A, dependency version range only
- [ ] Every modified module stays ≤ 300 lines — N/A, no source modules touched

## Notes for reviewers

Root cause evidence (from PR #799's CI run on `1b66822`):
- `mypy`: 26 errors across 8 files, all `mcp` 2.x API mismatches (`Server` generic arity, `Tool`/`CallToolResult` kwarg renames, `mcp.client.streamable_http.streamablehttp_client` missing, `mcp.shared.memory.create_connected_server_and_client_session` missing, `NotificationParams.root` missing).
- `Tool-run smoke (ubuntu-latest / macos-latest)`: `ModuleNotFoundError: No module named 'mcp.shared.session'` from `contextweaver/adapters/live_refresh.py`.

`uv.lock` already pins `mcp` to 1.26.0/1.27.2, so this ceiling just makes `pyproject.toml`'s stated contract match what the repo actually runs against; CI's `pip install -e ".[dev,...]"` steps don't consume the lockfile, which is how a fresh resolve floated onto 2.0.0 unnoticed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kgf6XW3jhRpJDh157soNML)_