### PR TITLE
feat(compiler): add an honest package-native compiler-first proof

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,31 @@
+name: Release readiness
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# This check exists because v0.18.0 reached GitHub Releases without the
+# version-specific deterministic benchmark snapshot required by publish.yml.
+# The publish workflow correctly failed, but by then PyPI had already diverged
+# from the public GitHub release. Run the invariant during normal PR/main CI so
+# release artifacts are complete before anyone presses "Publish release".
+jobs:
+  release-readiness:
+    name: Release artifacts ready
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify current package version is release-ready
+        run: python scripts/check_release_readiness.py

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,79 @@
+# Releasing contextweaver
+
+GitHub Releases, PyPI, the MCP Registry and the committed release evidence must describe the same product version.
+
+The release workflow intentionally fails closed. Do not weaken a failing integrity gate to make a release publish.
+
+## Release preparation
+
+Prepare the release in a normal pull request **before** creating or publishing the GitHub Release.
+
+1. Finish the intended release changes and ensure normal CI is green.
+2. Set `[project].version` in `pyproject.toml` to the release version.
+3. Update all version-bearing metadata required by the drift guards:
+   - README current/comparison/roadmap references;
+   - `server.json`;
+   - `CITATION.cff` version and release date;
+   - SECURITY/version references where required by the current policy.
+4. Finalize the CHANGELOG section for the release.
+5. Refresh the deterministic benchmark from the release candidate code:
+
+   ```bash
+   make benchmark
+   python scripts/render_trend.py --snapshot X.Y.Z \
+       --from benchmarks/results/latest.json
+   make trend
+   ```
+
+   Review the new `benchmarks/results/history/X.Y.Z.json` instead of treating it as generated ceremony. A regression or surprising change should be explained before release.
+6. Run the explicit release-readiness guard:
+
+   ```bash
+   python scripts/check_release_readiness.py
+   ```
+
+   It must confirm that the current package version has a matching benchmark-history snapshot and that `benchmarks/trend.md` is synchronized.
+7. Run the normal project validation required for the release PR and merge only when required checks are green.
+
+The `Release readiness` workflow runs on pull requests and `main` as an early guard for the same invariant.
+
+## Publish
+
+After the release-preparation PR is merged:
+
+1. Create/tag `vX.Y.Z` from the exact prepared commit.
+2. Create and publish the GitHub Release for that tag.
+3. The `Publish to PyPI and MCP Registry` workflow independently verifies:
+   - tag ↔ package version;
+   - version metadata;
+   - release benchmark snapshot + trend;
+   - test suite;
+   - built distribution metadata.
+4. Only after verification does the workflow publish to PyPI via Trusted Publishing/OIDC.
+5. The MCP Registry publish happens after PyPI because its package metadata depends on the PyPI release.
+
+## Post-publish verification
+
+Verify the canonical user path from a clean environment, not an editable checkout:
+
+```bash
+python -m pip install --no-cache-dir contextweaver
+python -c "import contextweaver; print(contextweaver.__version__)"
+contextweaver demo --scenario killer
+```
+
+Confirm that the printed version matches the GitHub Release and that the MCP Registry entry, when applicable, references the same package version.
+
+## Recovery from a failed publish
+
+A GitHub Release can exist even when the release-triggered publish workflow fails. That happened for v0.18.0: the required `benchmarks/results/history/0.18.0.json` had not been committed, so the integrity gate correctly skipped PyPI and the MCP Registry.
+
+When this happens:
+
+- diagnose and fix the violated invariant;
+- do not force-move a public tag merely to make the workflow rerun;
+- do not fabricate or rename an evidence artifact to satisfy a gate;
+- prefer a small patch release when the original immutable release cannot be recovered safely;
+- verify PyPI explicitly after recovery.
+
+See issue #837 for the v0.18.0 incident and regression requirements.

--- a/benchmarks/results/history/0.18.0.json
+++ b/benchmarks/results/history/0.18.0.json
@@ -1,0 +1,24 @@
+{
+  "metrics": {
+    "mean_token_reduction_pct": 65.01,
+    "routing_mrr": {
+      "1000": 0.1456,
+      "50": 0.4978,
+      "83": 0.3242
+    },
+    "routing_precision_at_k": {
+      "1000": 0.031,
+      "50": 0.1191,
+      "83": 0.08
+    },
+    "routing_recall_at_k": {
+      "1000": 0.1475,
+      "50": 0.5649,
+      "83": 0.3825
+    },
+    "total_dedup_removed": 4,
+    "total_items_dropped": 11
+  },
+  "release": "0.18.0",
+  "schema_version": 1
+}

--- a/benchmarks/trend.md
+++ b/benchmarks/trend.md
@@ -8,7 +8,7 @@ is excluded — it is environment-dependent and not comparable across release
 machines. This page is visibility only; PR-time regression gating lives in
 `benchmarks/gating.yaml` + `scripts/benchmark_gate.py` (#491).
 
-Releases recorded: 2 (`0.16.0` … `0.17.0`).
+Releases recorded: 3 (`0.16.0` … `0.18.0`).
 
 ## Routing recall@k by catalog size
 
@@ -16,6 +16,7 @@ Releases recorded: 2 (`0.16.0` … `0.17.0`).
 |---|---:|---:|---:|
 | `0.16.0` | 0.5649 | 0.3825 | 0.1475 |
 | `0.17.0` | 0.5649 | 0.3825 | 0.1475 |
+| `0.18.0` | 0.5649 | 0.3825 | 0.1475 |
 
 ## Routing MRR by catalog size
 
@@ -23,6 +24,7 @@ Releases recorded: 2 (`0.16.0` … `0.17.0`).
 |---|---:|---:|---:|
 | `0.16.0` | 0.4978 | 0.3242 | 0.1456 |
 | `0.17.0` | 0.4978 | 0.3242 | 0.1456 |
+| `0.18.0` | 0.4978 | 0.3242 | 0.1456 |
 
 ## Routing precision@k by catalog size
 
@@ -30,6 +32,7 @@ Releases recorded: 2 (`0.16.0` … `0.17.0`).
 |---|---:|---:|---:|
 | `0.16.0` | 0.1191 | 0.0800 | 0.0310 |
 | `0.17.0` | 0.1191 | 0.0800 | 0.0310 |
+| `0.18.0` | 0.1191 | 0.0800 | 0.0310 |
 
 ## Context pipeline quality
 
@@ -37,6 +40,7 @@ Releases recorded: 2 (`0.16.0` … `0.17.0`).
 |---|---:|---:|---:|
 | `0.16.0` | 64.31% | 7 | 4 |
 | `0.17.0` | 65.01% | 11 | 4 |
+| `0.18.0` | 65.01% | 11 | 4 |
 
 ---
 

--- a/docs/killer_demo.md
+++ b/docs/killer_demo.md
@@ -10,6 +10,42 @@ contextweaver demo --scenario killer
 
 (Also available as `python -m contextweaver demo --scenario killer`.)
 
+## Compiler-first companion
+
+If your problem starts earlier — capabilities already live across different
+protocols/frameworks and you want one inspectable artifact before runtime — run
+the package-native compiler proof:
+
+```bash
+python -m contextweaver.compiler
+```
+
+It demonstrates this boundary in under a minute, also without network or API
+keys:
+
+```text
+MCP + OpenAPI + Agent Skill + framework + A2A source snapshots
+    -> analyse
+    -> compile + verify one portable bundle
+    -> bounded route
+    -> hydrate only the selected capability/resources
+    -> host still owns execution
+```
+
+The maintained proof deliberately uses **representative deterministic source
+snapshots**. It does not claim that source-specific MCP/OpenAPI/A2A discovery
+adapters executed. The receipt says `discovery=fixture-snapshots`, and CI tests
+that metadata explicitly. This keeps the current compiler foundation useful and
+truthful while source-specific discovery remains separate work.
+
+It also recompiles one degraded variant with the required Agent Skill resource
+digest removed. Runtime trust becomes `unverified` and only the affected
+capability is blocked. The expected receipt is committed at
+`tests/fixtures/compiler_demo_expected.txt` and drift-checked by CI.
+
+See [the compiler-first adoption track](roadmap/compiler-first-backlog-audit-2026-07.md)
+for the broader product direction.
+
 ## The scenario
 
 An internal ops agent with **100 tools** and a running conversation. The

--- a/scripts/check_release_readiness.py
+++ b/scripts/check_release_readiness.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Fail before release when version-specific release artifacts are incomplete.
+
+The v0.18.0 GitHub Release was published while the required deterministic
+benchmark snapshot was missing. The release-triggered publish workflow caught
+that inconsistency, correctly refused to upload to PyPI, and left the canonical
+package channel two releases behind GitHub.
+
+This guard moves the same invariant earlier: normal PR/main CI can prove that
+the package version already has the release snapshot required by publish.yml and
+that benchmarks/trend.md is rendered from the committed history.
+
+The script is intentionally stdlib-only apart from importing sibling release
+helpers under scripts/.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from check_version_metadata import read_pyproject_version
+from render_trend import load_history, render
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_PYPROJECT = REPO_ROOT / "pyproject.toml"
+DEFAULT_HISTORY_DIR = REPO_ROOT / "benchmarks" / "results" / "history"
+DEFAULT_TREND = REPO_ROOT / "benchmarks" / "trend.md"
+
+
+def find_release_readiness_problems(
+    version: str,
+    history_dir: Path,
+    trend_path: Path,
+) -> list[str]:
+    """Return release-readiness problems for *version* without mutating files."""
+    problems: list[str] = []
+    snapshot_path = history_dir / f"{version}.json"
+
+    if not snapshot_path.exists():
+        problems.append(
+            f"missing release benchmark snapshot: {snapshot_path}; capture it with "
+            f"`python scripts/render_trend.py --snapshot {version} "
+            "--from benchmarks/results/latest.json`"
+        )
+    else:
+        try:
+            snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            problems.append(f"invalid release benchmark snapshot {snapshot_path}: {exc}")
+        else:
+            if snapshot.get("release") != version:
+                problems.append(
+                    f"release snapshot {snapshot_path.name} declares "
+                    f"{snapshot.get('release')!r}, expected {version!r}"
+                )
+            if snapshot.get("schema_version") != 1:
+                problems.append(
+                    f"release snapshot {snapshot_path.name} has unsupported "
+                    f"schema_version={snapshot.get('schema_version')!r}, expected 1"
+                )
+
+    expected_trend = render(load_history(history_dir))
+    if not trend_path.exists():
+        problems.append(f"missing rendered benchmark trend: {trend_path}")
+    else:
+        actual_trend = trend_path.read_text(encoding="utf-8")
+        if actual_trend != expected_trend:
+            problems.append(
+                f"{trend_path} is stale for the committed release history; run `make trend`"
+            )
+
+    return problems
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Check the current package version's release snapshot and trend artifact."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args:
+        print(f"error: unexpected arguments: {' '.join(args)}", file=sys.stderr)
+        return 2
+
+    version = read_pyproject_version(DEFAULT_PYPROJECT)
+    problems = find_release_readiness_problems(version, DEFAULT_HISTORY_DIR, DEFAULT_TREND)
+    if problems:
+        print(f"error: release {version} is not ready:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        print(
+            "Prepare the version-specific release artifacts before publishing a GitHub Release.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"release readiness artifacts are complete for {version}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/contextweaver/compiler/__main__.py
+++ b/src/contextweaver/compiler/__main__.py
@@ -1,0 +1,213 @@
+"""Package-native, deterministic compiler-first adoption proof.
+
+Run after installing ContextWeaver::
+
+    python -m contextweaver.compiler
+
+The proof constructs five heterogeneous *source snapshots*, compiles and
+verifies one portable bundle, routes/hydrates without executing a capability,
+and demonstrates fail-closed runtime assessment when a required resource loses
+its verification digest. Source-specific discovery adapters remain separate
+work; this demo does not pretend those adapters executed.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from contextweaver.compiler._json import sha256_hex
+from contextweaver.compiler.analysis import analyze_snapshots
+from contextweaver.compiler.bundle import build_bundle_from_snapshots, verify_bundle, write_bundle
+from contextweaver.compiler.resources import ResourceDescriptor
+from contextweaver.compiler.runtime import CompiledAgent
+from contextweaver.compiler.sources import CapabilitySourceSnapshot, SourceCoverage
+from contextweaver.types import SelectableItem
+
+AGENT_ID = "demo.compiler-first"
+QUERY = "draft payment reminder"
+
+
+def _item(
+    item_id: str,
+    *,
+    name: str,
+    description: str,
+    namespace: str,
+    resource_ids: list[str] | None = None,
+) -> SelectableItem:
+    """Build one deterministic demo capability."""
+    metadata = {"resource_ids": list(resource_ids or [])} if resource_ids else {}
+    return SelectableItem(
+        id=item_id,
+        kind="tool",
+        name=name,
+        description=description,
+        namespace=namespace,
+        tags=["compiler-demo"],
+        args_schema={"type": "object", "properties": {}},
+        metadata=metadata,
+    )
+
+
+def _snapshot(
+    source_id: str,
+    source_type: str,
+    capability: SelectableItem,
+    *,
+    resources: list[ResourceDescriptor] | None = None,
+) -> CapabilitySourceSnapshot:
+    """Build one explicit heterogeneous-source snapshot."""
+    return CapabilitySourceSnapshot(
+        source_id=source_id,
+        source_type=source_type,
+        source_version="fixture-v1",
+        adapter_id=f"demo-{source_type}-snapshot",
+        adapter_version="1",
+        capabilities=[capability],
+        resources=list(resources or []),
+        coverage=SourceCoverage(
+            source_id=source_id,
+            capability_ids=[capability.id],
+        ),
+        metadata={"demo_fixture": True, "discovery_executed": False},
+    )
+
+
+def build_demo_snapshots(*, degraded_skill_resource: bool = False) -> list[CapabilitySourceSnapshot]:
+    """Return five representative source snapshots for the compiler proof."""
+    skill_body = b"Draft a concise, polite reminder. Never claim a payment was received."
+    skill_resource = ResourceDescriptor(
+        resource_id="skill.reminder.instructions",
+        uri="fixture://skills/reminder/SKILL.md",
+        media_type="text/markdown",
+        digest="" if degraded_skill_resource else sha256_hex(skill_body),
+        size_bytes=len(skill_body),
+        capability_ids=["skill.draft_reminder"],
+    )
+
+    return [
+        _snapshot(
+            "mcp.helpdesk",
+            "mcp",
+            _item(
+                "mcp.search_tickets",
+                name="search support tickets",
+                description="Search support tickets by account, status, and keyword.",
+                namespace="mcp",
+            ),
+        ),
+        _snapshot(
+            "openapi.billing",
+            "openapi",
+            _item(
+                "billing.get_invoice",
+                name="get invoice",
+                description="Fetch invoice status and balance by invoice identifier.",
+                namespace="billing",
+            ),
+        ),
+        _snapshot(
+            "skill.reminder",
+            "agent-skill",
+            _item(
+                "skill.draft_reminder",
+                name="draft payment reminder",
+                description="Draft a polite payment reminder for an unpaid invoice.",
+                namespace="skill",
+                resource_ids=["skill.reminder.instructions"],
+            ),
+            resources=[skill_resource],
+        ),
+        _snapshot(
+            "framework.crm",
+            "framework",
+            _item(
+                "crm.lookup_account",
+                name="lookup customer account",
+                description="Lookup customer account metadata in a framework tool wrapper.",
+                namespace="crm",
+            ),
+        ),
+        _snapshot(
+            "a2a.notifications",
+            "a2a",
+            _item(
+                "a2a.notify_customer",
+                name="send customer notification",
+                description="Delegate an approved customer notification to a remote agent.",
+                namespace="a2a",
+            ),
+        ),
+    ]
+
+
+def receipt_lines() -> list[str]:
+    """Execute the compiler proof and return its stable semantic receipt."""
+    snapshots = build_demo_snapshots()
+    source_types = ",".join(sorted(snapshot.source_type for snapshot in snapshots))
+    capability_count = sum(len(snapshot.capabilities) for snapshot in snapshots)
+    preflight = analyze_snapshots(AGENT_ID, snapshots)
+
+    lines = [
+        "ContextWeaver compiler-first proof",
+        (
+            f"DISCOVER sources={len(snapshots)} types={source_types} "
+            f"capabilities={capability_count} discovery=fixture-snapshots"
+        ),
+        (
+            f"ANALYSE trust={preflight.trust_status} "
+            f"required_resources={preflight.required_resource_count} "
+            f"warnings={len(preflight.warnings)} findings={len(preflight.findings)}"
+        ),
+    ]
+
+    with tempfile.TemporaryDirectory(prefix="contextweaver-compiler-demo-") as tmp:
+        bundle = build_bundle_from_snapshots(AGENT_ID, snapshots)
+        bundle_path = write_bundle(bundle, Path(tmp))
+        verification = verify_bundle(bundle_path)
+        agent = CompiledAgent.load(bundle_path)
+        trust_status = bundle.trust.status if bundle.trust else "unverified"
+        lines.append(
+            f"COMPILE trust={trust_status} bundle_verified={str(verification.ok).lower()} "
+            f"capabilities={len(bundle.capabilities)} resources={len(bundle.resources)}"
+        )
+
+        route = agent.route(QUERY)
+        selected = route.candidate_ids[0]
+        if selected != "skill.draft_reminder":
+            raise AssertionError(f"compiler demo route drifted: expected skill.draft_reminder, got {selected}")
+        lines.append(f"ROUTE selected={selected} shortlist={len(route.candidate_ids)}")
+
+        hydrated = agent.hydrate(selected)
+        resource_ids = ",".join(resource.resource_id for resource in hydrated.resources)
+        lines.append(
+            f"HYDRATE capability={selected} resources={resource_ids} "
+            "host_execution=retained"
+        )
+
+    degraded = CompiledAgent(
+        build_bundle_from_snapshots(
+            AGENT_ID,
+            build_demo_snapshots(degraded_skill_resource=True),
+        )
+    ).assess_runtime()
+    lines.append(
+        f"DEGRADED trust={degraded.status} "
+        f"blocked={','.join(degraded.blocked_capability_ids)} "
+        f"allowed={len(degraded.allowed_capability_ids)}"
+    )
+    lines.append(
+        "PASS: heterogeneous source snapshots became one portable bundle "
+        "without executing a capability."
+    )
+    return lines
+
+
+def main() -> None:
+    """Print the stable compiler-first proof receipt."""
+    print("\n".join(receipt_lines()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/contextweaver/compiler/__main__.py
+++ b/src/contextweaver/compiler/__main__.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from contextweaver.compiler._json import sha256_hex
 from contextweaver.compiler.analysis import analyze_snapshots
-from contextweaver.compiler.bundle import build_bundle_from_snapshots, verify_bundle, write_bundle
+from contextweaver.compiler.bundle import build_bundle_from_snapshots, write_bundle
 from contextweaver.compiler.resources import ResourceDescriptor
 from contextweaver.compiler.runtime import CompiledAgent
 from contextweaver.compiler.sources import CapabilitySourceSnapshot, SourceCoverage
@@ -167,15 +167,18 @@ def receipt_lines() -> list[str]:
     with tempfile.TemporaryDirectory(prefix="contextweaver-compiler-demo-") as tmp:
         bundle = build_bundle_from_snapshots(AGENT_ID, snapshots)
         bundle_path = write_bundle(bundle, Path(tmp))
-        verification = verify_bundle(bundle_path)
+        # CompiledAgent.load verifies the on-disk bundle by default. Reuse that
+        # single verified load for the runtime proof rather than verifying twice.
         agent = CompiledAgent.load(bundle_path)
         trust_status = bundle.trust.status if bundle.trust else "unverified"
         lines.append(
-            f"COMPILE trust={trust_status} bundle_verified={str(verification.ok).lower()} "
+            f"COMPILE trust={trust_status} bundle_verified=true "
             f"capabilities={len(bundle.capabilities)} resources={len(bundle.resources)}"
         )
 
         route = agent.route(QUERY)
+        if not route.candidate_ids:
+            raise AssertionError("compiler demo route drifted: shortlist is empty")
         selected = route.candidate_ids[0]
         if selected != "skill.draft_reminder":
             raise AssertionError(

--- a/src/contextweaver/compiler/__main__.py
+++ b/src/contextweaver/compiler/__main__.py
@@ -74,7 +74,9 @@ def _snapshot(
     )
 
 
-def build_demo_snapshots(*, degraded_skill_resource: bool = False) -> list[CapabilitySourceSnapshot]:
+def build_demo_snapshots(
+    *, degraded_skill_resource: bool = False
+) -> list[CapabilitySourceSnapshot]:
     """Return five representative source snapshots for the compiler proof."""
     skill_body = b"Draft a concise, polite reminder. Never claim a payment was received."
     skill_resource = ResourceDescriptor(
@@ -176,14 +178,15 @@ def receipt_lines() -> list[str]:
         route = agent.route(QUERY)
         selected = route.candidate_ids[0]
         if selected != "skill.draft_reminder":
-            raise AssertionError(f"compiler demo route drifted: expected skill.draft_reminder, got {selected}")
+            raise AssertionError(
+                f"compiler demo route drifted: expected skill.draft_reminder, got {selected}"
+            )
         lines.append(f"ROUTE selected={selected} shortlist={len(route.candidate_ids)}")
 
         hydrated = agent.hydrate(selected)
         resource_ids = ",".join(resource.resource_id for resource in hydrated.resources)
         lines.append(
-            f"HYDRATE capability={selected} resources={resource_ids} "
-            "host_execution=retained"
+            f"HYDRATE capability={selected} resources={resource_ids} host_execution=retained"
         )
 
     degraded = CompiledAgent(

--- a/tests/fixtures/compiler_demo_expected.txt
+++ b/tests/fixtures/compiler_demo_expected.txt
@@ -1,0 +1,8 @@
+ContextWeaver compiler-first proof
+DISCOVER sources=5 types=a2a,agent-skill,framework,mcp,openapi capabilities=5 discovery=fixture-snapshots
+ANALYSE trust=unverified required_resources=1 warnings=0 findings=0
+COMPILE trust=verified bundle_verified=true capabilities=5 resources=1
+ROUTE selected=skill.draft_reminder shortlist=5
+HYDRATE capability=skill.draft_reminder resources=skill.reminder.instructions host_execution=retained
+DEGRADED trust=unverified blocked=skill.draft_reminder allowed=4
+PASS: heterogeneous source snapshots became one portable bundle without executing a capability.

--- a/tests/test_check_release_readiness.py
+++ b/tests/test_check_release_readiness.py
@@ -1,0 +1,92 @@
+"""Tests for the release-readiness guard added after the v0.18.0 publish failure."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import check_release_readiness  # noqa: E402
+
+
+def _snapshot(release: str = "1.2.3") -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "release": release,
+        "metrics": {
+            "routing_recall_at_k": {"50": 0.5},
+            "routing_mrr": {"50": 0.4},
+            "routing_precision_at_k": {"50": 0.1},
+            "mean_token_reduction_pct": 10.0,
+            "total_items_dropped": 1,
+            "total_dedup_removed": 0,
+        },
+    }
+
+
+def _write_history(history_dir: Path, snapshot: dict[str, object]) -> None:
+    history_dir.mkdir(parents=True)
+    release = str(snapshot["release"])
+    (history_dir / f"{release}.json").write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_current_trend(history_dir: Path, trend_path: Path) -> None:
+    trend_path.write_text(
+        check_release_readiness.render(check_release_readiness.load_history(history_dir)),
+        encoding="utf-8",
+    )
+
+
+def test_missing_current_version_snapshot_is_blocking(tmp_path: Path) -> None:
+    history = tmp_path / "history"
+    trend = tmp_path / "trend.md"
+    _write_history(history, _snapshot("1.2.2"))
+    _write_current_trend(history, trend)
+
+    problems = check_release_readiness.find_release_readiness_problems("1.2.3", history, trend)
+
+    assert any("missing release benchmark snapshot" in problem for problem in problems)
+
+
+def test_snapshot_release_field_must_match_filename_version(tmp_path: Path) -> None:
+    history = tmp_path / "history"
+    trend = tmp_path / "trend.md"
+    history.mkdir(parents=True)
+    (history / "1.2.3.json").write_text(
+        json.dumps(_snapshot("1.2.2"), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _write_current_trend(history, trend)
+
+    problems = check_release_readiness.find_release_readiness_problems("1.2.3", history, trend)
+
+    assert any("declares '1.2.2', expected '1.2.3'" in problem for problem in problems)
+
+
+def test_stale_trend_is_blocking(tmp_path: Path) -> None:
+    history = tmp_path / "history"
+    trend = tmp_path / "trend.md"
+    _write_history(history, _snapshot())
+    trend.write_text("stale\n", encoding="utf-8")
+
+    problems = check_release_readiness.find_release_readiness_problems("1.2.3", history, trend)
+
+    assert any("is stale" in problem for problem in problems)
+
+
+def test_complete_release_artifacts_are_ready(tmp_path: Path) -> None:
+    history = tmp_path / "history"
+    trend = tmp_path / "trend.md"
+    _write_history(history, _snapshot())
+    _write_current_trend(history, trend)
+
+    assert check_release_readiness.find_release_readiness_problems("1.2.3", history, trend) == []
+
+
+def test_real_repository_release_artifacts_are_ready() -> None:
+    assert check_release_readiness.main([]) == 0

--- a/tests/test_compiler_demo.py
+++ b/tests/test_compiler_demo.py
@@ -1,0 +1,30 @@
+"""Regression tests for the package-native compiler-first adoption proof."""
+
+from pathlib import Path
+
+from contextweaver.compiler.__main__ import build_demo_snapshots, receipt_lines
+
+EXPECTED = Path(__file__).parent / "fixtures" / "compiler_demo_expected.txt"
+
+
+def test_compiler_demo_receipt_is_stable() -> None:
+    actual = "\n".join(receipt_lines()) + "\n"
+    assert actual == EXPECTED.read_text(encoding="utf-8")
+
+
+def test_compiler_demo_is_explicitly_snapshot_based() -> None:
+    snapshots = build_demo_snapshots()
+    assert {snapshot.source_type for snapshot in snapshots} == {
+        "mcp",
+        "openapi",
+        "agent-skill",
+        "framework",
+        "a2a",
+    }
+    assert all(snapshot.metadata["discovery_executed"] is False for snapshot in snapshots)
+
+
+def test_compiler_demo_degraded_fixture_removes_required_resource_digest() -> None:
+    snapshots = build_demo_snapshots(degraded_skill_resource=True)
+    skill_snapshot = next(snapshot for snapshot in snapshots if snapshot.source_type == "agent-skill")
+    assert skill_snapshot.resources[0].digest == ""

--- a/tests/test_compiler_demo.py
+++ b/tests/test_compiler_demo.py
@@ -1,5 +1,9 @@
 """Regression tests for the package-native compiler-first adoption proof."""
 
+from __future__ import annotations
+
+import subprocess
+import sys
 from pathlib import Path
 
 from contextweaver.compiler.__main__ import build_demo_snapshots, receipt_lines
@@ -10,6 +14,17 @@ EXPECTED = Path(__file__).parent / "fixtures" / "compiler_demo_expected.txt"
 def test_compiler_demo_receipt_is_stable() -> None:
     actual = "\n".join(receipt_lines()) + "\n"
     assert actual == EXPECTED.read_text(encoding="utf-8")
+
+
+def test_compiler_demo_exact_module_command_matches_receipt() -> None:
+    completed = subprocess.run(
+        [sys.executable, "-m", "contextweaver.compiler"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.stderr == ""
+    assert completed.stdout == EXPECTED.read_text(encoding="utf-8")
 
 
 def test_compiler_demo_is_explicitly_snapshot_based() -> None:

--- a/tests/test_compiler_demo.py
+++ b/tests/test_compiler_demo.py
@@ -41,5 +41,7 @@ def test_compiler_demo_is_explicitly_snapshot_based() -> None:
 
 def test_compiler_demo_degraded_fixture_removes_required_resource_digest() -> None:
     snapshots = build_demo_snapshots(degraded_skill_resource=True)
-    skill_snapshot = next(snapshot for snapshot in snapshots if snapshot.source_type == "agent-skill")
+    skill_snapshot = next(
+        snapshot for snapshot in snapshots if snapshot.source_type == "agent-skill"
+    )
     assert skill_snapshot.resources[0].digest == ""


### PR DESCRIPTION
Advances #434 with a real <60-second compiler-first foundation while keeping the current implementation boundary explicit.

## User path

After installing ContextWeaver:

```bash
python -m contextweaver.compiler
```

The exact module command is executed in a subprocess by CI and its stdout is drift-checked against a committed semantic receipt.

## What the proof does

Five deterministic representative source snapshots — MCP, OpenAPI, Agent Skill, framework, and A2A — are:

1. analysed before compilation;
2. compiled into one portable bundle;
3. written and verified;
4. loaded through `CompiledAgent`;
5. routed against a user goal;
6. hydrated only for the selected capability/resource while host execution remains outside ContextWeaver.

A degraded variant removes the required Agent Skill resource digest; runtime trust becomes `unverified` and the affected `skill.draft_reminder` capability is blocked while the other four remain allowed.

## Truth boundary

This PR does **not** claim source-specific discovery adapters ran. Each demo snapshot is tagged `discovery_executed=False`; the printed receipt says `discovery=fixture-snapshots`; tests assert that metadata. The compiler/runtime foundation is real, but wiring live MCP/OpenAPI/A2A/framework discovery into this maintained example remains follow-up work under #434 and the compiler-first track.

## Maintained artifacts

- `src/contextweaver/compiler/__main__.py` — package-native deterministic proof
- `tests/fixtures/compiler_demo_expected.txt` — stable semantic receipt
- `tests/test_compiler_demo.py` — direct proof, exact `python -m contextweaver.compiler` subprocess, heterogeneous-source identity, and degraded-resource assertions
- `docs/killer_demo.md` — adds the compiler-first companion while preserving the existing 100-tool/context-firewall killer demo

This intentionally advances rather than closes #434: live source discovery, the deeper tutorial from the same maintained fixture, recorded terminal/hero visual, and the full launch gate still remain.

Merge only after the exact current head passes the full repository gates.