### PR TITLE
fix(ci): make MCP Registry publish idempotent on duplicate version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,8 +138,13 @@ jobs:
       - name: Publish server.json (retry while PyPI metadata propagates)
         run: |
           for attempt in 1 2 3 4 5 6; do
-            if ./mcp-publisher publish; then
+            err_msg=$(./mcp-publisher publish 2>&1) && exit_code=0 || exit_code=$?
+            if [ "$exit_code" -eq 0 ]; then
               echo "Published to the MCP Registry."
+              exit 0
+            fi
+            if echo "$err_msg" | grep -qi 'cannot publish duplicate version'; then
+              echo "Version already present in the MCP Registry; treating as success."
               exit 0
             fi
             echo "Attempt $attempt failed (PyPI metadata may still be propagating); retrying in 30s..."


### PR DESCRIPTION
## Problem

The MCP Registry publish step has been failing since `v0.16.0` with a false-negative error loop:

```
Error: publish failed: server returned status 400: {detail: Failed to publish server, errors: [{message: invalid version: cannot publish duplicate version}]}
```

This error is misleading -- the version was already accepted by the MCP Registry on the first attempt, but the publisher returned a non-zero exit code. The retry loop then hit already exists for all 6 attempts, failing the entire publish job despite PyPI and all upstream steps succeeding.

## Root cause

- `mcp-publisher publish` exits non-zero on HTTP 400 duplicate version.
- The bash `if ./mcp-publisher publish; then ... fi` pattern treats this as a hard failure.
- With `set -eu` inherited from earlier steps, the first non-zero exit immediately fails the `if` branch, never allowing idempotent handling.

## Fix

Capture both stdout/stderr and exit code explicitly, then check:
- `exit_code == 0` -> success, done.
- Error message contains `cannot publish duplicate version` -> already present, treat as success.
- Any other error -> retry up to 6 times (existing behavior).

## Impact

- `v0.18.1` and all future releases can complete MCP Registry publish without manual intervention.
- `v0.16.0`/`v0.17.0`/`v0.18.0` will need retroactive publishing or manual registry update if the registry state is inconsistent with PyPI.
- No change to Trusted Publishing behavior (PyPI publish is unchanged).

Refs #849.
