### PR TITLE
feat(compiler): add an honest package-native compiler-first proof

### DIFF
--- a/docs/killer_demo.md
+++ b/docs/killer_demo.md
@@ -10,6 +10,42 @@ contextweaver demo --scenario killer
 
 (Also available as `python -m contextweaver demo --scenario killer`.)
 
+## Compiler-first companion
+
+If your problem starts earlier — capabilities already live across different
+protocols/frameworks and you want one inspectable artifact before runtime — run
+the package-native compiler proof:
+
+```bash
+python -m contextweaver.compiler
+```
+
+It demonstrates this boundary in under a minute, also without network or API
+keys:
+
+```text
+MCP + OpenAPI + Agent Skill + framework + A2A source snapshots
+    -> analyse
+    -> compile + verify one portable bundle
+    -> bounded route
+    -> hydrate only the selected capability/resources
+    -> host still owns execution
+```
+
+The maintained proof deliberately uses **representative deterministic source
+snapshots**. It does not claim that source-specific MCP/OpenAPI/A2A discovery
+adapters executed. The receipt says `discovery=fixture-snapshots`, and CI tests
+that metadata explicitly. This keeps the current compiler foundation useful and
+truthful while source-specific discovery remains separate work.
+
+It also recompiles one degraded variant with the required Agent Skill resource
+digest removed. Runtime trust becomes `unverified` and only the affected
+capability is blocked. The expected receipt is committed at
+`tests/fixtures/compiler_demo_expected.txt` and drift-checked by CI.
+
+See [the compiler-first adoption track](roadmap/compiler-first-backlog-audit-2026-07.md)
+for the broader product direction.
+
 ## The scenario
 
 An internal ops agent with **100 tools** and a running conversation. The

--- a/docs/killer_demo.md
+++ b/docs/killer_demo.md
@@ -1,50 +1,171 @@
 # The 60-second failure mode
 
-> The fastest way to see why a naive tool-using agent loop breaks down — and
-> what contextweaver does about it — in one command, with no API keys and no
-> network.
+> Two deterministic proofs, each with no API key and no network: a
+> compiler-first capability-surface proof and the original tool/context-pressure
+> demo.
+
+## Compiler-first: understand it in 10 seconds
+
+An agent's effective capabilities often arrive through several formats and
+wrappers. Their identities can collide, required resources can go missing, and
+the surface seen in one environment may be hard to reproduce in another.
+
+```mermaid
+flowchart TD
+    A["MCP · OpenAPI · Agent Skill<br/>framework · A2A snapshots"] --> B["Analyse<br/>identity · coverage · trust"]
+    B --> C["Compile once<br/>versioned, verified bundle"]
+    C --> D["Evaluate candidate<br/>fixture gate"]
+    D --> E["Expose one phase<br/>route + selected resource"]
+    E -. "execution remains outside" .-> H["Host executes"]
+```
+
+ContextWeaver's compiler foundation turns deterministic source snapshots into a
+content-addressed portable bundle, evaluates the bounded candidate selected for
+the current phase, and hydrates only that capability's declared resource. The
+host still decides whether and how to execute it.
+
+### Copy/paste success in under a minute
+
+From a checkout with ContextWeaver installed, run the package module:
+
+```bash
+python -m contextweaver.compiler
+```
+
+The same command is run against the built wheel in the isolated package smoke
+job. Its exact stdout is committed in
+[`tests/fixtures/compiler_demo_expected.txt`](../tests/fixtures/compiler_demo_expected.txt)
+and byte-compared in CI, including under optimized Python (`-O`).
+
+The first receipt reports:
+
+- five representative source snapshots and five normalized capabilities;
+- one real cross-source identity ambiguity: two namespaces expose
+  `draft payment reminder`;
+- a content-addressed, verified bundle and its format/example versions;
+- one explicit fixture evaluation gate before runtime hydration;
+- a phase allowlist that reduces exposure to one capability and one required
+  Agent Skill resource;
+- a degraded recompile where the missing required digest blocks only the
+  affected capability, followed by the remediation result.
+
+These counts and outcomes describe only
+[`build_demo_snapshots()`](../src/contextweaver/compiler/__main__.py) at
+`fixture-v1`. They are a regression fixture, not a universal benchmark.
+
+### Deep walkthrough: the same maintained example
+
+#### 1. Discover and analyse the candidate surface
+
+`build_demo_snapshots()` constructs five versioned
+`CapabilitySourceSnapshot` objects representing MCP, OpenAPI, Agent Skills,
+one framework object, and A2A. Two snapshots intentionally use the same human
+name in different namespaces. `analyze_collisions()` reports that ambiguity
+before compilation.
+
+This is an honest fixture boundary: the demo does **not** run source-specific
+network/filesystem discovery. Every snapshot carries
+`discovery_executed=False`, the receipt says
+`discovery=fixture-snapshots`, and CI asserts both. Use the existing
+source adapters separately when turning real inputs into `SelectableItem`
+objects; dedicated compiler discovery adapters remain future work.
+
+#### 2. Compile, inspect, and verify
+
+`build_bundle_from_snapshots()` normalizes the five snapshots into one
+`CompiledBundle`. `write_bundle()` emits a content-addressed directory:
+
+| File | What it makes inspectable |
+|---|---|
+| `agent.json` | agent identity and fixture version |
+| `capabilities.json` | normalized, deterministic capability surface |
+| `resources.json` | required resource identity, digest, size, and closure |
+| `lock.json` | source snapshots, adapter versions, coverage, provenance |
+| `manifest.json` | component digests, logical bundle digest, trust summary |
+
+`CompiledAgent.load()` verifies the on-disk component hashes, logical digest,
+directory identity, and recomputed trust projection before the runtime facade
+is constructed. The demo uses a temporary directory only to leave no local
+state; the same bundle format is portable to a caller-owned path.
+
+A bundle diff surface is not shipped yet, so this demo does not invent one.
+The content-addressed directory and deterministic JSON files are already
+ordinary diff inputs; a first-class semantic diff remains tracked by
+[#434](https://github.com/dgenio/contextweaver/issues/434).
+
+#### 3. Evaluate before exposing runtime context
+
+The maintained `compiler-demo-eval-v1` fixture asks for a payment reminder.
+The demo evaluates three conditions before hydration:
+
+1. the routed top candidate is `skill.draft_reminder`;
+2. runtime trust allows that candidate;
+3. the `draft-reminder` phase namespace allowlist exposes exactly one
+   candidate.
+
+This is a one-case adoption regression gate, not evidence of general routing
+quality. Broader comparative claims remain gated on
+[#445](https://github.com/dgenio/contextweaver/issues/445).
+
+#### 4. Route and hydrate progressively
+
+The verified bundle is loaded once. `CompiledAgent.route()` applies the
+fixture's phase boundary (`allowed_namespaces={"skill"}`), then
+`CompiledAgent.hydrate()` returns only the selected capability and its
+declared `skill.reminder.instructions` resource.
+
+ContextWeaver stops there. It does not call a model, fetch the resource, invoke
+the tool, or authorize a side effect. The host owns credentials, authorization,
+execution, and result ingestion.
+
+#### 5. Observe failure and remediate it
+
+The degraded variant removes the required Agent Skill resource digest and
+recompiles. Runtime assessment becomes `unverified`; only
+`skill.draft_reminder` is blocked while the other four capabilities remain
+available. Restoring the digest returns the original verified assessment with
+zero blocked capabilities.
+
+This proves a non-token value: required resource closure can fail closed for
+the affected capability without pretending the entire heterogeneous surface is
+healthy or unusable.
+
+### When not to use ContextWeaver
+
+Use a simpler option when it solves the actual problem:
+
+- For one provider and runtime-only selection, use provider-native deferred
+  loading/tool search. OpenAI supports
+  [hosted and client-executed tool search](https://developers.openai.com/api/docs/guides/tools-tool-search),
+  and Claude Code
+  [defers MCP schemas behind tool search](https://docs.anthropic.com/en/docs/claude-code/mcp).
+- For a small, static surface, pass the few tool schemas directly.
+- For MCP server lifecycle, container isolation, credentials, or profiles,
+  [Docker MCP Gateway](https://docs.docker.com/ai/mcp-catalog-and-toolkit/mcp-gateway/)
+  is the more direct product.
+- For a single MCP-only surface where reproducibility, pre-runtime evaluation,
+  source provenance, and phase-aware context are not problems, a normal MCP
+  client or gateway is enough.
+- Do not use ContextWeaver as a tool executor, authorization layer, sandbox,
+  agent framework, or prompt-injection defense; it provides none of those
+  guarantees.
+
+ContextWeaver is the better fit when you need a provider-independent,
+inspectable capability artifact before runtime, or when its phase-aware
+routing/context-result behavior is independently useful. Provider-native tool
+search can also consume a bounded surface produced upstream; the approaches
+are complementary.
+
+## Runtime context-pressure demo
+
+The original demo shows why a naive tool-using agent loop breaks down — and
+what ContextWeaver does about it — in one command:
 
 ```bash
 contextweaver demo --scenario killer
 ```
 
 (Also available as `python -m contextweaver demo --scenario killer`.)
-
-## Compiler-first companion
-
-If your problem starts earlier — capabilities already live across different
-protocols/frameworks and you want one inspectable artifact before runtime — run
-the package-native compiler proof:
-
-```bash
-python -m contextweaver.compiler
-```
-
-It demonstrates this boundary in under a minute, also without network or API
-keys:
-
-```text
-MCP + OpenAPI + Agent Skill + framework + A2A source snapshots
-    -> analyse
-    -> compile + verify one portable bundle
-    -> bounded route
-    -> hydrate only the selected capability/resources
-    -> host still owns execution
-```
-
-The maintained proof deliberately uses **representative deterministic source
-snapshots**. It does not claim that source-specific MCP/OpenAPI/A2A discovery
-adapters executed. The receipt says `discovery=fixture-snapshots`, and CI tests
-that metadata explicitly. This keeps the current compiler foundation useful and
-truthful while source-specific discovery remains separate work.
-
-It also recompiles one degraded variant with the required Agent Skill resource
-digest removed. Runtime trust becomes `unverified` and only the affected
-capability is blocked. The expected receipt is committed at
-`tests/fixtures/compiler_demo_expected.txt` and drift-checked by CI.
-
-See [the compiler-first adoption track](roadmap/compiler-first-backlog-audit-2026-07.md)
-for the broader product direction.
 
 ## The scenario
 
@@ -86,8 +207,11 @@ also prints a token estimate using the active tokeniser.
 ## Where to go next
 
 - The [catalog showcase architecture](architectures/catalog_showcase.md) is
-  the same story as a runnable, inspectable script with `BuildStats`.
+  the same runtime-pressure story as a runnable, inspectable script with
+  `BuildStats`.
 - The [Showcase](showcase.md) walks the other `demo --scenario` flows
   (`large-catalog`, `huge-tool-output`, `mcp-gateway-full`).
 - The [Quickstart](quickstart.md) shows the direct-API version you would
   embed in your own agent loop.
+- The [compiler-first adoption track](roadmap/compiler-first-backlog-audit-2026-07.md)
+  records the broader product direction and remaining launch gates.

--- a/docs/killer_demo.md
+++ b/docs/killer_demo.md
@@ -32,10 +32,13 @@ From a checkout with ContextWeaver installed, run the package module:
 python -m contextweaver.compiler
 ```
 
-The same command is run against the built wheel in the isolated package smoke
-job. Its exact stdout is committed in
+That exact module command is executed in subprocess tests on every normal CI
+lane, and its exact stdout is committed in
 [`tests/fixtures/compiler_demo_expected.txt`](../tests/fixtures/compiler_demo_expected.txt)
-and byte-compared in CI, including under optimized Python (`-O`).
+and byte-compared in CI, including under optimized Python (`-O`). The existing
+built-wheel smoke separately validates isolated `uvx`/`pipx` packaging and the
+public console entry point; it does not currently claim to execute this module
+proof from the wheel.
 
 The first receipt reports:
 

--- a/src/contextweaver/compiler/__main__.py
+++ b/src/contextweaver/compiler/__main__.py
@@ -4,11 +4,12 @@ Run after installing ContextWeaver::
 
     python -m contextweaver.compiler
 
-The proof constructs five heterogeneous *source snapshots*, compiles and
-verifies one portable bundle, routes/hydrates without executing a capability,
-and demonstrates fail-closed runtime assessment when a required resource loses
-its verification digest. Source-specific discovery adapters remain separate
-work; this demo does not pretend those adapters executed.
+The proof constructs five heterogeneous *source snapshots*, detects one
+cross-source identity ambiguity, compiles and verifies one portable bundle,
+evaluates a phase-bounded route, hydrates only the selected capability, and
+demonstrates fail-closed runtime assessment when a required resource loses its
+verification digest. Source-specific discovery adapters remain separate work;
+this demo does not pretend those adapters executed.
 """
 
 from __future__ import annotations
@@ -18,14 +19,25 @@ from pathlib import Path
 
 from contextweaver.compiler._json import sha256_hex
 from contextweaver.compiler.analysis import analyze_snapshots
-from contextweaver.compiler.bundle import build_bundle_from_snapshots, write_bundle
+from contextweaver.compiler.bundle import (
+    COMPILED_BUNDLE_VERSION,
+    build_bundle_from_snapshots,
+    write_bundle,
+)
 from contextweaver.compiler.resources import ResourceDescriptor
 from contextweaver.compiler.runtime import CompiledAgent
 from contextweaver.compiler.sources import CapabilitySourceSnapshot, SourceCoverage
+from contextweaver.exceptions import ValidationError
+from contextweaver.routing.collision import analyze_collisions
 from contextweaver.types import SelectableItem
 
 AGENT_ID = "demo.compiler-first"
+ARTIFACT_VERSION = "fixture-v1"
+EVAL_FIXTURE_ID = "compiler-demo-eval-v1"
+PHASE_ID = "draft-reminder"
+PHASE_NAMESPACE = "skill"
 QUERY = "draft payment reminder"
+EXPECTED_CAPABILITY_ID = "skill.draft_reminder"
 
 
 def _item(
@@ -61,7 +73,7 @@ def _snapshot(
     return CapabilitySourceSnapshot(
         source_id=source_id,
         source_type=source_type,
-        source_version="fixture-v1",
+        source_version=ARTIFACT_VERSION,
         adapter_id=f"demo-{source_type}-snapshot",
         adapter_version="1",
         capabilities=[capability],
@@ -85,7 +97,7 @@ def build_demo_snapshots(
         media_type="text/markdown",
         digest="" if degraded_skill_resource else sha256_hex(skill_body),
         size_bytes=len(skill_body),
-        capability_ids=["skill.draft_reminder"],
+        capability_ids=[EXPECTED_CAPABILITY_ID],
     )
 
     return [
@@ -113,10 +125,10 @@ def build_demo_snapshots(
             "skill.reminder",
             "agent-skill",
             _item(
-                "skill.draft_reminder",
+                EXPECTED_CAPABILITY_ID,
                 name="draft payment reminder",
                 description="Draft a polite payment reminder for an unpaid invoice.",
-                namespace="skill",
+                namespace=PHASE_NAMESPACE,
                 resource_ids=["skill.reminder.instructions"],
             ),
             resources=[skill_resource],
@@ -125,9 +137,9 @@ def build_demo_snapshots(
             "framework.crm",
             "framework",
             _item(
-                "crm.lookup_account",
-                name="lookup customer account",
-                description="Lookup customer account metadata in a framework tool wrapper.",
+                "crm.draft_payment_reminder",
+                name="draft payment reminder",
+                description="Draft a payment reminder using a framework-native tool object.",
                 namespace="crm",
             ),
         ),
@@ -150,9 +162,25 @@ def receipt_lines() -> list[str]:
     source_types = ",".join(sorted(snapshot.source_type for snapshot in snapshots))
     capability_count = sum(len(snapshot.capabilities) for snapshot in snapshots)
     preflight = analyze_snapshots(AGENT_ID, snapshots)
+    collisions = analyze_collisions(
+        [capability for snapshot in snapshots for capability in snapshot.capabilities]
+    )
+    ambiguities = [
+        finding
+        for finding in collisions.findings
+        if finding.kind in ("exact_name", "near_name")
+    ]
+    if len(ambiguities) != 1:
+        raise ValidationError(
+            f"compiler demo ambiguity drifted: expected 1, got {len(ambiguities)}"
+        )
 
     lines = [
         "ContextWeaver compiler-first proof",
+        (
+            "SURFACE mcp+openapi+agent-skill+framework+a2a -> compile-once "
+            "-> evaluate -> portable-bundle -> phase-bounded-hydration"
+        ),
         (
             f"DISCOVER sources={len(snapshots)} types={source_types} "
             f"capabilities={capability_count} discovery=fixture-snapshots"
@@ -160,52 +188,87 @@ def receipt_lines() -> list[str]:
         (
             f"ANALYSE trust={preflight.trust_status} "
             f"required_resources={preflight.required_resource_count} "
-            f"warnings={len(preflight.warnings)} findings={len(preflight.findings)}"
+            f"warnings={len(preflight.warnings)} findings={len(preflight.findings)} "
+            f"ambiguities={len(ambiguities)}"
         ),
     ]
 
     with tempfile.TemporaryDirectory(prefix="contextweaver-compiler-demo-") as tmp:
-        bundle = build_bundle_from_snapshots(AGENT_ID, snapshots)
+        bundle = build_bundle_from_snapshots(
+            AGENT_ID,
+            snapshots,
+            version=ARTIFACT_VERSION,
+        )
         bundle_path = write_bundle(bundle, Path(tmp))
         # CompiledAgent.load verifies the on-disk bundle by default. Reuse that
         # single verified load for the runtime proof rather than verifying twice.
         agent = CompiledAgent.load(bundle_path)
+        assessment = agent.assess_runtime()
         trust_status = bundle.trust.status if bundle.trust else "unverified"
         lines.append(
-            f"COMPILE trust={trust_status} bundle_verified=true "
-            f"capabilities={len(bundle.capabilities)} resources={len(bundle.resources)}"
+            f"COMPILE trust={trust_status} bundle_version={COMPILED_BUNDLE_VERSION} "
+            f"artifact_version={ARTIFACT_VERSION} bundle_id={bundle.bundle_digest()[:12]} "
+            f"bundle_verified=true capabilities={len(bundle.capabilities)} "
+            f"resources={len(bundle.resources)}"
         )
 
-        route = agent.route(QUERY)
+        route = agent.route(QUERY, allowed_namespaces={PHASE_NAMESPACE})
         if not route.candidate_ids:
-            raise AssertionError("compiler demo route drifted: shortlist is empty")
+            raise ValidationError("compiler demo route drifted: shortlist is empty")
         selected = route.candidate_ids[0]
-        if selected != "skill.draft_reminder":
-            raise AssertionError(
-                f"compiler demo route drifted: expected skill.draft_reminder, got {selected}"
+        gate_passed = (
+            selected == EXPECTED_CAPABILITY_ID
+            and selected in assessment.allowed_capability_ids
+            and len(route.candidate_ids) == 1
+        )
+        if not gate_passed:
+            raise ValidationError(
+                "compiler demo evaluation drifted: expected one allowed skill capability, "
+                f"got {route.candidate_ids}"
             )
-        lines.append(f"ROUTE selected={selected} shortlist={len(route.candidate_ids)}")
+        lines.append(
+            f"EVALUATE gate=PASS fixture={EVAL_FIXTURE_ID} cases=1 "
+            f"phase={PHASE_ID} allowed_namespace={PHASE_NAMESPACE} selected={selected}"
+        )
+        lines.append(
+            f"ROUTE selected={selected} shortlist={len(route.candidate_ids)} "
+            f"phase={PHASE_ID}"
+        )
 
         hydrated = agent.hydrate(selected)
         resource_ids = ",".join(resource.resource_id for resource in hydrated.resources)
         lines.append(
-            f"HYDRATE capability={selected} resources={resource_ids} host_execution=retained"
+            f"HYDRATE capability={selected} resources={resource_ids} "
+            "exposed_capabilities=1 host_execution=retained"
         )
 
     degraded = CompiledAgent(
         build_bundle_from_snapshots(
             AGENT_ID,
             build_demo_snapshots(degraded_skill_resource=True),
+            version=ARTIFACT_VERSION,
         )
     ).assess_runtime()
+    if degraded.status != "unverified" or degraded.blocked_capability_ids != [
+        EXPECTED_CAPABILITY_ID
+    ]:
+        raise ValidationError(
+            "compiler demo degraded path drifted: "
+            f"status={degraded.status} blocked={degraded.blocked_capability_ids}"
+        )
     lines.append(
         f"DEGRADED trust={degraded.status} "
         f"blocked={','.join(degraded.blocked_capability_ids)} "
-        f"allowed={len(degraded.allowed_capability_ids)}"
+        f"allowed={len(degraded.allowed_capability_ids)} "
+        "remediation=restore-required-resource-digest"
     )
     lines.append(
-        "PASS: heterogeneous source snapshots became one portable bundle "
-        "without executing a capability."
+        f"REMEDIATE trust={assessment.status} "
+        f"blocked={len(assessment.blocked_capability_ids)} action=restore-digest"
+    )
+    lines.append(
+        "PASS: one evaluated portable bundle exposed only the selected phase resource; "
+        "no capability was executed."
     )
     return lines
 

--- a/src/contextweaver/compiler/__main__.py
+++ b/src/contextweaver/compiler/__main__.py
@@ -1,0 +1,219 @@
+"""Package-native, deterministic compiler-first adoption proof.
+
+Run after installing ContextWeaver::
+
+    python -m contextweaver.compiler
+
+The proof constructs five heterogeneous *source snapshots*, compiles and
+verifies one portable bundle, routes/hydrates without executing a capability,
+and demonstrates fail-closed runtime assessment when a required resource loses
+its verification digest. Source-specific discovery adapters remain separate
+work; this demo does not pretend those adapters executed.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from contextweaver.compiler._json import sha256_hex
+from contextweaver.compiler.analysis import analyze_snapshots
+from contextweaver.compiler.bundle import build_bundle_from_snapshots, write_bundle
+from contextweaver.compiler.resources import ResourceDescriptor
+from contextweaver.compiler.runtime import CompiledAgent
+from contextweaver.compiler.sources import CapabilitySourceSnapshot, SourceCoverage
+from contextweaver.types import SelectableItem
+
+AGENT_ID = "demo.compiler-first"
+QUERY = "draft payment reminder"
+
+
+def _item(
+    item_id: str,
+    *,
+    name: str,
+    description: str,
+    namespace: str,
+    resource_ids: list[str] | None = None,
+) -> SelectableItem:
+    """Build one deterministic demo capability."""
+    metadata = {"resource_ids": list(resource_ids or [])} if resource_ids else {}
+    return SelectableItem(
+        id=item_id,
+        kind="tool",
+        name=name,
+        description=description,
+        namespace=namespace,
+        tags=["compiler-demo"],
+        args_schema={"type": "object", "properties": {}},
+        metadata=metadata,
+    )
+
+
+def _snapshot(
+    source_id: str,
+    source_type: str,
+    capability: SelectableItem,
+    *,
+    resources: list[ResourceDescriptor] | None = None,
+) -> CapabilitySourceSnapshot:
+    """Build one explicit heterogeneous-source snapshot."""
+    return CapabilitySourceSnapshot(
+        source_id=source_id,
+        source_type=source_type,
+        source_version="fixture-v1",
+        adapter_id=f"demo-{source_type}-snapshot",
+        adapter_version="1",
+        capabilities=[capability],
+        resources=list(resources or []),
+        coverage=SourceCoverage(
+            source_id=source_id,
+            capability_ids=[capability.id],
+        ),
+        metadata={"demo_fixture": True, "discovery_executed": False},
+    )
+
+
+def build_demo_snapshots(
+    *, degraded_skill_resource: bool = False
+) -> list[CapabilitySourceSnapshot]:
+    """Return five representative source snapshots for the compiler proof."""
+    skill_body = b"Draft a concise, polite reminder. Never claim a payment was received."
+    skill_resource = ResourceDescriptor(
+        resource_id="skill.reminder.instructions",
+        uri="fixture://skills/reminder/SKILL.md",
+        media_type="text/markdown",
+        digest="" if degraded_skill_resource else sha256_hex(skill_body),
+        size_bytes=len(skill_body),
+        capability_ids=["skill.draft_reminder"],
+    )
+
+    return [
+        _snapshot(
+            "mcp.helpdesk",
+            "mcp",
+            _item(
+                "mcp.search_tickets",
+                name="search support tickets",
+                description="Search support tickets by account, status, and keyword.",
+                namespace="mcp",
+            ),
+        ),
+        _snapshot(
+            "openapi.billing",
+            "openapi",
+            _item(
+                "billing.get_invoice",
+                name="get invoice",
+                description="Fetch invoice status and balance by invoice identifier.",
+                namespace="billing",
+            ),
+        ),
+        _snapshot(
+            "skill.reminder",
+            "agent-skill",
+            _item(
+                "skill.draft_reminder",
+                name="draft payment reminder",
+                description="Draft a polite payment reminder for an unpaid invoice.",
+                namespace="skill",
+                resource_ids=["skill.reminder.instructions"],
+            ),
+            resources=[skill_resource],
+        ),
+        _snapshot(
+            "framework.crm",
+            "framework",
+            _item(
+                "crm.lookup_account",
+                name="lookup customer account",
+                description="Lookup customer account metadata in a framework tool wrapper.",
+                namespace="crm",
+            ),
+        ),
+        _snapshot(
+            "a2a.notifications",
+            "a2a",
+            _item(
+                "a2a.notify_customer",
+                name="send customer notification",
+                description="Delegate an approved customer notification to a remote agent.",
+                namespace="a2a",
+            ),
+        ),
+    ]
+
+
+def receipt_lines() -> list[str]:
+    """Execute the compiler proof and return its stable semantic receipt."""
+    snapshots = build_demo_snapshots()
+    source_types = ",".join(sorted(snapshot.source_type for snapshot in snapshots))
+    capability_count = sum(len(snapshot.capabilities) for snapshot in snapshots)
+    preflight = analyze_snapshots(AGENT_ID, snapshots)
+
+    lines = [
+        "ContextWeaver compiler-first proof",
+        (
+            f"DISCOVER sources={len(snapshots)} types={source_types} "
+            f"capabilities={capability_count} discovery=fixture-snapshots"
+        ),
+        (
+            f"ANALYSE trust={preflight.trust_status} "
+            f"required_resources={preflight.required_resource_count} "
+            f"warnings={len(preflight.warnings)} findings={len(preflight.findings)}"
+        ),
+    ]
+
+    with tempfile.TemporaryDirectory(prefix="contextweaver-compiler-demo-") as tmp:
+        bundle = build_bundle_from_snapshots(AGENT_ID, snapshots)
+        bundle_path = write_bundle(bundle, Path(tmp))
+        # CompiledAgent.load verifies the on-disk bundle by default. Reuse that
+        # single verified load for the runtime proof rather than verifying twice.
+        agent = CompiledAgent.load(bundle_path)
+        trust_status = bundle.trust.status if bundle.trust else "unverified"
+        lines.append(
+            f"COMPILE trust={trust_status} bundle_verified=true "
+            f"capabilities={len(bundle.capabilities)} resources={len(bundle.resources)}"
+        )
+
+        route = agent.route(QUERY)
+        if not route.candidate_ids:
+            raise AssertionError("compiler demo route drifted: shortlist is empty")
+        selected = route.candidate_ids[0]
+        if selected != "skill.draft_reminder":
+            raise AssertionError(
+                f"compiler demo route drifted: expected skill.draft_reminder, got {selected}"
+            )
+        lines.append(f"ROUTE selected={selected} shortlist={len(route.candidate_ids)}")
+
+        hydrated = agent.hydrate(selected)
+        resource_ids = ",".join(resource.resource_id for resource in hydrated.resources)
+        lines.append(
+            f"HYDRATE capability={selected} resources={resource_ids} host_execution=retained"
+        )
+
+    degraded = CompiledAgent(
+        build_bundle_from_snapshots(
+            AGENT_ID,
+            build_demo_snapshots(degraded_skill_resource=True),
+        )
+    ).assess_runtime()
+    lines.append(
+        f"DEGRADED trust={degraded.status} "
+        f"blocked={','.join(degraded.blocked_capability_ids)} "
+        f"allowed={len(degraded.allowed_capability_ids)}"
+    )
+    lines.append(
+        "PASS: heterogeneous source snapshots became one portable bundle "
+        "without executing a capability."
+    )
+    return lines
+
+
+def main() -> None:
+    """Print the stable compiler-first proof receipt."""
+    print("\n".join(receipt_lines()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/compiler_demo_expected.txt
+++ b/tests/fixtures/compiler_demo_expected.txt
@@ -1,8 +1,11 @@
 ContextWeaver compiler-first proof
+SURFACE mcp+openapi+agent-skill+framework+a2a -> compile-once -> evaluate -> portable-bundle -> phase-bounded-hydration
 DISCOVER sources=5 types=a2a,agent-skill,framework,mcp,openapi capabilities=5 discovery=fixture-snapshots
-ANALYSE trust=unverified required_resources=1 warnings=0 findings=0
-COMPILE trust=verified bundle_verified=true capabilities=5 resources=1
-ROUTE selected=skill.draft_reminder shortlist=5
-HYDRATE capability=skill.draft_reminder resources=skill.reminder.instructions host_execution=retained
-DEGRADED trust=unverified blocked=skill.draft_reminder allowed=4
-PASS: heterogeneous source snapshots became one portable bundle without executing a capability.
+ANALYSE trust=unverified required_resources=1 warnings=0 findings=0 ambiguities=1
+COMPILE trust=verified bundle_version=contextweaver.compiler.bundle.v1 artifact_version=fixture-v1 bundle_id=ff347d4ee592 bundle_verified=true capabilities=5 resources=1
+EVALUATE gate=PASS fixture=compiler-demo-eval-v1 cases=1 phase=draft-reminder allowed_namespace=skill selected=skill.draft_reminder
+ROUTE selected=skill.draft_reminder shortlist=1 phase=draft-reminder
+HYDRATE capability=skill.draft_reminder resources=skill.reminder.instructions exposed_capabilities=1 host_execution=retained
+DEGRADED trust=unverified blocked=skill.draft_reminder allowed=4 remediation=restore-required-resource-digest
+REMEDIATE trust=verified blocked=0 action=restore-digest
+PASS: one evaluated portable bundle exposed only the selected phase resource; no capability was executed.

--- a/tests/fixtures/compiler_demo_expected.txt
+++ b/tests/fixtures/compiler_demo_expected.txt
@@ -1,0 +1,8 @@
+ContextWeaver compiler-first proof
+DISCOVER sources=5 types=a2a,agent-skill,framework,mcp,openapi capabilities=5 discovery=fixture-snapshots
+ANALYSE trust=unverified required_resources=1 warnings=0 findings=0
+COMPILE trust=verified bundle_verified=true capabilities=5 resources=1
+ROUTE selected=skill.draft_reminder shortlist=5
+HYDRATE capability=skill.draft_reminder resources=skill.reminder.instructions host_execution=retained
+DEGRADED trust=unverified blocked=skill.draft_reminder allowed=4
+PASS: heterogeneous source snapshots became one portable bundle without executing a capability.

--- a/tests/test_compiler_demo.py
+++ b/tests/test_compiler_demo.py
@@ -1,0 +1,47 @@
+"""Regression tests for the package-native compiler-first adoption proof."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from contextweaver.compiler.__main__ import build_demo_snapshots, receipt_lines
+
+EXPECTED = Path(__file__).parent / "fixtures" / "compiler_demo_expected.txt"
+
+
+def test_compiler_demo_receipt_is_stable() -> None:
+    actual = "\n".join(receipt_lines()) + "\n"
+    assert actual == EXPECTED.read_text(encoding="utf-8")
+
+
+def test_compiler_demo_exact_module_command_matches_receipt() -> None:
+    completed = subprocess.run(
+        [sys.executable, "-m", "contextweaver.compiler"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.stderr == ""
+    assert completed.stdout == EXPECTED.read_text(encoding="utf-8")
+
+
+def test_compiler_demo_is_explicitly_snapshot_based() -> None:
+    snapshots = build_demo_snapshots()
+    assert {snapshot.source_type for snapshot in snapshots} == {
+        "mcp",
+        "openapi",
+        "agent-skill",
+        "framework",
+        "a2a",
+    }
+    assert all(snapshot.metadata["discovery_executed"] is False for snapshot in snapshots)
+
+
+def test_compiler_demo_degraded_fixture_removes_required_resource_digest() -> None:
+    snapshots = build_demo_snapshots(degraded_skill_resource=True)
+    skill_snapshot = next(
+        snapshot for snapshot in snapshots if snapshot.source_type == "agent-skill"
+    )
+    assert skill_snapshot.resources[0].digest == ""

--- a/tests/test_compiler_demo.py
+++ b/tests/test_compiler_demo.py
@@ -6,9 +6,24 @@ import subprocess
 import sys
 from pathlib import Path
 
-from contextweaver.compiler.__main__ import build_demo_snapshots, receipt_lines
+from contextweaver.compiler.__main__ import (
+    EXPECTED_CAPABILITY_ID,
+    PHASE_NAMESPACE,
+    build_demo_snapshots,
+    receipt_lines,
+)
+from contextweaver.routing.collision import analyze_collisions
 
 EXPECTED = Path(__file__).parent / "fixtures" / "compiler_demo_expected.txt"
+
+
+def _run_module(*flags: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *flags, "-m", "contextweaver.compiler"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
 
 def test_compiler_demo_receipt_is_stable() -> None:
@@ -17,12 +32,13 @@ def test_compiler_demo_receipt_is_stable() -> None:
 
 
 def test_compiler_demo_exact_module_command_matches_receipt() -> None:
-    completed = subprocess.run(
-        [sys.executable, "-m", "contextweaver.compiler"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    completed = _run_module()
+    assert completed.stderr == ""
+    assert completed.stdout == EXPECTED.read_text(encoding="utf-8")
+
+
+def test_compiler_demo_checks_survive_optimized_python() -> None:
+    completed = _run_module("-O")
     assert completed.stderr == ""
     assert completed.stdout == EXPECTED.read_text(encoding="utf-8")
 
@@ -37,6 +53,26 @@ def test_compiler_demo_is_explicitly_snapshot_based() -> None:
         "a2a",
     }
     assert all(snapshot.metadata["discovery_executed"] is False for snapshot in snapshots)
+
+
+def test_compiler_demo_surfaces_one_cross_source_identity_ambiguity() -> None:
+    snapshots = build_demo_snapshots()
+    capabilities = [
+        capability for snapshot in snapshots for capability in snapshot.capabilities
+    ]
+    findings = analyze_collisions(capabilities).findings
+    ambiguities = [
+        finding for finding in findings if finding.kind in ("exact_name", "near_name")
+    ]
+    assert len(ambiguities) == 1
+    assert ambiguities[0].item_ids == [
+        "crm.draft_payment_reminder",
+        EXPECTED_CAPABILITY_ID,
+    ]
+    assert {capability.namespace for capability in capabilities} >= {
+        "crm",
+        PHASE_NAMESPACE,
+    }
 
 
 def test_compiler_demo_degraded_fixture_removes_required_resource_digest() -> None:


### PR DESCRIPTION
Supersedes #838 with a clean current-main history and advances #434 with a package-native compiler-first adoption proof.

## User path

With ContextWeaver installed from a matching checkout/build:

```bash
python -m contextweaver.compiler
```

The exact module command is executed in subprocess tests and its semantic stdout is drift-checked against a committed receipt, including under optimized Python (`-O`). The repository's existing isolated wheel smoke separately validates the public console-entry packaging; this PR does not overstate that as wheel-level execution of the compiler module.

## What the maintained proof now shows

Five deterministic representative source snapshots — MCP, OpenAPI, Agent Skill, framework, and A2A — are:

1. analysed for trust/coverage plus one intentional cross-source human-name ambiguity;
2. compiled into one versioned/content-addressed portable bundle;
3. verified through `CompiledAgent.load()`;
4. routed under a one-namespace phase boundary;
5. checked by an explicit one-case fixture evaluation gate;
6. hydrated only for the selected capability and declared Skill resource, while host execution remains outside ContextWeaver;
7. recompiled in a degraded state where a missing required resource digest blocks only the affected capability;
8. shown remediated after the required digest is restored.

## Truth boundary

This does **not** claim source-specific discovery adapters ran. Every demo snapshot carries `discovery_executed=False`; the receipt says `discovery=fixture-snapshots`; tests assert that boundary. The evaluation gate is a one-case adoption regression fixture, not a general routing-quality benchmark.

## Adoption surface

`docs/killer_demo.md` now includes:

- a 10-second Mermaid compiler-first visual;
- the copy/paste command and evidence contract;
- a deep walkthrough using the same maintained fixture;
- the host-executes boundary;
- degraded/remediation behavior;
- explicit `when not to use ContextWeaver` alternatives/non-claims;
- the existing runtime context-pressure demo as a separate companion story.

## Files

- `src/contextweaver/compiler/__main__.py`
- `tests/fixtures/compiler_demo_expected.txt`
- `tests/test_compiler_demo.py`
- `docs/killer_demo.md`

## What remains under #434

This PR intentionally advances rather than closes the launch gate. Remaining work includes live source-specific compiler discovery/adapters, a recorded <60-second terminal cast derived from the maintained command, and broader routing-quality/launch evidence beyond the single deterministic fixture before broad external distribution.

Merge only after the exact final head passes CI, CodeQL, Release readiness, the benchmark quality gate, and review-thread checks. No prior green head may be borrowed.