### PR TITLE
fix(release): restore v0.18 benchmark snapshot and gate release readiness

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,31 @@
+name: Release readiness
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# This check exists because v0.18.0 reached GitHub Releases without the
+# version-specific deterministic benchmark snapshot required by publish.yml.
+# The publish workflow correctly failed, but by then PyPI had already diverged
+# from the public GitHub release. Run the invariant during normal PR/main CI so
+# release artifacts are complete before anyone presses "Publish release".
+jobs:
+  release-readiness:
+    name: Release artifacts ready
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify current package version is release-ready
+        run: python scripts/check_release_readiness.py

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,79 @@
+# Releasing contextweaver
+
+GitHub Releases, PyPI, the MCP Registry and the committed release evidence must describe the same product version.
+
+The release workflow intentionally fails closed. Do not weaken a failing integrity gate to make a release publish.
+
+## Release preparation
+
+Prepare the release in a normal pull request **before** creating or publishing the GitHub Release.
+
+1. Finish the intended release changes and ensure normal CI is green.
+2. Set `[project].version` in `pyproject.toml` to the release version.
+3. Update all version-bearing metadata required by the drift guards:
+   - README current/comparison/roadmap references;
+   - `server.json`;
+   - `CITATION.cff` version and release date;
+   - SECURITY/version references where required by the current policy.
+4. Finalize the CHANGELOG section for the release.
+5. Refresh the deterministic benchmark from the release candidate code:
+
+   ```bash
+   make benchmark
+   python scripts/render_trend.py --snapshot X.Y.Z \
+       --from benchmarks/results/latest.json
+   make trend
+   ```
+
+   Review the new `benchmarks/results/history/X.Y.Z.json` instead of treating it as generated ceremony. A regression or surprising change should be explained before release.
+6. Run the explicit release-readiness guard:
+
+   ```bash
+   python scripts/check_release_readiness.py
+   ```
+
+   It must confirm that the current package version has a matching benchmark-history snapshot and that `benchmarks/trend.md` is synchronized.
+7. Run the normal project validation required for the release PR and merge only when required checks are green.
+
+The `Release readiness` workflow runs on pull requests and `main` as an early guard for the same invariant.
+
+## Publish
+
+After the release-preparation PR is merged:
+
+1. Create/tag `vX.Y.Z` from the exact prepared commit.
+2. Create and publish the GitHub Release for that tag.
+3. The `Publish to PyPI and MCP Registry` workflow independently verifies:
+   - tag ↔ package version;
+   - version metadata;
+   - release benchmark snapshot + trend;
+   - test suite;
+   - built distribution metadata.
+4. Only after verification does the workflow publish to PyPI via Trusted Publishing/OIDC.
+5. The MCP Registry publish happens after PyPI because its package metadata depends on the PyPI release.
+
+## Post-publish verification
+
+Verify the canonical user path from a clean environment, not an editable checkout:
+
+```bash
+python -m pip install --no-cache-dir contextweaver
+python -c "import contextweaver; print(contextweaver.__version__)"
+contextweaver demo --scenario killer
+```
+
+Confirm that the printed version matches the GitHub Release and that the MCP Registry entry, when applicable, references the same package version.
+
+## Recovery from a failed publish
+
+A GitHub Release can exist even when the release-triggered publish workflow fails. That happened for v0.18.0: the required `benchmarks/results/history/0.18.0.json` had not been committed, so the integrity gate correctly skipped PyPI and the MCP Registry.
+
+When this happens:
+
+- diagnose and fix the violated invariant;
+- do not force-move a public tag merely to make the workflow rerun;
+- do not fabricate or rename an evidence artifact to satisfy a gate;
+- prefer a small patch release when the original immutable release cannot be recovered safely;
+- verify PyPI explicitly after recovery.
+
+See issue #837 for the v0.18.0 incident and regression requirements.

--- a/benchmarks/results/history/0.18.0.json
+++ b/benchmarks/results/history/0.18.0.json
@@ -1,0 +1,24 @@
+{
+  "metrics": {
+    "mean_token_reduction_pct": 65.01,
+    "routing_mrr": {
+      "1000": 0.1456,
+      "50": 0.4978,
+      "83": 0.3242
+    },
+    "routing_precision_at_k": {
+      "1000": 0.031,
+      "50": 0.1191,
+      "83": 0.08
+    },
+    "routing_recall_at_k": {
+      "1000": 0.1475,
+      "50": 0.5649,
+      "83": 0.3825
+    },
+    "total_dedup_removed": 4,
+    "total_items_dropped": 11
+  },
+  "release": "0.18.0",
+  "schema_version": 1
+}

--- a/benchmarks/trend.md
+++ b/benchmarks/trend.md
@@ -8,7 +8,7 @@ is excluded — it is environment-dependent and not comparable across release
 machines. This page is visibility only; PR-time regression gating lives in
 `benchmarks/gating.yaml` + `scripts/benchmark_gate.py` (#491).
 
-Releases recorded: 2 (`0.16.0` … `0.17.0`).
+Releases recorded: 3 (`0.16.0` … `0.18.0`).
 
 ## Routing recall@k by catalog size
 
@@ -16,6 +16,7 @@ Releases recorded: 2 (`0.16.0` … `0.17.0`).
 |---|---:|---:|---:|
 | `0.16.0` | 0.5649 | 0.3825 | 0.1475 |
 | `0.17.0` | 0.5649 | 0.3825 | 0.1475 |
+| `0.18.0` | 0.5649 | 0.3825 | 0.1475 |
 
 ## Routing MRR by catalog size
 
@@ -23,6 +24,7 @@ Releases recorded: 2 (`0.16.0` … `0.17.0`).
 |---|---:|---:|---:|
 | `0.16.0` | 0.4978 | 0.3242 | 0.1456 |
 | `0.17.0` | 0.4978 | 0.3242 | 0.1456 |
+| `0.18.0` | 0.4978 | 0.3242 | 0.1456 |
 
 ## Routing precision@k by catalog size
 
@@ -30,6 +32,7 @@ Releases recorded: 2 (`0.16.0` … `0.17.0`).
 |---|---:|---:|---:|
 | `0.16.0` | 0.1191 | 0.0800 | 0.0310 |
 | `0.17.0` | 0.1191 | 0.0800 | 0.0310 |
+| `0.18.0` | 0.1191 | 0.0800 | 0.0310 |
 
 ## Context pipeline quality
 
@@ -37,6 +40,7 @@ Releases recorded: 2 (`0.16.0` … `0.17.0`).
 |---|---:|---:|---:|
 | `0.16.0` | 64.31% | 7 | 4 |
 | `0.17.0` | 65.01% | 11 | 4 |
+| `0.18.0` | 65.01% | 11 | 4 |
 
 ---
 

--- a/scripts/check_release_readiness.py
+++ b/scripts/check_release_readiness.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Fail before release when version-specific release artifacts are incomplete.
+
+The v0.18.0 GitHub Release was published while the required deterministic
+benchmark snapshot was missing. The release-triggered publish workflow caught
+that inconsistency, correctly refused to upload to PyPI, and left the canonical
+package channel two releases behind GitHub.
+
+This guard moves the same invariant earlier: normal PR/main CI can prove that
+the package version already has the release snapshot required by publish.yml and
+that benchmarks/trend.md is rendered from the committed history.
+
+The script is intentionally stdlib-only apart from importing sibling release
+helpers under scripts/.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from check_version_metadata import read_pyproject_version
+from render_trend import load_history, render
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_PYPROJECT = REPO_ROOT / "pyproject.toml"
+DEFAULT_HISTORY_DIR = REPO_ROOT / "benchmarks" / "results" / "history"
+DEFAULT_TREND = REPO_ROOT / "benchmarks" / "trend.md"
+
+
+def find_release_readiness_problems(
+    version: str,
+    history_dir: Path,
+    trend_path: Path,
+) -> list[str]:
+    """Return release-readiness problems for *version* without mutating files."""
+    problems: list[str] = []
+    snapshot_path = history_dir / f"{version}.json"
+
+    if not snapshot_path.exists():
+        problems.append(
+            f"missing release benchmark snapshot: {snapshot_path}; capture it with "
+            f"`python scripts/render_trend.py --snapshot {version} "
+            "--from benchmarks/results/latest.json`"
+        )
+    else:
+        try:
+            snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            problems.append(f"invalid release benchmark snapshot {snapshot_path}: {exc}")
+        else:
+            if snapshot.get("release") != version:
+                problems.append(
+                    f"release snapshot {snapshot_path.name} declares "
+                    f"{snapshot.get('release')!r}, expected {version!r}"
+                )
+            if snapshot.get("schema_version") != 1:
+                problems.append(
+                    f"release snapshot {snapshot_path.name} has unsupported "
+                    f"schema_version={snapshot.get('schema_version')!r}, expected 1"
+                )
+
+    expected_trend = render(load_history(history_dir))
+    if not trend_path.exists():
+        problems.append(f"missing rendered benchmark trend: {trend_path}")
+    else:
+        actual_trend = trend_path.read_text(encoding="utf-8")
+        if actual_trend != expected_trend:
+            problems.append(
+                f"{trend_path} is stale for the committed release history; run `make trend`"
+            )
+
+    return problems
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Check the current package version's release snapshot and trend artifact."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args:
+        print(f"error: unexpected arguments: {' '.join(args)}", file=sys.stderr)
+        return 2
+
+    version = read_pyproject_version(DEFAULT_PYPROJECT)
+    problems = find_release_readiness_problems(version, DEFAULT_HISTORY_DIR, DEFAULT_TREND)
+    if problems:
+        print(f"error: release {version} is not ready:", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        print(
+            "Prepare the version-specific release artifacts before publishing a GitHub Release.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"release readiness artifacts are complete for {version}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_release_readiness.py
+++ b/tests/test_check_release_readiness.py
@@ -1,0 +1,92 @@
+"""Tests for the release-readiness guard added after the v0.18.0 publish failure."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import check_release_readiness  # noqa: E402
+
+
+def _snapshot(release: str = "1.2.3") -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "release": release,
+        "metrics": {
+            "routing_recall_at_k": {"50": 0.5},
+            "routing_mrr": {"50": 0.4},
+            "routing_precision_at_k": {"50": 0.1},
+            "mean_token_reduction_pct": 10.0,
+            "total_items_dropped": 1,
+            "total_dedup_removed": 0,
+        },
+    }
+
+
+def _write_history(history_dir: Path, snapshot: dict[str, object]) -> None:
+    history_dir.mkdir(parents=True)
+    release = str(snapshot["release"])
+    (history_dir / f"{release}.json").write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_current_trend(history_dir: Path, trend_path: Path) -> None:
+    trend_path.write_text(
+        check_release_readiness.render(check_release_readiness.load_history(history_dir)),
+        encoding="utf-8",
+    )
+
+
+def test_missing_current_version_snapshot_is_blocking(tmp_path: Path) -> None:
+    history = tmp_path / "history"
+    trend = tmp_path / "trend.md"
+    _write_history(history, _snapshot("1.2.2"))
+    _write_current_trend(history, trend)
+
+    problems = check_release_readiness.find_release_readiness_problems("1.2.3", history, trend)
+
+    assert any("missing release benchmark snapshot" in problem for problem in problems)
+
+
+def test_snapshot_release_field_must_match_filename_version(tmp_path: Path) -> None:
+    history = tmp_path / "history"
+    trend = tmp_path / "trend.md"
+    history.mkdir(parents=True)
+    (history / "1.2.3.json").write_text(
+        json.dumps(_snapshot("1.2.2"), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _write_current_trend(history, trend)
+
+    problems = check_release_readiness.find_release_readiness_problems("1.2.3", history, trend)
+
+    assert any("declares '1.2.2', expected '1.2.3'" in problem for problem in problems)
+
+
+def test_stale_trend_is_blocking(tmp_path: Path) -> None:
+    history = tmp_path / "history"
+    trend = tmp_path / "trend.md"
+    _write_history(history, _snapshot())
+    trend.write_text("stale\n", encoding="utf-8")
+
+    problems = check_release_readiness.find_release_readiness_problems("1.2.3", history, trend)
+
+    assert any("is stale" in problem for problem in problems)
+
+
+def test_complete_release_artifacts_are_ready(tmp_path: Path) -> None:
+    history = tmp_path / "history"
+    trend = tmp_path / "trend.md"
+    _write_history(history, _snapshot())
+    _write_current_trend(history, trend)
+
+    assert check_release_readiness.find_release_readiness_problems("1.2.3", history, trend) == []
+
+
+def test_real_repository_release_artifacts_are_ready() -> None:
+    assert check_release_readiness.main([]) == 0


### PR DESCRIPTION
## Summary

Fixes the release-process failure tracked in #837.

The v0.18.0 GitHub Release was published without the version-specific deterministic benchmark snapshot required by `.github/workflows/publish.yml`. The integrity gate correctly failed, so PyPI remained at 0.16.0 and the MCP Registry publish was skipped.

This PR restores the missing evidence from the **v0.18.0 release tag itself** and moves the invariant earlier so the same failure is caught during normal PR/main validation rather than only after a GitHub Release is public.

## Changes

- add `benchmarks/results/history/0.18.0.json`, derived by the existing `render_trend.py` extraction rules from `v0.18.0:benchmarks/results/latest.json`;
- regenerate `benchmarks/trend.md` with the v0.18.0 row;
- add `scripts/check_release_readiness.py` to verify:
  - the current package version has a matching history snapshot;
  - the snapshot declares the same release version/schema;
  - `benchmarks/trend.md` matches committed history;
- add focused tests reproducing the exact missing-snapshot failure plus mismatched-version and stale-trend cases;
- add a lightweight `Release readiness` workflow on PRs/main/manual runs;
- add `RELEASING.md` documenting preparation, publish, verification and safe recovery. It explicitly forbids weakening the integrity gate or fabricating/renaming evidence to satisfy it.

## Why the 0.18.0 snapshot is legitimate

The committed v0.18.0 `benchmarks/results/latest.json` contains the deterministic metrics consumed by `extract_snapshot()` in `scripts/render_trend.py`. The new history file is the output that existing code produces for `--snapshot 0.18.0`; latency/environment-dependent fields are intentionally excluded by that existing mechanism.

The deterministic snapshot happens to match 0.17.0 on the retained routing/context metrics except for the release identifier. That is a property of the release data, not a copied placeholder.

## Safety / release recovery

This PR does **not** force-move the public `v0.18.0` tag and does **not** publish a package automatically.

After this PR is validated and merged, #837 should choose the safest immutable recovery path. If the original public release cannot be republished cleanly, prefer a minimal patch release rather than rewriting published history.

## Validation expected from CI

- `tests/test_check_release_readiness.py` passes;
- `python scripts/check_release_readiness.py` reports v0.18.0 ready;
- the new `Release readiness` workflow is green;
- normal repository CI remains green;
- `python scripts/render_trend.py --check` agrees with the committed trend.

## Follow-up after merge

1. recover PyPI with the smallest safe release action;
2. verify a clean `pip install --no-cache-dir contextweaver` returns the intended current version;
3. verify the MCP Registry separately after PyPI propagation;
4. close #837 only after GitHub/PyPI/package metadata agree.

Closes #837 only after the post-merge publish/verification steps are complete; this PR alone should not auto-close the incident.