### PR TITLE
docs: correct canonical weaver-spec schema-host status

### DIFF
--- a/docs/weaver_spec_mapping.md
+++ b/docs/weaver_spec_mapping.md
@@ -16,12 +16,20 @@ pip install 'contextweaver[weaver-spec]'
 
 contextweaver tracks `weaver_contracts >= 0.2.0, < 1.0` (any MAJOR=0 release;
 the spec promises no breaking changes within a major version). The CI step
-`weaver-spec conformance` fetches the JSON Schemas at job time from
+`weaver-spec conformance` currently fetches the JSON Schemas at job time from
 `https://raw.githubusercontent.com/dgenio/weaver-spec/main/contracts/json/`
 (the source the gate uses) and exercises the adapter against them on every
-PR. The same documents are also published at
-`https://weaver-spec.dev/contracts/v0/` — both URLs serve the same content;
-the raw GitHub URL is the one the gate actually reads.
+PR. `weaver-spec` reserves `https://weaver-spec.dev/contracts/v0/...` as the
+canonical `$id` namespace, but the canonical host is **not yet a live schema
+endpoint**; live immutable hosting is tracked upstream in
+[`weaver-spec#213`](https://github.com/dgenio/weaver-spec/issues/213). Do not
+assume those `$id` URLs resolve until that deployment is verified.
+
+The mutable `main` fetch is also not sufficient evidence for a versioned
+compatibility claim. Pinning/gating the conformance input to an immutable
+reviewed spec version is tracked in [#469](https://github.com/dgenio/contextweaver/issues/469),
+and publication of a current implementation-generated conformance bundle is
+tracked in [#846](https://github.com/dgenio/contextweaver/issues/846).
 
 ## Name-clash note
 
@@ -218,6 +226,7 @@ locally:
 make weaver-conformance
 ```
 
-This fetches the published schemas, exercises every `to_weaver_*` / `from_weaver_*`
-pair, and validates the JSON form of `SelectableItem`, `ChoiceCard`,
-`RoutingDecision`, and `Frame` against the corresponding schema.
+This fetches the current gate inputs, exercises every `to_weaver_*` /
+`from_weaver_*` pair, and validates the JSON form of `SelectableItem`,
+`ChoiceCard`, `RoutingDecision`, and `Frame` against the corresponding schema.
+See #469 for the work to make the gating spec input immutable/version-identifiable.


### PR DESCRIPTION
## Summary

Corrects one public interoperability claim that became false during the weaver-spec adoption audit.

`docs/weaver_spec_mapping.md` previously said the schemas fetched from `raw.githubusercontent.com/.../weaver-spec/main/...` were also published live at `https://weaver-spec.dev/contracts/v0/`. The canonical weaver-spec hosting policy explicitly says that host is not yet serving the schemas, and current resolution checks confirm it is not a usable endpoint.

This PR now states:

- the CI gate currently fetches mutable `main` source schemas;
- `weaver-spec.dev` is the reserved canonical `$id` namespace, **not yet a live schema endpoint**;
- immutable gating is tracked by #469;
- current implementation-generated conformance evidence is tracked by #846;
- live canonical hosting is tracked upstream in dgenio/weaver-spec#213.

## Scope

Only the mapping document is changed here. The same stale wording also exists in the large README / derived published docs and is already tracked by #848 so those source/generated surfaces can be updated atomically rather than through a destructive whole-file connector rewrite.

A second, unrelated stale statement about upstream Extended `ExecutionCandidate` / `ExecutionFeedback` types was found in the same mapping page and is tracked separately as #851; this hosting PR intentionally does not pretend to resolve that contract-shape question.

## Related

- #848 live-host wording cleanup across README/PyPI/generated docs
- #851 Extended execution-contract wording
- #469 immutable conformance input
- #846 current conformance bundle publication
- dgenio/weaver-spec#213 canonical schema hosting
