### PR TITLE
chore(deps): align library dependency policy with compatibility CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,20 +2,16 @@ version: 2
 
 # Automated dependency updates (issue #443).
 #
-# contextweaver is a library, not an application. Python dependency ranges in
-# pyproject.toml are compatibility contracts: minimum versions are proven by
-# the floor-deps job and must not be raised merely because a newer release
-# exists. Normal CI and the scheduled latest/pre-release job exercise current
-# resolutions without requiring an application-style lockfile.
+# contextweaver is a published library, not an application. The Python ranges
+# in pyproject.toml are the downstream compatibility contract: floor-deps proves
+# the minimums and normal/latest CI exercises newer resolutions. Routine bot
+# PRs must therefore not rewrite those ranges merely because a release exists.
 #
-# Version updates are deliberately low-noise: routine non-major Python updates
-# are grouped, Docker Actions move together, and a short cooldown avoids opening
-# PRs for releases that are immediately superseded. Security updates bypass the
-# cooldown and have explicit grouping rules.
-#
-# All GitHub Actions are pinned to immutable commit SHAs. Dependabot resolves
-# the corresponding upstream versions and updates those SHAs; version comments
-# in workflow files document the human-readable release line.
+# Python Dependabot is security-only. A vulnerability fix may legitimately
+# raise a floor; ordinary compatibility evolution remains human-reviewed. The
+# deliberate MCP v2 incompatibility remains excluded until migration #827.
+# GitHub Actions are a different trust boundary: they stay SHA-pinned and
+# Dependabot continues to maintain those immutable pins.
 
 updates:
   - package-ecosystem: pip
@@ -25,36 +21,22 @@ updates:
       day: monday
       time: "06:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 5
-    cooldown:
-      default-days: 7
+    # Disable routine version-update PRs. Dependabot security updates are
+    # configured separately by GitHub and are not counted against this limit.
+    open-pull-requests-limit: 0
     groups:
-      python-nonmajor:
-        applies-to: version-updates
-        patterns:
-          - "*"
-        update-types:
-          - minor
-          - patch
-      python-security-nonmajor:
+      python-security:
         applies-to: security-updates
         patterns:
           - "*"
-        update-types:
-          - minor
-          - patch
     ignore:
-      # MCP SDK v2 is a real API/protocol migration, not dependency hygiene.
-      # Ignore the incompatible versions themselves: Dependabot can otherwise
-      # widen a declared requirement (<2 -> <3) without classifying that
-      # manifest edit as a SemVer-major dependency update. Migration is #827.
       - dependency-name: mcp
         versions:
           - ">=2,<3"
     labels:
       - dependencies
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "fix(deps)"
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/workflows/deps-latest-weekly.yml
+++ b/.github/workflows/deps-latest-weekly.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   latest-prerelease:
-    name: Latest + pre-release deps (3.13)
+    name: Latest + pre-release deps (3.14)
     runs-on: ubuntu-latest
     # Non-gating by construction: scheduled-only and not a required status
     # check, so a failure blocks no PR or merge. The run is allowed to go red on
@@ -32,21 +32,19 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          # Newest *supported* Python (3.14 is pending — the heavy dev/adapter
-          # stack still caps at Requires-Python <3.14). Bump to 3.14 once that
-          # ecosystem ships 3.14 wheels.
-          python-version: "3.13"
+          python-version: "3.14"
+          allow-prereleases: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install newest deps (incl. pre-releases)
-        # ``--prerelease allow`` + ``--upgrade`` pulls the absolute newest
-        # releases, pre-releases included — the most aggressive resolution, so
-        # a green run here is strong evidence the no-upper-cap policy holds.
+        # Keep this to the 3.14-resolvable dev surface. The heavier adapter tree
+        # remains exercised separately on 3.13 below until its upstreams publish
+        # compatible 3.14 distributions.
         run: uv pip install --system --prerelease allow --upgrade -e ".[dev,langchain]"
 
       - name: Test (latest / pre-release versions)

--- a/.github/workflows/deps-latest-weekly.yml
+++ b/.github/workflows/deps-latest-weekly.yml
@@ -45,7 +45,7 @@ jobs:
         # Keep this to the 3.14-resolvable dev surface. The heavier adapter tree
         # remains exercised separately on 3.13 below until its upstreams publish
         # compatible 3.14 distributions.
-        run: uv pip install --system --prerelease allow --upgrade -e ".[dev,langchain]"
+        run: uv pip install --system --prerelease allow --upgrade -e ".[dev]"
 
       - name: Test (latest / pre-release versions)
         run: pytest -q

--- a/.github/workflows/python-next.yml
+++ b/.github/workflows/python-next.yml
@@ -1,0 +1,31 @@
+name: Python Next Canary
+
+on:
+  schedule:
+    - cron: "15 6 * * 3"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - ".github/workflows/python-next.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  python-next:
+    name: Python 3.15 pre-release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.15"
+          allow-prereleases: true
+      - name: Install library and core test toolchain
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run core suite
+        run: pytest -q


### PR DESCRIPTION
## What changed

- make Python Dependabot security-only so routine releases cannot rewrite public compatibility ranges
- keep MCP v2 explicitly excluded until migration #827
- move the scheduled latest/pre-release dependency canary to Python 3.14 on the resolvable core/dev surface
- add a non-gating Python 3.15 pre-release canary
- keep GitHub Actions SHA-pin maintenance unchanged

## Why

ContextWeaver is a published library. `pyproject.toml` is the downstream compatibility contract; floor/latest CI should prove that contract, while bots should only change Python requirements automatically when vulnerability remediation requires it.

## Validation

Merge only after the existing exact-head CI/CodeQL and the new compatibility workflow signals have been reviewed.